### PR TITLE
Controls::onMouseDown event

### DIFF
--- a/src/applications/osgearth_controls/osgearth_controls.cpp
+++ b/src/applications/osgearth_controls/osgearth_controls.cpp
@@ -60,6 +60,11 @@ struct MyClickHandler : public ControlEventHandler
         OE_NOTICE << "Thank you for clicking on " << typeid(control).name()
                   << std::endl;
     }
+    void onMouseDown( Control* control, int mouseButtonMask )
+    {
+        OE_NOTICE << "Clicking on " << typeid(control).name()
+                  << std::endl;
+    }
 };
 
 static LabelControl* s_sliderLabel;

--- a/src/osgEarthUtil/Controls
+++ b/src/osgEarthUtil/Controls
@@ -89,6 +89,7 @@ namespace osgEarth { namespace Util { namespace Controls
     {
     public:
         virtual void onClick( class Control* control, int mouseButtonMask ) { }
+        virtual void onMouseDown( class Control* control, int mouseButtonMask ) { }
         virtual void onValueChanged( class Control* control, float value ) { }
         virtual void onValueChanged( class Control* control, bool value ) { }
     };
@@ -213,6 +214,7 @@ namespace osgEarth { namespace Util { namespace Controls
         optional<osg::Vec4f> _backColor, _foreColor, _activeColor;
         osg::observer_ptr<Control> _parent;
         bool _active;
+        bool _clicked;
         bool _absorbEvents;
     };
 

--- a/src/osgEarthUtil/Controls.cpp
+++ b/src/osgEarthUtil/Controls.cpp
@@ -46,6 +46,7 @@ _foreColor( osg::Vec4f(1,1,1,1) ),
 _activeColor( osg::Vec4f(.4,.4,.4,1) ),
 _visible( true ),
 _active( false ),
+_clicked( false ),
 _absorbEvents( false )
 {
     //nop
@@ -320,14 +321,30 @@ Control::handle( const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& aa, 
             {
                 cx._active.push( this );
             }
+            _clicked = false;
         }
         else 
         {
-            if ( ea.getEventType() == osgGA::GUIEventAdapter::RELEASE )
+            if ( ea.getEventType() == osgGA::GUIEventAdapter::PUSH )
+            {
+                _clicked = true;
+            }
+            else if ( ea.getEventType() == osgGA::GUIEventAdapter::RELEASE )
             {
                 for( ControlEventHandlerList::const_iterator i = _eventHandlers.begin(); i != _eventHandlers.end(); ++i )
                 {
                     i->get()->onClick( this, ea.getButtonMask() );
+                }
+                _clicked = false;
+            }
+            if ( _clicked )
+            {
+                if ( ea.getEventType() == osgGA::GUIEventAdapter::FRAME )
+                {
+                    for( ControlEventHandlerList::const_iterator i = _eventHandlers.begin(); i != _eventHandlers.end(); ++i )
+                    {
+                        i->get()->onMouseDown( this, ea.getButtonMask() );
+                    }
                 }
             }
         }
@@ -1399,8 +1416,6 @@ bool
 ControlCanvas::handle( const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& aa )
 {
     bool handled = false;
-    if ( ea.getEventType() == osgGA::GUIEventAdapter::FRAME )
-        return handled;
 
     float invY = _context._vp->height() - ea.getY();
 


### PR DESCRIPTION
In our globe plugin for QGIS we need control buttons for continous panning etc. while the mouse button is pressed.
