### PR TITLE
Fixed variables names extraction from numeric expression in case the variable name use operand characters

### DIFF
--- a/src/osgEarthSymbology/Expression.cpp
+++ b/src/osgEarthSymbology/Expression.cpp
@@ -78,18 +78,53 @@ NumericExpression::init()
 {
     _vars.clear();
     _rpn.clear();
-    StringTokenizer tokenizer( "", "" );
-    tokenizer.addDelims( "[],()%*/+-", true );
-    tokenizer.addQuotes( "'\"", true );
-    tokenizer.keepEmpties() = false;
+
+    StringTokenizer variablesTokenizer( "", "" );
+    variablesTokenizer.addDelims( "[]", true );
+    variablesTokenizer.addQuotes( "'\"", true );
+    variablesTokenizer.keepEmpties() = false;
+
+    StringTokenizer operandTokenizer( "", "" );
+    operandTokenizer.addDelims( ",()%*/+-", true );
+    operandTokenizer.addQuotes( "'\"", true );
+    operandTokenizer.keepEmpties() = false;
+
+    StringVector variablesTokens;
+    variablesTokenizer.tokenize( _src, variablesTokens );
 
     StringVector t;
-    tokenizer.tokenize( _src, t );
-    //tokenize(_src, t, "[],()%*/+-", "'\"", false, true);
+    bool invar = false;
+    for( unsigned i=0; i<variablesTokens.size(); ++i )
+    {
+        if ( variablesTokens[i] == "[" && !invar )
+        {
+            // Start variable, add "[" token
+            invar = true;
+            t.push_back(variablesTokens[i]);
+        }
+        else if ( variablesTokens[i] == "]" && invar )
+        {
+            // End variable, add "]" token
+            invar = false;
+            t.push_back(variablesTokens[i]);
+        }
+        else if ( invar )
+        {
+            // Variable, add variable token
+            t.push_back(variablesTokens[i]);
+        }
+        else
+        {
+            // Operands, tokenize it and add tokens
+            StringVector operandTokens;
+            operandTokenizer.tokenize( variablesTokens[i], operandTokens );
+            t.insert(t.end(), operandTokens.begin(), operandTokens.end());
+        }
+    }
 
     // identify tokens:
     AtomVector infix;
-    bool invar = false;
+    invar = false;
     for( unsigned i=0; i<t.size(); ++i ) {
         if ( t[i] == "[" && !invar ) {
             invar = true;


### PR DESCRIPTION
The numeric expression is now parsed in two pass :
- first pass to extract variables names, with "[" and "]" tokens
- second pass to extract operands, with previously used token (except "[" and "]")
