### PR TITLE
Cache features in FeatureSourceIndexNode

### DIFF
--- a/src/osgEarthFeatures/BuildGeometryFilter.cpp
+++ b/src/osgEarthFeatures/BuildGeometryFilter.cpp
@@ -264,7 +264,7 @@ BuildGeometryFilter::process( FeatureList& features, const FilterContext& contex
 
             // record the geometry's primitive set(s) in the index:
             if ( context.featureIndex() )
-                context.featureIndex()->tagPrimitiveSets( osgGeom, input->getFID() );
+                context.featureIndex()->tagPrimitiveSets( osgGeom, input );
 
             // build secondary geometry, if necessary (polygon outlines)
             if ( renderType == Geometry::TYPE_POLYGON && lineSymbol )
@@ -319,7 +319,7 @@ BuildGeometryFilter::process( FeatureList& features, const FilterContext& contex
 
                 // Mark each primitive set with its feature ID.
                 if ( context.featureIndex() )
-                    context.featureIndex()->tagPrimitiveSets( outline, input->getFID() );
+                    context.featureIndex()->tagPrimitiveSets( outline, input );
             }
 
         }

--- a/src/osgEarthFeatures/ExtrudeGeometryFilter
+++ b/src/osgEarthFeatures/ExtrudeGeometryFilter
@@ -119,7 +119,7 @@ namespace osgEarth { namespace Features
             osg::Drawable*      drawable, 
             osg::StateSet*      stateSet, 
             const std::string&  name,
-            FeatureID           fid,
+            Feature*            feature,
             FeatureSourceIndex* index);
         
         bool process( 

--- a/src/osgEarthFeatures/ExtrudeGeometryFilter.cpp
+++ b/src/osgEarthFeatures/ExtrudeGeometryFilter.cpp
@@ -633,7 +633,7 @@ void
 ExtrudeGeometryFilter::addDrawable(osg::Drawable*      drawable,
                                    osg::StateSet*      stateSet,
                                    const std::string&  name,
-                                   FeatureID           fid,
+                                   Feature*            feature,
                                    FeatureSourceIndex* index )
 {
     // find the geode for the active stateset, creating a new one if necessary. NULL is a 
@@ -655,7 +655,7 @@ ExtrudeGeometryFilter::addDrawable(osg::Drawable*      drawable,
 
     if ( index )
     {
-        index->tagPrimitiveSets( drawable, fid );
+        index->tagPrimitiveSets( drawable, feature );
     }
 }
 
@@ -852,23 +852,22 @@ ExtrudeGeometryFilter::process( FeatureList& features, FilterContext& context )
                     name = input->eval( _featureNameExpr, &context );
 
                 FeatureSourceIndex* index = context.featureIndex();
-                FeatureID fid = input->getFID();
 
-                addDrawable( walls.get(), wallStateSet, name, fid, index );
+                addDrawable( walls.get(), wallStateSet, name, input, index );
 
                 if ( rooflines.valid() )
                 {
-                    addDrawable( rooflines.get(), roofStateSet, name, fid, index );
+                    addDrawable( rooflines.get(), roofStateSet, name, input, index );
                 }
 
                 if ( baselines.valid() )
                 {
-                    addDrawable( baselines.get(), 0L, name, fid, index );
+                    addDrawable( baselines.get(), 0L, name, input, index );
                 }
 
                 if ( outlines.valid() )
                 {
-                    addDrawable( outlines.get(), 0L, name, fid, index );
+                    addDrawable( outlines.get(), 0L, name, input, index );
                 }
             }   
         }

