### PR TITLE
Fixed incomplete type compile issue on mac osx.

### DIFF
--- a/src/osgEarth/MapNode
+++ b/src/osgEarth/MapNode
@@ -25,6 +25,7 @@
 #include <osgEarth/MapNodeOptions>
 #include <osgEarth/TerrainEngineNode>
 #include <osg/CoordinateSystemNode>
+#include <osg/PagedLOD>
 #include <osgSim/OverlayNode>
 
 namespace osgEarth


### PR DESCRIPTION
In MapNode.cpp,  RemoveBlacklistedFilenamesVisitor, osg::PagedLOD is defined by a forward declaration but never included.  Adding the #include<osg/PagedLOD> to MapNode fixes that.
