### PR TITLE
Modified the ModelNode annotation to use symbol's model instead of symbol's URI if model is set

### DIFF
--- a/src/osgEarthAnnotation/ModelNode.cpp
+++ b/src/osgEarthAnnotation/ModelNode.cpp
@@ -61,24 +61,36 @@ ModelNode::init(const osgDB::Options* dbOptions)
 
     if ( sym.valid() )
     {
-        if ( sym->url().isSet() )
+        if ( ( sym->url().isSet() ) || (sym->getModel() != NULL) )
         {
-            URI uri( sym->url()->eval(), sym->url()->uriContext() );
-            osg::Node* node = 0L;
-            
-            if ( sym->uriAliasMap()->empty() )
+            // Try to get a model from symbol
+            osg::ref_ptr<osg::Node> node = NULL;
+            //osg::ref_ptr<osg::Node> node = sym->getModel();
+
+            // Try to get a model from URI
+            if (node.valid() == false)
             {
-                node = uri.getNode( dbOptions );
-            }
-            else
-            {
-                // install an alias map if there's one in the symbology.
-                osg::ref_ptr<osgDB::Options> tempOptions = Registry::instance()->cloneOrCreateOptions(dbOptions);
-                tempOptions->setReadFileCallback( new URIAliasMapReadCallback(*sym->uriAliasMap(), uri.full()) );
-                node = uri.getNode( tempOptions.get() );
+                URI uri( sym->url()->eval(), sym->url()->uriContext() );
+
+                if ( sym->uriAliasMap()->empty() )
+                {
+                    node = uri.getNode( dbOptions );
+                }
+                else
+                {
+                    // install an alias map if there's one in the symbology.
+                    osg::ref_ptr<osgDB::Options> tempOptions = Registry::instance()->cloneOrCreateOptions(dbOptions);
+                    tempOptions->setReadFileCallback( new URIAliasMapReadCallback(*sym->uriAliasMap(), uri.full()) );
+                    node = uri.getNode( tempOptions.get() );
+                }
+
+                if (node.valid() == false)
+                {
+                    OE_WARN << LC << "No model and failed to load data from " << uri.full() << std::endl;
+                }
             }
 
-            if ( node )
+            if (node.valid() == true)
             {
                 // generate shader code for the loaded model:
                 ShaderGenerator gen;
@@ -118,12 +130,12 @@ ModelNode::init(const osgDB::Options* dbOptions)
             }
             else
             {
-                OE_WARN << LC << "Failed to load data from " << uri.full() << std::endl;
+                OE_WARN << LC << "No model" << std::endl;
             }
         }
         else
         {
-            OE_WARN << LC << "Symbology: no URI" << std::endl;
+            OE_WARN << LC << "Symbology: no URI or model" << std::endl;
         }
     }
     else


### PR DESCRIPTION
This allow the developper to use ModelNode annotation with a "in memory" osg::Node
