### PR TITLE
VPB image layers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,12 @@ SET(OpenThreads_SOURCE_DIR ${OSGEARTH_SOURCE_DIR})
 # Maybe this can be used override existing behavior if needed?
 SET(CMAKE_MODULE_PATH "${OSGEARTH_SOURCE_DIR}/CMakeModules;${CMAKE_MODULE_PATH}")
 
+# check if STLport is required
+OPTION(USE_STLPORT "Set to ON to build OSGEARTH with stlport instead of the default STL library." OFF)
+IF(USE_STLPORT)
+	INCLUDE_DIRECTORIES(${STLPORT_DIR}/stlport)
+	LINK_DIRECTORIES(${STLPORT_DIR}/lib)
+ENDIF()
 
 # Okay, here's the problem: On some platforms, linking against OpenThreads
 # is not enough and explicit linking to the underlying thread library
@@ -155,7 +161,6 @@ MAKE_DIRECTORY(${OUTPUT_LIBDIR})
 SET(LIBRARY_OUTPUT_PATH ${OUTPUT_LIBDIR})
 
 LINK_DIRECTORIES( ${LINK_DIRECTORIES} ${OUTPUT_LIBDIR} )
-
 
 
 #SET(INSTALL_BINDIR VIRTUALPLANETBUILDER/bin)

--- a/src/osgEarth/Common
+++ b/src/osgEarth/Common
@@ -31,7 +31,7 @@
 #include <map>
 #include <algorithm>
 #include <iomanip>
-
+#include <cctype>
 
 // define the OSG Version checks for older OSG versions
 
@@ -92,7 +92,7 @@ namespace osgEarth
     toString(const T value)
     {
         std::stringstream out;
-        out << std::fixed << value;
+		out << std::setprecision(20) << std::fixed << value;
         std::string outStr;
         outStr = out.str();
         return outStr;

--- a/src/osgEarth/Notify.cpp
+++ b/src/osgEarth/Notify.cpp
@@ -37,6 +37,7 @@ using namespace osgEarth;
 #include <stdlib.h>
 #include <iostream>
 #include <fstream>
+#include <cctype>
 
 using namespace std;
 

--- a/src/osgEarthDrivers/vpb/VPBOptions
+++ b/src/osgEarthDrivers/vpb/VPBOptions
@@ -53,6 +53,9 @@ namespace osgEarth { namespace Drivers
         optional<int>& layer() { return _layer; }
         const optional<int>& layer() const { return _layer; }
 
+		optional<std::string>& layerSetName() { return _layerSetName; }
+		const optional<std::string>& layerSetName() const { return _layerSetName; }
+
         optional<int>& numTilesWideAtLod0() { return _widthLod0; }
         const optional<int>& numTilesWideAtLod0() const { return _widthLod0; }
 
@@ -82,6 +85,7 @@ namespace osgEarth { namespace Drivers
             conf.updateIfSet("primary_split_level", _primarySplitLevel);
             conf.updateIfSet("secondary_split_level", _secondarySplitLevel);
             conf.updateIfSet("layer", _layer);
+			conf.updateIfSet("layer_setname", _layerSetName);
             conf.updateIfSet("num_tiles_wide_at_lod_0", _widthLod0 );
             conf.updateIfSet("num_tiles_high_at_lod_0", _heightLod0 );
             conf.updateIfSet("base_name", _baseName );
@@ -105,6 +109,7 @@ namespace osgEarth { namespace Drivers
             conf.getIfSet("primary_split_level", _primarySplitLevel);
             conf.getIfSet("secondary_split_level", _secondarySplitLevel);
             conf.getIfSet("layer", _layer);
+			conf.getIfSet("layer_setname", _layerSetName);
             conf.getIfSet("numTilesWideAtLod0", _widthLod0 );
             conf.getIfSet("numTilesHighAtLod0", _heightLod0 );
             conf.getIfSet("base_name", _baseName);
@@ -115,7 +120,7 @@ namespace osgEarth { namespace Drivers
             else if ( ds == "nested" ) _dirStruct = DS_NESTED;
         }
 
-        optional<std::string> _url, _baseName;
+        optional<std::string> _url, _baseName, _layerSetName;
         optional<int> _primarySplitLevel, _secondarySplitLevel, _layer, _widthLod0, _heightLod0;
         optional<DirectoryStructure> _dirStruct;
     };

--- a/src/osgEarthUtil/Controls.cpp
+++ b/src/osgEarthUtil/Controls.cpp
@@ -1404,7 +1404,7 @@ ControlCanvas::handle( const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter
 
     float invY = _context._vp->height() - ea.getY();
 
-    for( ControlList::const_reverse_iterator i = _controls.rbegin(); i != _controls.rend(); ++i )
+    for( ControlList::reverse_iterator i = _controls.rbegin(); i != _controls.rend(); ++i )
     {
         Control* control = i->get();
         if ( control->intersects( ea.getX(), invY ) )


### PR DESCRIPTION
The current revision contains an extended version of the VPB driver to support image layers. It supports layer numbers and named image sets.
It also contains some minor changes/enhancements to build osgEarth with STLport.
Regards,
Andreas
