### PR TITLE
Bug fix : check for NULL pointer

### DIFF
--- a/src/osgEarth/TerrainLayer.cpp
+++ b/src/osgEarth/TerrainLayer.cpp
@@ -356,6 +356,12 @@ TerrainLayer::getCacheBin( const Profile* profile, const std::string& binId )
         return 0L;
     }
 
+    // if cache is not setted, return NULL
+    if (_cache == NULL)
+    {
+        return 0L;
+    }
+
     // see if the cache bin already exists and return it if so
     {
         Threading::ScopedReadLock shared(_cacheBinsMutex);


### PR DESCRIPTION
 In some circumstances, the _cache member can be NULL and that leads to a crash. For example :
- create a layer (image or elevation)
- do not add it to a map 
- do not configure it's caching policy

Then run a TMSPackager::package method on it : it will crash because "_cache" is NULL
