### PR TITLE
Fixed compile issue on OSX.

### DIFF
--- a/src/osgEarth/MapNode
+++ b/src/osgEarth/MapNode
@@ -25,6 +25,7 @@
 #include <osgEarth/MapNodeOptions>
 #include <osgEarth/TerrainEngineNode>
 #include <osg/CoordinateSystemNode>
+#include <osg/PagedLOD>
 #include <osgSim/OverlayNode>
 
 namespace osgEarth


### PR DESCRIPTION
In SinglePassTerrainTechnique.cpp, I added an #ifdef **APPLE** for <ext/hash_map> everything else still includes just <hash_map>.
