### PR TITLE
Simple model source load from node

### DIFF
--- a/src/osgEarthDrivers/model_simple/SimpleModelOptions
+++ b/src/osgEarthDrivers/model_simple/SimpleModelOptions
@@ -81,7 +81,7 @@ namespace osgEarth { namespace Drivers
             conf.getIfSet( "lod_scale", _lod_scale );
             conf.getIfSet( "location", _location);
             conf.getIfSet( "orientation", _orientation);
-            _node = conf.getNonSerializable<ExternalDataset>( "SimpleModelOptions::Node" );
+            _node = conf.getNonSerializable<osg::Node>( "SimpleModelOptions::Node" );
         }
 
         optional<URI> _url;

--- a/src/osgEarthDrivers/model_simple/SimpleModelSource.cpp
+++ b/src/osgEarthDrivers/model_simple/SimpleModelSource.cpp
@@ -39,7 +39,7 @@ namespace
     {
     public:
         LODScaleOverrideNode() : m_lodScale(1.0f) {}
-        virtual	~LODScaleOverrideNode() {}
+        virtual ~LODScaleOverrideNode() {}
     public:
         void setLODScale(float scale) { m_lodScale = scale; }
         float getLODScale() const { return m_lodScale; }
@@ -88,20 +88,20 @@ public:
     {
         osg::ref_ptr<osg::Node> result;
 
-		if (_options.node() != NULL)
-		{
-			result = _options.node();
-		}
-		else
-		{
-			// required if the model includes local refs, like PagedLOD or ProxyNode:
-			osg::ref_ptr<osgDB::Options> localOptions = 
-				Registry::instance()->cloneOrCreateOptions( _dbOptions.get() );
+        if (_options.node() != NULL)
+        {
+            result = _options.node();
+        }
+        else
+        {
+            // required if the model includes local refs, like PagedLOD or ProxyNode:
+            osg::ref_ptr<osgDB::Options> localOptions = 
+                Registry::instance()->cloneOrCreateOptions( _dbOptions.get() );
 
-			localOptions->getDatabasePathList().push_back( osgDB::getFilePath(_options.url()->full()) );
+            localOptions->getDatabasePathList().push_back( osgDB::getFilePath(_options.url()->full()) );
 
-			result = _options.url()->getNode( localOptions.get(), CachePolicy::INHERIT, progress );
-		}
+            result = _options.url()->getNode( localOptions.get(), CachePolicy::INHERIT, progress );
+        }
 
         if (_options.location().isSet())
         {


### PR DESCRIPTION
This modification allow to use a node created "in memory" with the "simple model source layer"
