### PR TITLE
Use of fully qualified names in OSGEARTH_REGISTER_FEATUREFILTER macro to avoid namespace errors in user code

### DIFF
--- a/src/osgEarthFeatures/Filter
+++ b/src/osgEarthFeatures/Filter
@@ -114,10 +114,10 @@ namespace osgEarth { namespace Features
     };
 
 #define OSGEARTH_REGISTER_FEATUREFILTER( CLASSNAME )\
-    static RegisterFeatureFilterProxy<CLASSNAME> s_osgEarthRegisterFeatureFilterProxy_##CLASSNAME;
+    static osgEarth::Features::RegisterFeatureFilterProxy<CLASSNAME> s_osgEarthRegisterFeatureFilterProxy_##CLASSNAME;
 
 #define OSGEARTH_REGISTER_SIMPLE_FEATUREFILTER( KEY, CLASSNAME)\
-    static RegisterFeatureFilterProxy< SimpleFeatureFilterFactory<CLASSNAME> > s_osgEarthRegisterFeatureFilterProxy_##CLASSNAME##KEY(new SimpleFeatureFilterFactory<CLASSNAME>(#KEY));
+    static osgEarth::Features::RegisterFeatureFilterProxy< osgEarth::Features::SimpleFeatureFilterFactory<CLASSNAME> > s_osgEarthRegisterFeatureFilterProxy_##CLASSNAME##KEY(new osgEarth::Features::SimpleFeatureFilterFactory<CLASSNAME>(#KEY));
 
 
     template<typename T>


### PR DESCRIPTION
This example code didn't compile because "RegisterFeatureFilterProxy" symbol is undefined :

namespace MyNameSpace
{
    class MyFilter : public osgEarth::Features::FeatureFilter
    {
     ....
    };

```
OSGEARTH_REGISTER_FEATUREFILTER(MyFilter)
```

};
