### PR TITLE
Pull request for LabelControl changes in osgEarthUtil module

### DIFF
--- a/src/osgEarthUtil/Controls
+++ b/src/osgEarthUtil/Controls
@@ -354,6 +354,15 @@ namespace osgEarth { namespace Util { namespace Controls
         void setHaloColor( const osg::Vec4f& value );
         const optional<osg::Vec4f>& haloColor() const { return _haloColor; }
 
+        void setTextBackdropType(osgText::Text::BackdropType value);
+        const osgText::Text::BackdropType getTextBackdropType() const { return _backdropType; }
+
+        void setTextBackdropImplementation(osgText::Text::BackdropImplementation value);
+        const osgText::Text::BackdropImplementation getTextBackdropImplementation() const { return _backdropImpl; }
+
+        void setTextBackdropOffset(float offsetValue);
+        float getTextBackdropOffset() const { return _backdropOffset; }
+
     public: // Control
         virtual void calcSize( const ControlContext& context, osg::Vec2f& out_size );
         virtual void draw    ( const ControlContext& context, DrawableList& out_drawables );
@@ -366,6 +375,9 @@ namespace osgEarth { namespace Util { namespace Controls
         osg::Vec3 _bmin, _bmax;
         optional<osg::Vec4f> _haloColor;
 		osgText::String::Encoding _encoding;
+        osgText::Text::BackdropType _backdropType;
+        osgText::Text::BackdropImplementation _backdropImpl;
+        float _backdropOffset;
     };
 
     /**

--- a/src/osgEarthUtil/Controls.cpp
+++ b/src/osgEarthUtil/Controls.cpp
@@ -631,7 +631,10 @@ LabelControl::LabelControl(const std::string& text,
                            const osg::Vec4f&  foreColor):
 _text    ( text ),
 _fontSize( fontSize ),
-_encoding( osgText::String::ENCODING_UNDEFINED )
+_encoding( osgText::String::ENCODING_UNDEFINED ),
+_backdropType( osgText::Text::OUTLINE ),
+_backdropImpl( osgText::Text::STENCIL_BUFFER ),
+_backdropOffset( 0.03f )
 {    
     setFont( Registry::instance()->getDefaultFont() );    
     setForeColor( foreColor );
@@ -643,7 +646,10 @@ LabelControl::LabelControl(const std::string& text,
                            float              fontSize ):
 _text    ( text ),
 _fontSize( fontSize ),
-_encoding( osgText::String::ENCODING_UNDEFINED )
+_encoding( osgText::String::ENCODING_UNDEFINED ),
+_backdropType( osgText::Text::OUTLINE ),
+_backdropImpl( osgText::Text::STENCIL_BUFFER ),
+_backdropOffset( 0.03f )
 {    	
     setFont( Registry::instance()->getDefaultFont() );   
     setForeColor( foreColor );
@@ -654,7 +660,10 @@ LabelControl::LabelControl(Control*           valueControl,
                            float              fontSize,
                            const osg::Vec4f&  foreColor):
 _fontSize( fontSize ),
-_encoding( osgText::String::ENCODING_UNDEFINED )
+_encoding( osgText::String::ENCODING_UNDEFINED ),
+_backdropType( osgText::Text::OUTLINE ),
+_backdropImpl( osgText::Text::STENCIL_BUFFER ),
+_backdropOffset( 0.03f )
 {
     setFont( Registry::instance()->getDefaultFont() );    
     setForeColor( foreColor );
@@ -668,7 +677,10 @@ LabelControl::LabelControl(Control*           valueControl,
                            const osg::Vec4f&  foreColor,
                            float              fontSize ):
 _fontSize( fontSize ),
-_encoding( osgText::String::ENCODING_UNDEFINED )
+_encoding( osgText::String::ENCODING_UNDEFINED ),
+_backdropType( osgText::Text::OUTLINE ),
+_backdropImpl( osgText::Text::STENCIL_BUFFER ),
+_backdropOffset( 0.03f )
 {    	
     setFont( Registry::instance()->getDefaultFont() );   
     setForeColor( foreColor );
@@ -725,6 +737,33 @@ LabelControl::setHaloColor( const osg::Vec4f& value )
 }
 
 void
+LabelControl::setTextBackdropImplementation(osgText::Text::BackdropImplementation value)
+{
+    if( _backdropImpl != value ) {
+        _backdropImpl = value;
+        dirty();
+    }
+}
+
+void
+LabelControl::setTextBackdropType(osgText::Text::BackdropType value)
+{
+    if( _backdropType != value ) {
+        _backdropType = value;
+        dirty();
+    }
+}
+
+void 
+LabelControl::setTextBackdropOffset(float offsetValue) 
+{
+    if ( offsetValue != _backdropOffset ) {
+        _backdropOffset = offsetValue;
+        dirty();
+    }
+}
+
+void
 LabelControl::calcSize(const ControlContext& cx, osg::Vec2f& out_size)
 {
     if ( visible() == true )
@@ -753,8 +792,9 @@ LabelControl::calcSize(const ControlContext& cx, osg::Vec2f& out_size)
 
         if ( haloColor().isSet() )
         {
-            t->setBackdropType( osgText::Text::OUTLINE );
-            t->setBackdropOffset( 0.03 );
+            t->setBackdropType( _backdropType );
+            t->setBackdropImplementation( _backdropImpl );
+            t->setBackdropOffset( _backdropOffset );
             t->setBackdropColor( haloColor().value() );
         }
 


### PR DESCRIPTION
Glenn/Jason,

I've added a couple of functions to osgEarth::Util::Controls::LabelControl to allow finer-grained control of backdrops (text outline) from external applications.  Requesting these modifications be included in the main osgEarth repo.

Thanks,
Brandon Hamm
