### PR TITLE
Bugfix : Event handlers were not removed from the view when Controls are deleted.

### DIFF
--- a/src/osgEarthUtil/Controls
+++ b/src/osgEarthUtil/Controls
@@ -828,7 +828,8 @@ namespace osgEarth { namespace Util { namespace Controls
         bool            _contextDirty;
         bool            _updatePending;
 
-		std::map<osgGA::GUIEventHandler*, osgViewer::View*> _eventHandlersMap;
+        typedef std::map< osg::observer_ptr<osgGA::GUIEventHandler>, osg::observer_ptr<osgViewer::View> > EventHandlersMap;
+		EventHandlersMap _eventHandlersMap;
 
         osg::ref_ptr<ControlNodeBin> _controlNodeBin;
 

--- a/src/osgEarthUtil/Controls.cpp
+++ b/src/osgEarthUtil/Controls.cpp
@@ -2497,14 +2497,16 @@ ControlCanvas::~ControlCanvas()
     OpenThreads::ScopedLock<OpenThreads::Mutex> lock( _viewCanvasMapMutex );
     _viewCanvasMap.erase( _context._view );
 
-    // commented out: causing a crash on exit
-#if 0
-    std::map<osgGA::GUIEventHandler*, osgViewer::View*>::iterator itr;
+    EventHandlersMap::iterator itr;
     for (itr = _eventHandlersMap.begin(); itr != _eventHandlersMap.end(); ++itr)
     {
-        itr->second->removeEventHandler(itr->first);
+		osgGA::GUIEventHandler* pGUIEventHandler = itr->first.get();
+		osgViewer::View* pView = itr->second.get();
+		if ( (pView != NULL) && (pGUIEventHandler != NULL) )
+		{
+			pView->removeEventHandler(pGUIEventHandler);
+		}
     }
-#endif
 }
 
 void


### PR DESCRIPTION
This is a bugfix for my previous pull request : https://github.com/gwaldron/osgearth/pull/221

Tested on osgearth_controls example :
- crash with my previous code
- ok with this fix, which use observer_ptr to track viewer / handlers deletion
