### PR TITLE
Update src/osgEarthDrivers/wms/ReaderWriterWMS.cpp

### DIFF
--- a/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
+++ b/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
@@ -127,7 +127,8 @@ public:
 
         // first the mandatory keys:
         buf
-            << std::fixed << _options.url()->full() << sep            
+            << std::fixed << _options.url()->full() << sep
+	    << "SERVICE=WMS"
             << "&VERSION=" << _options.wmsVersion().value()
             << "&REQUEST=GetMap"
             << "&LAYERS=" << _options.layers().value()


### PR DESCRIPTION
Service descriptor is mandatory when MapServer is the actual WMS server
