### PR TITLE
Support of "allow_projection_difference" option for gdalbuildvrt

### DIFF
--- a/src/osgEarth/TileSource
+++ b/src/osgEarth/TileSource
@@ -78,6 +78,9 @@ namespace osgEarth
         optional<int>& L2CacheSize() { return _L2CacheSize; }
         const optional<int>& L2CacheSize() const { return _L2CacheSize; }
 
+		optional<bool>& gdalAllowProjectionDifference() { return _gdalAllowProjectionDifference; }
+        const optional<bool>& gdalAllowProjectionDifference() const { return _gdalAllowProjectionDifference; }
+
     public:
         TileSourceOptions( const ConfigOptions& options =ConfigOptions() )
             : DriverConfigOptions( options ),
@@ -85,7 +88,8 @@ namespace osgEarth
               _noDataValue( (float)SHRT_MIN ),
               _noDataMinValue( -FLT_MAX ),
               _noDataMaxValue( FLT_MAX ),
-              _L2CacheSize( 16 )
+              _L2CacheSize( 16 ),
+			  _gdalAllowProjectionDifference(false)
         { 
             fromConfig( _conf );
         }
@@ -100,6 +104,7 @@ namespace osgEarth
             conf.updateIfSet( "blacklist_filename", _blacklistFilename);
             //conf.updateIfSet( "enable_l2_cache", _enableL2Cache );
             conf.updateIfSet( "l2_cache_size", _L2CacheSize );
+            conf.updateIfSet( "gdal_allow_projection_difference", _gdalAllowProjectionDifference );
             conf.updateObjIfSet( "profile", _profileOptions );
             return conf;
         }
@@ -119,6 +124,7 @@ namespace osgEarth
             conf.getIfSet( "blacklist_filename", _blacklistFilename);
             //conf.getIfSet( "enable_l2_cache", _enableL2Cache );
             conf.getIfSet( "l2_cache_size", _L2CacheSize );
+            conf.getIfSet( "gdal_allow_projection_difference", _gdalAllowProjectionDifference );
             conf.getObjIfSet( "profile", _profileOptions );
 
             // special handling of default tile size:
@@ -133,6 +139,7 @@ namespace osgEarth
         optional<ProfileOptions> _profileOptions;
         optional<std::string> _blacklistFilename;
         optional<int> _L2CacheSize;
+		optional<bool> _gdalAllowProjectionDifference;
         //optional<bool> _enableL2Cache;
     };
 

--- a/src/osgEarthDrivers/gdal/ReaderWriterGDAL.cpp
+++ b/src/osgEarthDrivers/gdal/ReaderWriterGDAL.cpp
@@ -190,7 +190,7 @@ getFiles(const std::string &file, const std::vector<std::string> &exts, std::vec
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 static GDALDatasetH
-build_vrt(std::vector<std::string> &files, ResolutionStrategy resolutionStrategy)
+build_vrt(std::vector<std::string> &files, ResolutionStrategy resolutionStrategy, bool allowProjectionDifference)
 {
     GDAL_SCOPED_LOCK;
 
@@ -297,9 +297,11 @@ build_vrt(std::vector<std::string> &files, ResolutionStrategy resolutionStrategy
                     (proj == NULL && projectionRef != NULL) ||
                     (proj != NULL && projectionRef != NULL && EQUAL(proj, projectionRef) == FALSE))
                 {
-                    fprintf( stderr, "gdalbuildvrt does not support heterogenous projection. Skipping %s\n",dsFileName);
-                    GDALClose(hDS);
-                    continue;
+					if(!allowProjectionDifference) {
+						fprintf( stderr, "gdalbuildvrt does not support heterogenous projection. Skipping %s\n",dsFileName);
+						GDALClose(hDS);
+						continue;
+					}
                 }
                 int _nBands = GDALGetRasterCount(hDS);
                 if (nBands != _nBands)
@@ -700,7 +702,7 @@ public:
         //If we found more than one file, try to combine them into a single logical dataset
         if (files.size() > 1)
         {
-            _srcDS = (GDALDataset*)build_vrt(files, HIGHEST_RESOLUTION);
+            _srcDS = (GDALDataset*)build_vrt(files, HIGHEST_RESOLUTION, _options.gdalAllowProjectionDifference().value());
             if (!_srcDS)
             {
                 OE_WARN << "[osgEarth::GDAL] Failed to build VRT from input datasets" << std::endl;


### PR DESCRIPTION
Hi

I've added support of allowProjectionDifference to GDAL driver. It helps when you have a lot of big files with wrong SRS on TIFs that you don't want to change. See also at:

http://www.gdal.org/gdalbuildvrt.html (-allow_projection_difference)

Cheers,
Remo
