### PR TITLE
Fixed a bug on neighbor tiles elevation reading with normalizeEdges option set to true

### DIFF
--- a/src/osgEarthDrivers/engine_quadtree/TileModelCompiler.cpp
+++ b/src/osgEarthDrivers/engine_quadtree/TileModelCompiler.cpp
@@ -1345,6 +1345,9 @@ namespace
             //Recalculate the west side
             if (w_neighbor.valid())
             {                                
+                unsigned int w_neighbor_numColums = w_neighbor->getNumColumns();
+                unsigned int w_neighbor_numRows = w_neighbor->getNumRows();
+
                 osg::ref_ptr< osg::Vec3Array > boundaryVerts = new osg::Vec3Array();
                 boundaryVerts->reserve( 2 * d.numRows );
 
@@ -1359,7 +1362,9 @@ namespace
                         osg::Vec3d ndc( (double)(i - static_cast<int>(d.numCols-1))/(double)(d.numCols-1), ((double)j)/(double)(d.numRows-1), 0.0);                                                                        
 
                         //TODO:  Should probably use an interpolated method here
-                        float heightValue = w_neighbor->getHeight( i, j );
+                        unsigned int neighbor_i = (i * w_neighbor_numColums) / d.numCols;
+                        unsigned int neighbor_j = (j * w_neighbor_numRows) / d.numRows;
+                        float heightValue = w_neighbor->getHeight( neighbor_i, neighbor_j );
                         ndc.z() = heightValue;                        
 
                         osg::Vec3d model;
@@ -1430,6 +1435,9 @@ namespace
             //Recalculate the east side
             if (e_neighbor.valid())
             {                
+                unsigned int e_neighbor_numColums = e_neighbor->getNumColumns();
+                unsigned int e_neighbor_numRows = e_neighbor->getNumRows();
+
                 osg::ref_ptr< osg::Vec3Array > boundaryVerts = new osg::Vec3Array();
                 boundaryVerts->reserve( 2 * d.numRows );
 
@@ -1444,7 +1452,9 @@ namespace
                         osg::Vec3d ndc( ((double)(d.numCols -1 + i))/(double)(d.numCols-1), ((double)j)/(double)(d.numRows-1), 0.0);
                         
                         //TODO:  Should probably use an interpolated method here
-                        float heightValue = e_neighbor->getHeight( i, j );
+                        unsigned int neighbor_i = (i * e_neighbor_numColums) / d.numCols;
+                        unsigned int neighbor_j = (j * e_neighbor_numRows) / d.numRows;
+                        float heightValue = e_neighbor->getHeight( neighbor_i, neighbor_j );
                         ndc.z() = heightValue;                        
 
                         osg::Vec3d model;
@@ -1512,6 +1522,9 @@ namespace
             //Recalculate the north side
             if (n_neighbor.valid())
             {
+                unsigned int n_neighbor_numColums = n_neighbor->getNumColumns();
+                unsigned int n_neighbor_numRows = n_neighbor->getNumRows();
+
                 osg::ref_ptr< osg::Vec3Array > boundaryVerts = new osg::Vec3Array();
                 boundaryVerts->reserve( 2 * d.numCols );
 
@@ -1527,7 +1540,9 @@ namespace
                         //osg::Vec3d ndc( (double)(i)/(double)(d.numCols-1), (double)(-static_cast<int>(j))/(double)(d.numRows-1), 0.0);                        
                         
                         //TODO:  Should probably use an interpolated method here
-                        float heightValue = n_neighbor->getHeight( i, j );
+                        unsigned int neighbor_i = (i * n_neighbor_numColums) / d.numCols;
+                        unsigned int neighbor_j = (j * n_neighbor_numRows) / d.numRows;
+                        float heightValue = n_neighbor->getHeight( neighbor_i, neighbor_j );
                         ndc.z() = heightValue;                        
 
                         osg::Vec3d model;
@@ -1595,6 +1610,9 @@ namespace
             //Recalculate the south side
             if (s_neighbor.valid())
             {
+                unsigned int s_neighbor_numColums = s_neighbor->getNumColumns();
+                unsigned int s_neighbor_numRows = s_neighbor->getNumRows();
+
                 osg::ref_ptr< osg::Vec3Array > boundaryVerts = new osg::Vec3Array();
                 boundaryVerts->reserve( 2 * d.numCols );
 
@@ -1609,7 +1627,9 @@ namespace
                         osg::Vec3d ndc( (double)(i)/(double)(d.numCols-1), (double)(j - static_cast<int>(d.numRows-1))/(double)(d.numRows-1), 0.0);                                                
                         
                         //TODO:  Should probably use an interpolated method here
-                        float heightValue = s_neighbor->getHeight( i, j );
+                        unsigned int neighbor_i = (i * s_neighbor_numColums) / d.numCols;
+                        unsigned int neighbor_j = (j * s_neighbor_numRows) / d.numRows;
+                        float heightValue = s_neighbor->getHeight( neighbor_i, neighbor_j );
                         ndc.z() = heightValue;                        
 
                         osg::Vec3d model;


### PR DESCRIPTION
I didn't experienced this bug before, so maybe it's related to this commit : https://github.com/gwaldron/osgearth/commit/1d4fbdc43dbfbae48b48d5e5f104dec4bd5bbcc4

The problem is on these lines :

float heightValue = w_neighbor->getHeight( i, j );
float heightValue = e_neighbor->getHeight( i, j );
float heightValue = s_neighbor->getHeight( i, j );
float heightValue = n_neighbor->getHeight( i, j );

i and j index are not always valid on the neighbor heightfiled