--- a/src/osgEarthFeatures/FeatureModelGraph.cpp
+++ b/src/osgEarthFeatures/FeatureModelGraph.cpp
@@ -635,7 +635,7 @@ FeatureModelGraph::buildLevel( const FeatureLevel& level, const GeoExtent& exten
     FeatureSourceIndexNode* index = 0L;
     if ( _session->getFeatureSource() && (_options.featureIndexing() == true) )
     {
-        index = new FeatureSourceIndexNode( _session->getFeatureSource() );
+        index = new FeatureSourceIndexNode( _session->getFeatureSource(), _options.storingAttributesOnFeatureIndexing() == true );
         group = index;
     }
     else

--- a/src/osgEarthFeatures/FeatureModelSource
+++ b/src/osgEarthFeatures/FeatureModelSource
@@ -72,6 +72,10 @@ namespace osgEarth { namespace Features
         optional<bool>& featureIndexing() { return _featureIndexing; }
         const optional<bool>& featureIndexing() const { return _featureIndexing; }
 
+        /** Storing attributes of features while indexing (default = no) */
+        optional<bool>& storingAttributesOnFeatureIndexing() { return _storingAttributesOnFeatureIndexing; }
+        const optional<bool>& storingAttributesOnFeatureIndexing() const { return _storingAttributesOnFeatureIndexing; }
+
         /** Whether to activate backface culling (default = yes) */
         optional<bool>& backfaceCulling() { return _backfaceCulling; }
         const optional<bool>& backfaceCulling() const { return _backfaceCulling; }
@@ -123,6 +127,7 @@ namespace osgEarth { namespace Features
         optional<bool>                  _mergeGeometry;
         optional<bool>                  _clusterCulling;
         optional<bool>                  _featureIndexing;
+		optional<bool>                  _storingAttributesOnFeatureIndexing;
         optional<bool>                  _backfaceCulling;
         optional<bool>                  _alphaBlending;
         optional<CachePolicy>           _cachePolicy;

--- a/src/osgEarthFeatures/FeatureModelSource.cpp
+++ b/src/osgEarthFeatures/FeatureModelSource.cpp
@@ -61,6 +61,7 @@ FeatureModelSourceOptions::fromConfig( const Config& conf )
     conf.getIfSet( "merge_geometry",   _mergeGeometry );
     conf.getIfSet( "cluster_culling",  _clusterCulling );
     conf.getIfSet( "feature_indexing", _featureIndexing );
+    conf.getIfSet( "storing_attributes_on_feature_indexing", _storingAttributesOnFeatureIndexing );	
     conf.getIfSet( "backface_culling", _backfaceCulling );
     conf.getIfSet( "alpha_blending",   _alphaBlending );
     conf.getIfSet( "fade_in_duration", _fadeInDuration );
@@ -93,6 +94,7 @@ FeatureModelSourceOptions::getConfig() const
     conf.updateIfSet( "merge_geometry",   _mergeGeometry );
     conf.updateIfSet( "cluster_culling",  _clusterCulling );
     conf.updateIfSet( "feature_indexing", _featureIndexing );
+    conf.updateIfSet( "storing_attributes_on_feature_indexing", _storingAttributesOnFeatureIndexing );	
     conf.updateIfSet( "backface_culling", _backfaceCulling );
     conf.updateIfSet( "alpha_blending",   _alphaBlending );
     conf.updateIfSet( "fade_in_duration", _fadeInDuration );

--- a/src/osgEarthFeatures/FeatureSourceIndexNode
+++ b/src/osgEarthFeatures/FeatureSourceIndexNode
@@ -34,8 +34,8 @@ namespace osgEarth { namespace Features
     class FeatureSourceIndex
     {
     public: // tagging functions
-        virtual void tagPrimitiveSets( osg::Drawable* drawable, FeatureID fid ) const =0;
-        virtual void tagNode( osg::Node* node, FeatureID fid ) const =0;
+        virtual void tagPrimitiveSets( osg::Drawable* drawable, Feature* feature ) const =0;
+        virtual void tagNode( osg::Node* node, Feature* feature ) const =0;
 
         virtual ~FeatureSourceIndex() { }
     };
@@ -50,7 +50,7 @@ namespace osgEarth { namespace Features
         /**
          * Constructs a new index node.
          */
-		FeatureSourceIndexNode(FeatureSource* featureSource);
+		FeatureSourceIndexNode(FeatureSource* featureSource, bool storingAttributesOnFeatureIndexing);
 
         virtual ~FeatureSourceIndexNode() { }
 
@@ -60,12 +60,12 @@ namespace osgEarth { namespace Features
         /**
          * Tags all the primitive sets in a Drawable with the specified FeatureID.
          */
-        void tagPrimitiveSets( osg::Drawable* drawable, FeatureID fid ) const;
+        void tagPrimitiveSets( osg::Drawable* drawable, Feature* feature ) const;
 
         /**
          * Tags a node with the specified FeatureID.
          */
-        void tagNode( osg::Node* node, FeatureID fid ) const;
+        void tagNode( osg::Node* node, Feature* feature ) const;
 
 
 	public:
@@ -100,7 +100,7 @@ namespace osgEarth { namespace Features
          */
 		bool getFID(osg::Drawable* drawable, int primitiveIndex, FeatureID& output) const;
 
-        /**
+		/**
          * Given a FeatureID, returns the collection of drawable/primitiveset combinations
          * corresponding to that feature.
          *
@@ -109,8 +109,17 @@ namespace osgEarth { namespace Features
          */
         FeatureDrawSet& getDrawSet( const FeatureID& fid );
 
+		/**
+         * Given a FeatureID, returns the cached feature.
+         *
+         * @param fid     Feature ID to look up
+		 * @param output  cached feature 
+         * @return true if successful 
+         */
+		bool getFeature(const FeatureID& fid, const Feature*& output) const;
+
 	private:
-        osg::ref_ptr<FeatureSource> _featureSource;
+        osg::ref_ptr<FeatureSource> _featureSource;		
 
         typedef std::map<FeatureID, FeatureDrawSet> FeatureIDDrawSetMap;
         FeatureIDDrawSetMap _drawSets;
@@ -122,6 +131,10 @@ namespace osgEarth { namespace Features
             FeatureIDDrawSetMap& _index;
             unsigned _psets;
         };
+		
+		bool _storingAttributesOnFeatureIndexing;
+		typedef std::map< FeatureID, osg::ref_ptr<const Feature> > FeatureMap;
+		mutable FeatureMap _features; // cache
 
     public:
         virtual const char* className() const { return "FeatureSourceIndexNode"; }

--- a/src/osgEarthFeatures/SubstituteModelFilter.cpp
+++ b/src/osgEarthFeatures/SubstituteModelFilter.cpp
@@ -249,7 +249,7 @@ SubstituteModelFilter::process(const FeatureList&           features,
 
                     if ( context.featureIndex() && !_useDrawInstanced )
                     {
-                        context.featureIndex()->tagNode( xform, input->getFID() );
+                        context.featureIndex()->tagNode( xform, input );
                     }
 
                     // name the feature if necessary
@@ -406,7 +406,7 @@ struct ClusterVisitor : public osg::NodeVisitor
                             geode.addDrawable( newDrawable.get() );
 
                             if ( _cx.featureIndex() )
-                                _cx.featureIndex()->tagPrimitiveSets( newDrawable.get(), feature->getFID() );
+                                _cx.featureIndex()->tagPrimitiveSets( newDrawable.get(), feature );
                         }
                     }
 


### PR DESCRIPTION
To enable it, you need to add the following on the earth file:

``` xml
<storing_attributes_on_feature_indexing>true</storing_attributes_on_feature_indexing> 
```

The name of it is wrong and must be changed. Currently i store features not attributetables. 

Please choose a name that you want to use :)
