### PR TITLE
Support of plugin options in DiskCache writer

### DIFF
--- a/src/osgEarth/Caching
+++ b/src/osgEarth/Caching
@@ -96,7 +96,8 @@ namespace osgEarth
     public:
         DiskCacheOptions( const ConfigOptions& options =ConfigOptions() )
             : CacheOptions( options ),
-              _writeWorldFiles( false )
+              _writeWorldFiles( false ),
+			  _imageWriterPluginOptions("")
         {
             fromConfig( _conf );
         }
@@ -109,11 +110,15 @@ namespace osgEarth
         optional<bool>& writeWorldFiles() { return _writeWorldFiles; }
         const optional<bool>& writeWorldFiles() const { return _writeWorldFiles; }
 
+        optional<std::string>& imageWriterPluginOptions() { return _imageWriterPluginOptions; }
+        const optional<std::string>& imageWriterPluginOptions() const { return _imageWriterPluginOptions; }
+
     public:
         virtual Config getConfig() const {
             Config conf = CacheOptions::getConfig();
             conf.update("path", _path);
             conf.updateIfSet("write_world_files", _writeWorldFiles);
+            conf.updateIfSet("image_writer_plugin_options", _imageWriterPluginOptions);
             return conf;
         }
         virtual void mergeConfig( const Config& conf ) {
@@ -125,10 +130,13 @@ namespace osgEarth
         void fromConfig( const Config& conf ) {
             _path = conf.value("path");
             conf.getIfSet("write_world_files", _writeWorldFiles);
+            conf.getIfSet("image_writer_plugin_options", _imageWriterPluginOptions);
+			
         }
 
-        std::string    _path;
-        optional<bool> _writeWorldFiles;
+        std::string           _path;
+        optional<bool>        _writeWorldFiles;
+		optional<std::string> _imageWriterPluginOptions;
     };
 
     //----------------------------------------------------------------------

--- a/src/osgEarth/Caching.cpp
+++ b/src/osgEarth/Caching.cpp
@@ -249,6 +249,9 @@ DiskCache::setImage( const TileKey& key, const CacheSpec& spec, const osg::Image
 
     bool writingJpeg = (ext == "jpg" || ext == "jpeg");
 
+	osg::ref_ptr<osgDB::ReaderWriter::Options> op = new osgDB::ReaderWriter::Options();
+	op->setOptionString(_options.imageWriterPluginOptions().value());
+
 	//If we are trying to write a non RGB image to JPEG, convert it to RGB before we write it
     if ((image->getPixelFormat() != GL_RGB) && writingJpeg)
     {
@@ -256,7 +259,7 @@ DiskCache::setImage( const TileKey& key, const CacheSpec& spec, const osg::Image
 		osg::ref_ptr<osg::Image> rgb = ImageUtils::convertToRGB8( image );
 		if (rgb.valid())
 		{
-			osgDB::writeImageFile(*rgb.get(), filename);
+			osgDB::writeImageFile(*rgb.get(), filename, op);
 		}
     }
     else


### PR DESCRIPTION
Hi Glenn

I patched Cache for the following feature:

http://www.osgearth.org/ticket/287

I use a parameter called "image_writer_plugin_options" in "cache" xml category. I hope it is usable.

Sample:

``` xml
<cache type="tms">
    <path>...</path>
    <format>jpg</format>
    <image_writer_plugin_options>JPEG_QUALITY 75</image_writer_plugin_options>
</cache>
```

Cheers
Remo
