### PR TITLE
Changes for explicit osg::ref_ptr<T> to T* conversion

### DIFF
--- a/src/applications/osgearth_featureeditor/osgearth_featureeditor.cpp
+++ b/src/applications/osgearth_featureeditor/osgearth_featureeditor.cpp
@@ -99,7 +99,7 @@ _featureGraph( featureGraph )
         //remove the editor if it's valid
         if (s_editor.valid())
         {
-            s_root->removeChild( s_editor );
+            s_root->removeChild( s_editor.get() );
             s_editor = NULL;
 
             Style outStyle;
@@ -113,7 +113,7 @@ _featureGraph( featureGraph )
         //Add the new add point handler
         if (!s_addPointHandler.valid() && s_activeFeature.valid())
         {
-            s_addPointHandler = new AddPointHandler(s_activeFeature, s_source.get(), s_mapNode->getMap()->getProfile()->getSRS());
+            s_addPointHandler = new AddPointHandler(s_activeFeature.get(), s_source.get(), s_mapNode->getMap()->getProfile()->getSRS());
             s_addPointHandler->setIntersectionMask( 0x1 );
             s_viewer->addEventHandler( s_addPointHandler.get() );
         }        
@@ -146,8 +146,8 @@ _featureGraph( featureGraph )
                 outStyle.getSymbol<LineSymbol>()->stroke()->stipple() =  0x00FF ;
                 _featureGraph->setStyles( _featureGraph->getStyles() );
             }
-            s_editor = new FeatureEditor(s_activeFeature, s_source, s_mapNode);
-            s_root->addChild( s_editor );
+            s_editor = new FeatureEditor(s_activeFeature.get(), s_source.get(), s_mapNode.get());
+            s_root->addChild( s_editor.get() );
         }
     }
 
@@ -240,7 +240,7 @@ int main(int argc, char** argv)
     s_activeFeature = feature;
   
     s_root = new osg::Group;
-    s_root->addChild( s_mapNode );
+    s_root->addChild( s_mapNode.get() );
 
     FeatureModelGraph* graph = new FeatureModelGraph( 
         s_source.get(), 
@@ -300,7 +300,7 @@ int main(int argc, char** argv)
     }
    
     
-    viewer.setSceneData( s_root );
+    viewer.setSceneData( s_root.get() );
     viewer.setCameraManipulator( new EarthManipulator() );
 
     if ( !useOverlay )

--- a/src/applications/osgearth_featureinfo/osgearth_featureinfo.cpp
+++ b/src/applications/osgearth_featureinfo/osgearth_featureinfo.cpp
@@ -86,7 +86,7 @@ void printAllFeatures(FeatureSource* features)
     while (cursor->hasMore())
     {
         osg::ref_ptr< Feature > feature = cursor->nextFeature();
-        printFeature( feature );
+        printFeature( feature.get() );
     }
 }
 

--- a/src/applications/osgearth_imageoverlay/osgearth_imageoverlay.cpp
+++ b/src/applications/osgearth_imageoverlay/osgearth_imageoverlay.cpp
@@ -134,8 +134,8 @@ struct ChangeImageHandler : public ControlEventHandler
       _preview(preview){ }
 
     void onClick( Control* control, int mouseButtonMask ) {
-        _overlay->setImage( _image );
-        _preview->setImage( _image );
+        _overlay->setImage( _image.get() );
+        _preview->setImage( _image.get() );
     }
     ImageOverlay* _overlay;
     osg::ref_ptr< osg::Image > _image;

--- a/src/applications/osgearth_ocean/osgearth_ocean.cpp
+++ b/src/applications/osgearth_ocean/osgearth_ocean.cpp
@@ -272,7 +272,7 @@ int main(int argc, char** argv)
     // assemble the rest of the scene graph and go
     osgViewer::Viewer viewer(arguments);
 
-    group->addChild( loadedModel );
+    group->addChild( loadedModel.get() );
     group->addChild( createMenu(&viewer) );
     viewer.setSceneData(group);
     

