### PR TITLE
Fixed bug in createSamplerFunction

### DIFF
--- a/src/osgEarth/TextureCompositorMulti.cpp
+++ b/src/osgEarth/TextureCompositorMulti.cpp
@@ -505,14 +505,14 @@ TextureCompositorMultiTexture::createSamplerFunction(UID layerUID,
     {
         std::stringstream buf;
 
-        buf << "uniform sampler2D tex"<< slot << "; \n"
+        buf << "uniform sampler2D "<< makeSamplerName(slot) << "; \n"
             << "vec4 " << functionName << "() \n"
             << "{ \n";
 
         if ( type == osg::Shader::VERTEX )
-            buf << "    return texture2D(tex"<< slot << ", gl_MultiTexCoord"<< slot <<".st); \n";
+            buf << "    return texture2D("<< makeSamplerName(slot) << ", gl_MultiTexCoord"<< slot <<".st); \n";
         else
-            buf << "    return texture2D(tex"<< slot << ", gl_TexCoord["<< slot << "].st); \n";
+            buf << "    return texture2D("<< makeSamplerName(slot) << ", gl_TexCoord["<< slot << "].st); \n";
 
         buf << "} \n";
 


### PR DESCRIPTION
Bug is described here: http://forum.osgearth.org/Issues-When-Sampling-a-Layer-In-Shader-td5993933.html
createSamplerFunction worked only for the first layer due to wrong sampler names.
