### PR TITLE
Add option to use an osg::Group which as a decorator on a model layer.

### DIFF
--- a/src/osgEarth/ModelLayer
+++ b/src/osgEarth/ModelLayer
@@ -90,6 +90,14 @@ namespace osgEarth
         optional<bool>& disableShaders() { return _disableShaderComp; }
         const optional<bool>& disableShaders() const { return _disableShaderComp; }
 
+        /**
+         * An osg::Group which acts as a decorator on this model layer.
+         * Usefull to add uniforms, shaders and state attributes on the top of the model layers,
+         * regardless the map used to display this model layer
+         */
+        osg::ref_ptr<osg::Group>& decorator() { return _decorator; }
+        const osg::ref_ptr<osg::Group>& decorator() const { return _decorator; }
+
     public:
         virtual Config getConfig() const;
         virtual void mergeConfig( const Config& conf );
@@ -105,6 +113,7 @@ namespace osgEarth
         optional<bool> _visible;
         optional<bool> _lighting;
         optional<bool> _disableShaderComp;
+        osg::ref_ptr<osg::Group> _decorator;
     };
 
     /**

--- a/src/osgEarth/ModelLayer.cpp
+++ b/src/osgEarth/ModelLayer.cpp
@@ -85,6 +85,7 @@ ModelLayerOptions::getConfig() const
     conf.updateIfSet( "enabled", _enabled );
     conf.updateIfSet( "visible", _visible );
     conf.updateIfSet( "lighting", _lighting );
+    conf.updateNonSerializable( "ModelLayerOptions::Decorator", _decorator.get() );
 
     // temporary.
     conf.updateIfSet( "disable_shaders", _disableShaderComp );
@@ -104,6 +105,7 @@ ModelLayerOptions::fromConfig( const Config& conf )
     conf.getIfSet( "enabled", _enabled );
     conf.getIfSet( "visible", _visible );
     conf.getIfSet( "lighting", _lighting );
+    _decorator = conf.getNonSerializable<osg::Group>( "ModelLayerOptions::Decorator" );
 
     // temporary.
     conf.getIfSet( "disable_shaders", _disableShaderComp );
@@ -225,6 +227,13 @@ ModelLayer::createSceneGraph(const Map*            map,
             // save an observer reference to the node so we can change the visibility/lighting/etc.
             _nodeSet.insert( node );
         }
+    }
+
+    // Add model layer decorator if requested in options
+    if ( (node != NULL) && (_runtimeOptions.decorator().valid() == true) )
+    {
+        _runtimeOptions.decorator()->addChild(node);
+        node = _runtimeOptions.decorator();
     }
 
     return node;


### PR DESCRIPTION
Usefull to add uniforms, shaders and state attributes on the top of the model layers, regardless the map used to display this model layer.

This also allow to add state attributes even if the model layer is not yet added in any map.
