### PR TITLE
Modified LabelNode RenderBin value to force labels nodes to be drawn last

### DIFF
--- a/src/osgEarthAnnotation/LabelNode.cpp
+++ b/src/osgEarthAnnotation/LabelNode.cpp
@@ -88,6 +88,7 @@ LabelNode::init( const Style& style )
 
     osg::StateSet* stateSet = _geode->getOrCreateStateSet();
     stateSet->setAttributeAndModes( new osg::Depth(osg::Depth::ALWAYS, 0, 1, false), 1 );
+    stateSet->setRenderBinDetails(INT_MAX, "RenderBin");	// Force labels nodes to be drawn last
 
     AnnotationUtils::installAnnotationProgram( stateSet );
 


### PR DESCRIPTION
This is a fix a this issue : http://forum.osgearth.org/ModelNode-and-LabelNode-display-problem-td7579602.html

I've set "INT_MAX" for RenderBin value, but maybe a configurable option is better ?
