### PR TITLE
Added an option on TileSource to select the GDAL interpolation method during reprojection : Nearest or Bilinear

### DIFF
--- a/src/osgEarth/CompositeTileSource.cpp
+++ b/src/osgEarth/CompositeTileSource.cpp
@@ -302,7 +302,7 @@ CompositeTileSource::createImage(const TileKey&    key,
                     {
                         //We got an image, but now we need to crop it to match the incoming key's extents
                         GeoImage geoImage( image.get(), parentKey.getExtent());
-                        GeoImage cropped = geoImage.crop( key.getExtent(), true, textureSize.x(), textureSize.y());
+                        GeoImage cropped = geoImage.crop( key.getExtent(), true, textureSize.x(), textureSize.y(), *source->_options.bilinearReprojection());
                         image = cropped.getImage();
                     }
 

--- a/src/osgEarth/GeoData
+++ b/src/osgEarth/GeoData
@@ -558,7 +558,8 @@ namespace osgEarth
             const GeoExtent& extent,
             bool exact = false,
             unsigned int width = 0,
-            unsigned int height = 0) const;
+            unsigned int height = 0,
+            bool useBilinearInterpolation = true) const;
 
         /**
          * Warps the image into a new spatial reference system.
@@ -576,7 +577,8 @@ namespace osgEarth
             const SpatialReference* to_srs,
             const GeoExtent* to_extent = 0,
             unsigned int width = 0,
-            unsigned int height = 0) const;
+            unsigned int height = 0,
+            bool useBilinearInterpolation = true) const;
 
         /**
          * Adds a one-pixel transparent border around an image.

--- a/src/osgEarth/ImageLayer.cpp
+++ b/src/osgEarth/ImageLayer.cpp
@@ -451,7 +451,7 @@ ImageLayer::createImageInNativeProfile( const TileKey& key, ProgressCallback* pr
             GeoExtent tightExtent = nativeProfile->clampAndTransformExtent( key.getExtent() );
 
             // a non-exact crop is critical here to avoid resampling the data
-            return result.crop( tightExtent, false );
+            return result.crop( tightExtent, false, 0, 0, *_runtimeOptions.driver()->bilinearReprojection() );
         }
 
         else // all fallback data
@@ -670,7 +670,7 @@ ImageLayer::createImageFromTileSource(const TileKey&    key,
                         // same pixel size; because chances are if we're requesting a fallback that we're
                         // planning to mosaic it later, and the mosaicer requires same-size images.
                         GeoImage raw( result.get(), finalKey.getExtent() );
-                        GeoImage cropped = raw.crop( key.getExtent(), true, raw.getImage()->s(), raw.getImage()->t() );
+                        GeoImage cropped = raw.crop( key.getExtent(), true, raw.getImage()->s(), raw.getImage()->t(), *_runtimeOptions.driver()->bilinearReprojection() );
                         result = cropped.takeImage();
                         fellBack = true;
                     }
@@ -811,7 +811,8 @@ ImageLayer::assembleImageFromTileSource(const TileKey&    key,
             key.getProfile()->getSRS(),
             &key.getExtent(), 
             *_runtimeOptions.reprojectedTileSize(),
-            *_runtimeOptions.reprojectedTileSize() );
+            *_runtimeOptions.reprojectedTileSize(),
+            *_runtimeOptions.driver()->bilinearReprojection());
     }
 
     return result;

--- a/src/osgEarth/TileSource
+++ b/src/osgEarth/TileSource
@@ -82,6 +82,9 @@ namespace osgEarth
         optional<int>& L2CacheSize() { return _L2CacheSize; }
         const optional<int>& L2CacheSize() const { return _L2CacheSize; }
 
+        optional<bool>& bilinearReprojection() { return _bilinearReprojection; }
+        const optional<bool>& bilinearReprojection() const { return _bilinearReprojection; }
+
     public:
         TileSourceOptions( const ConfigOptions& options =ConfigOptions() );
 
@@ -102,6 +105,7 @@ namespace osgEarth
         optional<ProfileOptions> _profileOptions;
         optional<std::string>    _blacklistFilename;
         optional<int>            _L2CacheSize;
+        optional<bool>           _bilinearReprojection;
     };
 
     typedef std::vector<TileSourceOptions> TileSourceOptionsVector;

--- a/src/osgEarth/TileSource.cpp
+++ b/src/osgEarth/TileSource.cpp
@@ -144,12 +144,13 @@ TileBlacklist::write(std::ostream &output) const
 
 
 TileSourceOptions::TileSourceOptions( const ConfigOptions& options ) :
-DriverConfigOptions( options ),
-_tileSize          ( 256 ),
-_noDataValue       ( (float)SHRT_MIN ),
-_noDataMinValue    ( -32000.0f ),
-_noDataMaxValue    (  32000.0f ),
-_L2CacheSize       ( 16 )
+DriverConfigOptions   ( options ),
+_tileSize             ( 256 ),
+_noDataValue          ( (float)SHRT_MIN ),
+_noDataMinValue       ( -32000.0f ),
+_noDataMaxValue       (  32000.0f ),
+_L2CacheSize          ( 16 ),
+_bilinearReprojection ( true )
 { 
     fromConfig( _conf );
 }
@@ -165,6 +166,7 @@ TileSourceOptions::getConfig() const
     conf.updateIfSet( "nodata_max", _noDataMaxValue );
     conf.updateIfSet( "blacklist_filename", _blacklistFilename);
     conf.updateIfSet( "l2_cache_size", _L2CacheSize );
+    conf.updateIfSet( "bilinear_reprojection", _bilinearReprojection );
     conf.updateObjIfSet( "profile", _profileOptions );
     return conf;
 }
@@ -187,6 +189,7 @@ TileSourceOptions::fromConfig( const Config& conf )
     conf.getIfSet( "nodata_max", _noDataMaxValue );
     conf.getIfSet( "blacklist_filename", _blacklistFilename);
     conf.getIfSet( "l2_cache_size", _L2CacheSize );
+    conf.getIfSet( "bilinear_reprojection", _bilinearReprojection );
     conf.getObjIfSet( "profile", _profileOptions );
 
     // special handling of default tile size:

--- a/src/osgEarthDrivers/osg/OSGTileSource.cpp
+++ b/src/osgEarthDrivers/osg/OSGTileSource.cpp
@@ -143,7 +143,7 @@ public:
         if ( !_image.valid() || key.getLevelOfDetail() > getMaxDataLevel() )
             return NULL;
 
-        GeoImage cropped = _image.crop( key.getExtent(), true, getPixelsPerTile(), getPixelsPerTile() );
+        GeoImage cropped = _image.crop( key.getExtent(), true, getPixelsPerTile(), getPixelsPerTile(), *_options.bilinearReprojection() );
         return cropped.valid() ? cropped.takeImage() : 0L;
     }
 


### PR DESCRIPTION
I've added this option to solve this issue :

Under some circumstances, one may want to get exact pixel values, without any interpolation (for eaxmple to display computation results as ground texture or to display Digital Land Use color codes as ground texture)

There is an option to change the GPU texture interpolation method (NEAREST / LINEAR) as a terrain opton, but if a tile source needs to be mosaiced or reprojected, there is also an interpolation done on CPU using GDAL.

This option allow to select the interpolation method used by GDAL.

The default behaviour remains unchanged.

There is several files modified, so here are some explanations on what I've done :

1/ Modified "reprojectImage" GeoData.cpp to get one more boolean parameter : "useBilinearInterpolation" which switch between "nearest" and "bilinear"

2/ Modifed TileSource options class to add the new boolean option

3/ Modified all calls to "reprojectImage" within the different tile source class to use the new tile source option parameter
