### PR TITLE
Use of shaders with TextureCompositorMulti even if there is no image layer.

### DIFF
--- a/src/osgEarth/TerrainEngineNode.cpp
+++ b/src/osgEarth/TerrainEngineNode.cpp
@@ -354,7 +354,7 @@ TerrainEngineNode::updateImageUniforms()
         // layer count has changed, but the shader has not yet caught up. In the future we might use this to disable
         // "ghost" layers that used to exist at a given index, but no longer do.
         
-        _imageLayerController->_layerVisibleUniform.attach( "osgearth_ImageLayerVisible", osg::Uniform::BOOL,  stateSet, MAX_IMAGE_LAYERS );
+        _imageLayerController->_layerVisibleUniform.attach( "osgearth_ImageLayerVisible", osg::Uniform::BOOL,  stateSet, mapf.imageLayers().size() );
         _imageLayerController->_layerOpacityUniform.attach( "osgearth_ImageLayerOpacity", osg::Uniform::FLOAT, stateSet, mapf.imageLayers().size() );
         _imageLayerController->_layerRangeUniform.attach  ( "osgearth_ImageLayerRange",   osg::Uniform::FLOAT, stateSet, 2 * mapf.imageLayers().size() );
 

--- a/src/osgEarth/TextureCompositor
+++ b/src/osgEarth/TextureCompositor
@@ -26,8 +26,6 @@
 #include <osg/StateSet>
 #include <osg/Program>
 
-#define MAX_IMAGE_LAYERS 16
-
 namespace osgEarth
 {
     class ImageLayer;


### PR DESCRIPTION
I've also removed the MAX_IMAGE_LAYERS definition to use the current map value getted from MapFrame object.

So now the only limit to texture count use is GPU capability and shaders can be used to do terrain coloring even if there is no image layer.
