### PR TITLE
Event handlers were not removed from the view when Controls are deleted.

### DIFF
--- a/src/osgEarthUtil/Controls
+++ b/src/osgEarthUtil/Controls
@@ -827,6 +827,8 @@ namespace osgEarth { namespace Util { namespace Controls
         bool            _contextDirty;
         bool            _updatePending;
 
+		std::map<osgGA::GUIEventHandler*, osgViewer::View*> _eventHandlersMap;
+
         osg::ref_ptr<ControlNodeBin> _controlNodeBin;
 
         Control* addControlImpl( Control* control );

--- a/src/osgEarthUtil/Controls.cpp
+++ b/src/osgEarthUtil/Controls.cpp
@@ -2453,8 +2453,14 @@ ControlCanvas::init( osgViewer::View* view, bool registerCanvas )
 
     this->setDataVariance( osg::Object::DYNAMIC );
 
-    view->addEventHandler( new ViewportHandler(this) );
-    view->addEventHandler( new ControlCanvasEventHandler(this) );
+    osg::ref_ptr<osgGA::GUIEventHandler> pViewportHandler = new ViewportHandler(this);
+    osg::ref_ptr<osgGA::GUIEventHandler> pControlCanvasEventHandler = new ControlCanvasEventHandler(this);
+
+    _eventHandlersMap[pViewportHandler] = view;
+    _eventHandlersMap[pControlCanvasEventHandler] = view;
+
+    view->addEventHandler( pViewportHandler );
+    view->addEventHandler( pControlCanvasEventHandler );
 
     setReferenceFrame(osg::Transform::ABSOLUTE_RF);
     setViewMatrix(osg::Matrix::identity());
@@ -2490,6 +2496,12 @@ ControlCanvas::~ControlCanvas()
 {
     OpenThreads::ScopedLock<OpenThreads::Mutex> lock( _viewCanvasMapMutex );
     _viewCanvasMap.erase( _context._view );
+
+    std::map<osgGA::GUIEventHandler*, osgViewer::View*>::iterator itr;
+    for (itr = _eventHandlersMap.begin(); itr != _eventHandlersMap.end(); ++itr)
+    {
+        itr->second->removeEventHandler(itr->first);
+    }
 }
 
 void


### PR DESCRIPTION
This cause problems if you want to delete a Control during runtime
