### PR TITLE
Add #undef Status to TileSource.

### DIFF
--- a/src/osgEarth/TileSource
+++ b/src/osgEarth/TileSource
@@ -20,6 +20,9 @@
 #ifndef OSGEARTH_TILE_SOURCE_H
 #define OSGEARTH_TILE_SOURCE_H 1
 
+// Need to undef Status in case it has been defined in Xlib.h. This can happen on Linux
+#undef Status
+
 #include <limits.h>
 
 #include <osg/Version>
@@ -50,14 +53,14 @@
 
 
 namespace osgEarth
-{   
+{
     /**
      * Configuration options for a tile source driver.
      */
     class OSGEARTH_EXPORT TileSourceOptions : public DriverConfigOptions // no export; header only
     {
     public:
-        
+
         optional<int>& tileSize() { return _tileSize; }
         const optional<int>& tileSize() const { return _tileSize; }
 
@@ -169,7 +172,7 @@ namespace osgEarth
     };
 
     /**
-     * A TileSource is an object that can create image and/or heightfield tiles. Driver 
+     * A TileSource is an object that can create image and/or heightfield tiles. Driver
      * plugins are responsible for creating and returning a TileSource that the Map
      * will then use to create tiles for tile keys.
      */
@@ -204,7 +207,7 @@ namespace osgEarth
             virtual void operator()( osg::ref_ptr<osg::HeightField>& in_out_hf ) =0;
         };
 
-    public:        
+    public:
         TileSource( const TileSourceOptions& options =TileSourceOptions() );
 
         /**
@@ -215,7 +218,7 @@ namespace osgEarth
         /**
          * Gets the number of pixels per tile for this TileSource.
          */
-        virtual int getPixelsPerTile() const;   
+        virtual int getPixelsPerTile() const;
 
         /**
          * Gets the list of areas with data for this TileSource
@@ -239,7 +242,7 @@ namespace osgEarth
         virtual osg::HeightField* createHeightField(
             const TileKey&        key,
             HeightFieldOperation* op        =0L,
-            ProgressCallback*     progress  =0L );     
+            ProgressCallback*     progress  =0L );
 
     public:
 
@@ -274,17 +277,17 @@ namespace osgEarth
             return _options.noDataMaxValue().value(); }
 
         /**
-         * Gets the maximum level of detail available from the tile source. Unlike 
-         * getMaxLevel(), which reports the maximum level at which to use this tile 
-         * source in a Map, this method reports the maximum level for which the 
+         * Gets the maximum level of detail available from the tile source. Unlike
+         * getMaxLevel(), which reports the maximum level at which to use this tile
+         * source in a Map, this method reports the maximum level for which the
          * tile source is able to return data.
          */
         virtual unsigned int getMaxDataLevel() const;
 
         /**
-         * Gets the minimum level of detail available from the tile source. Unlike 
-         * getMinLevel(), which reports the minimum level at which to use this tile 
-         * source in a Map, this method reports the minimum level for which the 
+         * Gets the minimum level of detail available from the tile source. Unlike
+         * getMinLevel(), which reports the minimum level at which to use this tile
+         * source in a Map, this method reports the minimum level for which the
          * tile source is able to return data.
          */
         virtual unsigned int getMinDataLevel() const;
@@ -298,7 +301,7 @@ namespace osgEarth
          *Gets the blacklist for this TileSource
          */
         TileBlacklist* getBlacklist();
-        const TileBlacklist* getBlacklist() const;     
+        const TileBlacklist* getBlacklist() const;
 
         /**
          * Whether or not the source has data for the given TileKey
@@ -323,7 +326,7 @@ namespace osgEarth
 
         /**
          * A hint as to what kind of caching policy would be appropriate to employ
-         * on this data source. By default, this is the default, which is to use a 
+         * on this data source. By default, this is the default, which is to use a
          * cache if one is configured. But a TileSource can report that caching should
          * not be used (for whatever reason) by returning CachePolicy::NO_CACHE.
          */
@@ -349,7 +352,7 @@ namespace osgEarth
          * Consider updating to the new initialize() method above since it properly
          * reports the results of the initialization.
          */
-        virtual void initialize( 
+        virtual void initialize(
             const osgDB::Options* dbOptions,
             const Profile*        overrideProfile ) { }
 
@@ -364,7 +367,7 @@ namespace osgEarth
         virtual bool isSameKindAs(const osg::Object* obj) const { return dynamic_cast<const TileSource*>(obj)!=NULL; }
         virtual const char* className() const { return "TileSource"; }
         virtual const char* libraryName() const { return "osgEarth"; }
-   
+
     protected:
 
         virtual ~TileSource();
@@ -388,7 +391,7 @@ namespace osgEarth
          * Creates an image for the given TileKey.
          * The returned object is new and is the responsibility of the caller.
          */
-        virtual osg::Image* createImage( 
+        virtual osg::Image* createImage(
             const TileKey&        key,
             ProgressCallback*     progress ) = 0;
 
@@ -396,7 +399,7 @@ namespace osgEarth
          * Creates a heightfield for the given TileKey
          * The returned object is new and is the responsibility of the caller.
          */
-        virtual osg::HeightField* createHeightField( 
+        virtual osg::HeightField* createHeightField(
             const TileKey&        key,
             ProgressCallback*     progress );
 
@@ -430,7 +433,7 @@ namespace osgEarth
         Status         _status;
     };
 
-    
+
     typedef std::vector< osg::ref_ptr<TileSource> > TileSourceVector;
 
     //--------------------------------------------------------------------
@@ -448,7 +451,7 @@ namespace osgEarth
      * tile source "pipelines" for data access and processing.
      */
     class OSGEARTH_EXPORT TileSourceFactory
-    {   
+    {
     public:
         static TileSource* create( const TileSourceOptions& options );
     };


### PR DESCRIPTION
Prevents "#define Status int" in Xlib.h from interfering with TileSource.
