### PR TITLE
An osg::ref_ptr is hold the map during FMG thread operations to avoid map destruction.

### DIFF
--- a/src/osgEarthFeatures/FeatureModelGraph
+++ b/src/osgEarthFeatures/FeatureModelGraph
@@ -74,6 +74,11 @@ namespace osgEarth { namespace Features
         void setStyles( StyleSheet* styles );
 
         /**
+         * Session associated with this feature graph.
+         */
+        Session* getSession() { return _session; }
+
+        /**
          * Mark the feature graph dirty and in need of regeneration 
          */
         void dirty();
@@ -89,7 +94,6 @@ namespace osgEarth { namespace Features
          * Access to the features levels
          */
         const std::vector<const FeatureLevel*>& getLevels() const { return _lodmap; };
-
 
     public: // osg::Node
 

--- a/src/osgEarthFeatures/FeatureModelGraph.cpp
+++ b/src/osgEarthFeatures/FeatureModelGraph.cpp
@@ -124,9 +124,16 @@ struct osgEarthFeatureModelPseudoLoader : public osgDB::ReaderWriter
 
         osg::ref_ptr<FeatureModelGraph> graph = getGraph(uid);
         if ( graph.valid() )
-            return ReadResult( graph->load( lod, x, y, uri ) );
-        else
-            return ReadResult::ERROR_IN_READING_FILE;
+        {
+            // Take a reference on the map to avoid map destruction during thread operation
+            osg::ref_ptr<const Map> map = graph->getSession()->getMap();
+            if (map.valid() == true)
+            {
+                return ReadResult( graph->load( lod, x, y, uri ) );
+            }
+        }
+
+        return ReadResult::ERROR_IN_READING_FILE;
     }
 
     static UID registerGraph( FeatureModelGraph* graph )

--- a/src/osgEarthFeatures/Session
+++ b/src/osgEarthFeatures/Session
@@ -27,6 +27,7 @@
 #include <osgEarth/ThreadingUtils>
 #include <osgEarth/MapInfo>
 #include <osgEarth/MapFrame>
+#include <osgEarth/Map>
 
 namespace osgEarth { namespace Features
 {
@@ -72,6 +73,11 @@ namespace osgEarth { namespace Features
          * Gets the map information backing up this session.
          */
         const MapInfo& getMapInfo() const { return _mapInfo; }
+
+        /**
+         * Gets the map related to this session. Be carefull, this is held by an osg::observer_ptr and may be NULL
+         */
+        const Map* getMap() const { return _map.get(); }
 
         /** The style sheet governing this session. */
         void setStyles( StyleSheet* value );


### PR DESCRIPTION
Map destruction can lead to an application crash if the thread try to access to the map, the map SRS or other informations.