--- a/src/osgEarth/Caching.cpp
+++ b/src/osgEarth/Caching.cpp
@@ -259,12 +259,12 @@ DiskCache::setImage( const TileKey& key, const CacheSpec& spec, const osg::Image
 		osg::ref_ptr<osg::Image> rgb = ImageUtils::convertToRGB8( image );
 		if (rgb.valid())
 		{
-			osgDB::writeImageFile(*rgb.get(), filename, op);
+			osgDB::writeImageFile(*rgb.get(), filename, op.get());
 		}
     }
     else
     {
-        osgDB::writeImageFile(*image, filename, op);
+        osgDB::writeImageFile(*image, filename, op.get());
     }
 }
 

--- a/src/osgEarth/TextureCompositorTexArray.cpp
+++ b/src/osgEarth/TextureCompositorTexArray.cpp
@@ -203,9 +203,9 @@ namespace
         {
             sampler = new osg::Uniform(osg::Uniform::SAMPLER_2D_ARRAY, str);
             sampler->set(unit);
-            ss->addUniform(sampler);
+            ss->addUniform(sampler.get());
         }
-        return sampler;
+        return sampler.get();
     }
 
     void assignImage(osg::Texture2DArray* texture, int slot, osg::Image* image)

--- a/src/osgEarthDrivers/engine_osgterrain/MultiPassTerrainTechnique.cpp
+++ b/src/osgEarthDrivers/engine_osgterrain/MultiPassTerrainTechnique.cpp
@@ -819,7 +819,7 @@ void MultiPassTerrainTechnique::generateGeometry(osgTerrain::Locator* masterLoca
     if (_transform.valid())
     {
         _transform->removeChildren( 0, _transform->getNumChildren() );
-        _transform->addChild(_passes);
+        _transform->addChild(_passes.get());
     }
 
     typedef std::map<int, osg::ref_ptr<osg::Geode> > OrderedGeodes;
@@ -833,7 +833,7 @@ void MultiPassTerrainTechnique::generateGeometry(osgTerrain::Locator* masterLoca
     if ( tilef._colorLayers.size() == 0 )
     {
         // if there's no data, just make a placeholder pass
-		osg::Geode* geode = createPass(0, 0L, masterLocator, centerModel, prototype);
+		osg::Geode* geode = createPass(0, 0L, masterLocator, centerModel, prototype.get());
 		_passes->addChild( geode );
 	}
     else

--- a/src/osgEarthDrivers/engine_osgterrain/OSGTileFactory.cpp
+++ b/src/osgEarthDrivers/engine_osgterrain/OSGTileFactory.cpp
@@ -876,7 +876,7 @@ OSGTileFactory::createHeightFieldLayer( const MapFrame& mapf, const TileKey& key
     // In a Plate Carre tesselation, scale the heightfield elevations from meters to degrees
     if ( isPlateCarre )
     {
-        HeightFieldUtils::scaleHeightFieldToDegrees( hf );
+        HeightFieldUtils::scaleHeightFieldToDegrees( hf.get() );
     }
 
     osgTerrain::HeightFieldLayer* hfLayer = new osgTerrain::HeightFieldLayer( hf.get() );

--- a/src/osgEarthDrivers/engine_osgterrain/SinglePassTerrainTechnique.cpp
+++ b/src/osgEarthDrivers/engine_osgterrain/SinglePassTerrainTechnique.cpp
@@ -1025,7 +1025,7 @@ SinglePassTerrainTechnique::createGeometry( const TileFrame& tilef )
 #if 1
         //Do a diff on the polygons to get the actual mask skirt
         osg::ref_ptr<osgEarth::Symbology::Geometry> outPoly;
-        maskSkirtPoly->difference(maskPoly, outPoly);
+        maskSkirtPoly->difference(maskPoly.get(), outPoly);
 #else
         osg::ref_ptr<osgEarth::Symbology::Geometry> outPoly = maskSkirtPoly;
 #endif
@@ -1041,7 +1041,7 @@ SinglePassTerrainTechnique::createGeometry( const TileFrame& tilef )
         
         std::vector<int> skirtIndices;
 
-        osgEarth::Symbology::GeometryIterator i( outPoly, false );
+        osgEarth::Symbology::GeometryIterator i( outPoly.get(), false );
         while( i.hasMore() )
         {
           osgEarth::Symbology::Geometry* part = i.next();

--- a/src/osgEarthDrivers/engine_osgterrain/Tile
+++ b/src/osgEarthDrivers/engine_osgterrain/Tile
@@ -110,7 +110,7 @@ public:
     float getVerticalScale() const { return _verticalScale; }
     void setVerticalScale( float verticalScale );
 
-    osgTerrain::Locator* getLocator() const { return _locator; }
+    osgTerrain::Locator* getLocator() const { return _locator.get(); }
 
     const osgTerrain::TileID& getTileId() const { return _tileId; }
 

--- a/src/osgEarthDrivers/model_feature_stencil/FeatureStencilModelSource.cpp
+++ b/src/osgEarthDrivers/model_feature_stencil/FeatureStencilModelSource.cpp
@@ -385,7 +385,7 @@ namespace
             bool hasLines = false;
             for( FeatureList::const_iterator i = featureList.begin(); i != featureList.end(); ++i )
             {
-                Feature* feature = *i;
+                Feature* feature = (*i).get();
                 Geometry* geom = feature->getGeometry();
                 if ( geom && 
                      ( geom->getComponentType() == Geometry::TYPE_LINESTRING ||
@@ -433,7 +433,7 @@ namespace
 
             for( FeatureList::iterator i = featureList.begin(); i != featureList.end(); ++i )
             {
-                Feature* feature = *i;
+                Feature* feature = (*i).get();
                 Geometry* geom = feature->getGeometry();
                 osg::Node* volume = createVolume( geom, -extrusionDistance, extrusionDistance * 2.0, cx );
 

--- a/src/osgEarthFeatures/FeatureModelGraph.cpp
+++ b/src/osgEarthFeatures/FeatureModelGraph.cpp
@@ -591,10 +591,10 @@ FeatureModelGraph::build( const Style& baseStyle, const Query& baseQuery, const 
                 if ( !group->containsNode( styleGroup ) )
                     group->addChild( styleGroup );                
 
-                if ( _factory->createOrUpdateNode( cursor, *feature->style(), context, node ) )
+                if ( _factory->createOrUpdateNode( cursor.get(), *feature->style(), context, node ) )
                 {
                     if ( node.valid() )
-                        styleGroup->addChild( node );
+                        styleGroup->addChild( node.get() );
                 }
             }
         }

--- a/src/osgEarthSymbology/Style
+++ b/src/osgEarthSymbology/Style
@@ -74,7 +74,7 @@ namespace osgEarth { namespace Symbology
         {
             for (SymbolList::const_iterator it = _symbols.begin(); it != _symbols.end(); ++it)
             {
-                Symbol* symbol = *it;
+                Symbol* symbol = (*it).get();
                 T* s = dynamic_cast<T*>(symbol);
                 if (s)
                     return s;
@@ -89,7 +89,7 @@ namespace osgEarth { namespace Symbology
         {
             for (SymbolList::const_iterator it = _symbols.begin(); it != _symbols.end(); ++it)
             {
-                Symbol* symbol = *it;
+                Symbol* symbol = (*it).get();
                 const T* s = dynamic_cast<const T*>(symbol);
                 if (s)
                     return s;

--- a/src/osgEarthUtil/Annotation
+++ b/src/osgEarthUtil/Annotation
@@ -78,7 +78,7 @@ namespace osgEarth { namespace Util { namespace Annotation
          * Control to pop up when the user clicks on the placemark (TODO)
          */
         void setPopupControl( Control* control );
-        Control* getPopupControl() const { return _popupControl; }
+        Control* getPopupControl() const { return _popupControl.get(); }
 
     private:
         std::string                _iconURI;

--- a/src/osgEarthUtil/FeatureEditing.cpp
+++ b/src/osgEarthUtil/FeatureEditing.cpp
@@ -213,7 +213,7 @@ FeatureEditor::init()
         dragger->setupDefaultGeometry();
         dragger->setMatrix(matrix);
         dragger->setHandleEvents( true );        
-        dragger->addDraggerCallback(new MoveFeatureDraggerCallback(_feature, _source, _mapNode->getMap(), i) );
+        dragger->addDraggerCallback(new MoveFeatureDraggerCallback(_feature.get(), _source.get(), _mapNode->getMap(), i) );
 
         addChild(dragger);        
     }

--- a/src/osgEarthUtil/ImageOverlayEditor
+++ b/src/osgEarthUtil/ImageOverlayEditor
@@ -19,13 +19,13 @@ namespace osgEarth { namespace Util
 
         ControlPointDraggerMap& getDraggers() { return _draggers; }
 
-        const osg::EllipsoidModel* getEllipsoid() const { return _ellipsoid;}
+        const osg::EllipsoidModel* getEllipsoid() const { return _ellipsoid.get();}
         void setEllipsoid( const osg::EllipsoidModel* ellipsoid) { _ellipsoid = ellipsoid; };
 
         osg::Node* getTerrain() const { return _terrain.get(); }
         void setTerrain( osg::Node* terrain) { _terrain = terrain;}
 
-        ImageOverlay* getOverlay() { return _overlay;}
+        ImageOverlay* getOverlay() { return _overlay.get();}
 
         void updateDraggers();
 

--- a/src/osgEarthUtil/ImageOverlayEditor.cpp
+++ b/src/osgEarthUtil/ImageOverlayEditor.cpp
@@ -128,7 +128,7 @@ _ellipsoid(ellipsoid),
 _terrain(terrain)
 {   
     _overlayCallback = new OverlayCallback(this);
-    _overlay->addCallback( _overlayCallback );
+    _overlay->addCallback( _overlayCallback.get() );
     addDragger( ImageOverlay::CONTROLPOINT_CENTER );
     addDragger( ImageOverlay::CONTROLPOINT_LOWER_LEFT );
     addDragger( ImageOverlay::CONTROLPOINT_LOWER_RIGHT );
@@ -138,7 +138,7 @@ _terrain(terrain)
 
 ImageOverlayEditor::~ImageOverlayEditor()
 {
-    _overlay->removeCallback( _overlayCallback );
+    _overlay->removeCallback( _overlayCallback.get() );
 }
 
 void
@@ -149,11 +149,11 @@ ImageOverlayEditor::addDragger( ImageOverlay::ControlPoint controlPoint )
     _ellipsoid->computeLocalToWorldTransformFromLatLongHeight(osg::DegreesToRadians(location.y()), osg::DegreesToRadians(location.x()), 0, matrix);    
 
     IntersectingDragger* dragger = new IntersectingDragger;
-    dragger->setNode( _terrain );
+    dragger->setNode( _terrain.get() );
     dragger->setupDefaultGeometry();
     dragger->setMatrix(matrix);
     dragger->setHandleEvents( true );
-    dragger->addDraggerCallback(new ImageOverlayDraggerCallback(_overlay, _ellipsoid, controlPoint));
+    dragger->addDraggerCallback(new ImageOverlayDraggerCallback(_overlay.get(), _ellipsoid.get(), controlPoint));
 
     addChild(dragger);
     _draggers[ controlPoint ] = dragger;

--- a/src/osgEarthUtil/MeasureTool.cpp
+++ b/src/osgEarthUtil/MeasureTool.cpp
@@ -55,7 +55,7 @@ _intersectionMask(0xffffffff)
 
     _feature->style() = style;
 
-    _featureNode = new FeatureNode( _mapNode, _feature.get(), false);
+    _featureNode = new FeatureNode( _mapNode.get(), _feature.get(), false);
     
 
     //Disable lighting and depth testing for the feature graph


### PR DESCRIPTION
Added osg::ref_ptr<T>::get() calls for explicit osg::ref_ptr<T> to T\* conversion.  Fixes some errors encountered when compiling with OSG 3.0 with the OSG_USE_REF_PTR_IMPLICIT_OUTPUT_CONVERSION flag set to false.
