### PR TITLE
For sqlite OGR sources, OGR_L_GetNextFeature(...) will return null only ...

### DIFF
--- a/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp
+++ b/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp
@@ -207,6 +207,7 @@ FeatureCursorOGR::readChunk()
     }
 
     unsigned handlesToQueue = _chunkSize - _queue.size();
+    bool resultSetEndReached = false;
 
     for( unsigned i=0; i<handlesToQueue; i++ )
     {
@@ -224,7 +225,10 @@ FeatureCursorOGR::readChunk()
             OGR_F_Destroy( handle );
         }
         else
+        {
+            resultSetEndReached = true;
             break;
+        }
     }
 
     // preprocess the features using the filter list:
@@ -241,7 +245,10 @@ FeatureCursorOGR::readChunk()
     }
 
     // read one more for "more" detection:
-    _nextHandleToQueue = OGR_L_GetNextFeature( _resultSetHandle );
+    if (!resultSetEndReached)
+        _nextHandleToQueue = OGR_L_GetNextFeature( _resultSetHandle );
+    else
+        _nextHandleToQueue = 0L;
 
     //OE_NOTICE << "read " << _queue.size() << " features ... " << std::endl;
 }


### PR DESCRIPTION
...once, and will subsequently loop in the result-set.  Without this change, attempting to point osgEarth to a sqlite feature set results in an endless loop.
