### PR TITLE
Cancel current keyboard task only if the task corresponds to the directi...

### DIFF
--- a/src/osgEarthUtil/EarthManipulator
+++ b/src/osgEarthUtil/EarthManipulator
@@ -702,6 +702,9 @@ namespace osgEarth { namespace Util
         virtual void handleContinuousAction( const Action& action, osg::View* view );
         virtual void handleMovementAction( const ActionType& type, double dx, double dy, osg::View* view );
 
+		// returns the defined dx and dy values for a keyboard action dir
+		void getKeyboardActionDxDy( const Action& action, double& dx, double& dy );
+
         // checks to see whether the mouse is "moving".
         bool isMouseMoving();
 

--- a/src/osgEarthUtil/EarthManipulator.cpp
+++ b/src/osgEarthUtil/EarthManipulator.cpp
@@ -1509,7 +1509,17 @@ EarthManipulator::handle(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapt
             
         case osgGA::GUIEventAdapter::KEYUP:
             resetMouse( aa );
-            _task->_type = TASK_NONE;
+			{
+				Action keydown_action = _settings->getAction( osgGA::GUIEventAdapter::KEYDOWN, ea.getKey(), ea.getModKeyMask() );
+				double dx = 0, dy = 0;
+				getKeyboardActionDxDy(keydown_action, dx, dy);
+
+				if( _task->_dx == dx && _task->_dy == dy )
+				{
+					// cancel current keyboard task only if the task corresponds to the direction in handleKeyboardAction
+					_task->_type = TASK_NONE;
+				}
+			}
             handled = true;
             break;
 
@@ -2279,10 +2289,11 @@ EarthManipulator::handleMouseClickAction( const Action& action )
     return false;
 }
 
-bool
-EarthManipulator::handleKeyboardAction( const Action& action, double duration )
+void
+EarthManipulator::getKeyboardActionDxDy( const Action& action, double& dx, double& dy )
 {
-    double dx = 0, dy = 0;
+    dx = 0;
+	dy = 0;
 
     switch( action._dir )
     {
@@ -2295,6 +2306,13 @@ EarthManipulator::handleKeyboardAction( const Action& action, double duration )
 
     dx *= _settings->getKeyboardSensitivity();
     dy *= _settings->getKeyboardSensitivity();
+}
+
+bool
+EarthManipulator::handleKeyboardAction( const Action& action, double duration )
+{
+    double dx = 0, dy = 0;
+    getKeyboardActionDxDy(action, dx, dy);
 
     applyOptionsToDeltas( action, dx, dy );
 


### PR DESCRIPTION
When using keyboard arrows to make a pan on the map, the switch from a dx direction to a dy direction could miss if we release the old arrow after the new one.

Example:
Press up arrow -> KEYDOWN event --> set PAN with up direction
Press left arrow -> KEYDOWN event --> change PAN to left direction
Release up arrow -> KEYUP event --> set PAN off (task none)
The move is stopped whereas the left key is still pressed.
