### PR TITLE
Modified elevation query to use the same interpolation method as the map.

### DIFF
--- a/src/osgEarth/ElevationQuery.cpp
+++ b/src/osgEarth/ElevationQuery.cpp
@@ -313,7 +313,7 @@ ElevationQuery::getElevationImpl(const GeoPoint& point,
         tile.get(), 
         mapPoint.x(), mapPoint.y(), 
         extent.xMin(), extent.yMin(), 
-        xInterval, yInterval );
+        xInterval, yInterval, _mapf.getMapInfo().getElevationInterpolation() );
 
     osg::Timer_t end = osg::Timer::instance()->tick();
     _queries++;


### PR DESCRIPTION
Without this parameter, in some situations results are visually incorrect : for example when you set the map elevation interpolation to "Nearest", the features are still clamped with an "Linear" interpolation, which leads to inconsistencies at extruded features bottom.
