### PR TITLE
Compile osgEarth for OpenGL ES

### DIFF
--- a/src/osgEarth/Capabilities.cpp
+++ b/src/osgEarth/Capabilities.cpp
@@ -150,6 +150,8 @@ _supportsMipmappedTextureUpdates( false )
 
         // Use the texture-proxy method to determine the maximum texture size 
         glGetIntegerv( GL_MAX_TEXTURE_SIZE, &_maxTextureSize );
+
+#if !(defined(OSG_GLES1_AVAILABLE) || defined (OSG_GLES2_AVAILABLE))
         for( int s = _maxTextureSize; s > 2; s >>= 1 )
         {
             glTexImage2D( GL_PROXY_TEXTURE_2D, 0, GL_RGBA8, s, s, 0, GL_RGBA, GL_UNSIGNED_BYTE, 0L );
@@ -161,6 +163,7 @@ _supportsMipmappedTextureUpdates( false )
                 break;
             }
         }
+#endif
         OE_INFO << LC << "  Max texture size = " << _maxTextureSize << std::endl;
 
         glGetIntegerv( GL_MAX_LIGHTS, &_maxLights );

--- a/src/osgEarth/ImageUtils.cpp
+++ b/src/osgEarth/ImageUtils.cpp
@@ -54,9 +54,17 @@ ImageUtils::normalizeImage( osg::Image* image )
     if ( image->getDataType() == GL_UNSIGNED_BYTE )
     {
         if ( image->getPixelFormat() == GL_RGB )
-            image->setInternalTextureFormat( GL_RGB8 );
+#if defined(OSG_GLES1_AVAILABLE) || defined (OSG_GLES2_AVAILABLE)
+          image->setInternalTextureFormat(GL_RGB8_OES);
+#else
+          image->setInternalTextureFormat( GL_RGB8 );
+#endif
         else if ( image->getPixelFormat() == GL_RGBA )
+#if defined(OSG_GLES1_AVAILABLE) || defined (OSG_GLES2_AVAILABLE)
+          image->setInternalTextureFormat(GL_RGBA8_OES);
+#else
             image->setInternalTextureFormat( GL_RGBA8 );
+#endif
     }
 }
 


### PR DESCRIPTION
I have modified osgEarth so that it at least compiles in an OpenGL ES environment. But these modifications do NOT result in a running version of osgEarth for OpenGL ES!!

If this will be possible I will find out later. And it may not only depend on osgEarth but also on osg itself. I have also announced necessary patches in the forum (General section).
