### PR TITLE
Add the possibility to all model layers classes to use an osg::StateSet as decorator

### DIFF
--- a/src/osgEarth/ModelLayer
+++ b/src/osgEarth/ModelLayer
@@ -90,6 +90,13 @@ namespace osgEarth
         optional<bool>& disableShaders() { return _disableShaderComp; }
         const optional<bool>& disableShaders() const { return _disableShaderComp; }
 
+        /**
+         * An osg::StateSet which is placed on top of this model layer nodes graph.
+         * This allow to set uniform, shaders... whitout the need of knowing which map owns this layer
+         */
+        osg::ref_ptr<osg::StateSet>& decoratorStateSet() { return _decoratorStateSet; }
+        const osg::ref_ptr<osg::StateSet>& decoratorStateSet() const { return _decoratorStateSet; }
+
     public:
         virtual Config getConfig() const;
         virtual void mergeConfig( const Config& conf );
@@ -105,6 +112,7 @@ namespace osgEarth
         optional<bool> _visible;
         optional<bool> _lighting;
         optional<bool> _disableShaderComp;
+        osg::ref_ptr<osg::StateSet> _decoratorStateSet;
     };
 
     /**

--- a/src/osgEarth/ModelLayer.cpp
+++ b/src/osgEarth/ModelLayer.cpp
@@ -85,6 +85,7 @@ ModelLayerOptions::getConfig() const
     conf.updateIfSet( "enabled", _enabled );
     conf.updateIfSet( "visible", _visible );
     conf.updateIfSet( "lighting", _lighting );
+    conf.updateNonSerializable( "ModelLayerOptions::DecoratorStateSet", _decoratorStateSet.get() );
 
     // temporary.
     conf.updateIfSet( "disable_shaders", _disableShaderComp );
@@ -104,6 +105,7 @@ ModelLayerOptions::fromConfig( const Config& conf )
     conf.getIfSet( "enabled", _enabled );
     conf.getIfSet( "visible", _visible );
     conf.getIfSet( "lighting", _lighting );
+    _decoratorStateSet = conf.getNonSerializable<osg::StateSet>( "ModelLayerOptions::DecoratorStateSet" );
 
     // temporary.
     conf.getIfSet( "disable_shaders", _disableShaderComp );
@@ -225,6 +227,16 @@ ModelLayer::createSceneGraph(const Map*            map,
             // save an observer reference to the node so we can change the visibility/lighting/etc.
             _nodeSet.insert( node );
         }
+    }
+
+    // Add model layer decorator state set if requested in options
+    if ( (node != NULL) && (_runtimeOptions.decoratorStateSet().valid() == true) )
+    {
+		// Build an osg::Group to store this StateSet
+		osg::Group* pGroup = new osg::Group();
+		pGroup->setStateSet(_runtimeOptions.decoratorStateSet());
+        pGroup->addChild(node);
+        node = pGroup;
     }
 
     return node;


### PR DESCRIPTION
This stateset can be set in layer's options by developper to keep access to a "top stateset" for the layer, even if the layer is not yet added to a map or if the layer is added in different maps.
