### PR TITLE
Remove recalculateCenter() calls from EarthManipulator::setViewpoint()

### DIFF
--- a/src/osgEarthUtil/EarthManipulator.cpp
+++ b/src/osgEarthUtil/EarthManipulator.cpp
@@ -901,9 +901,6 @@ EarthManipulator::setViewpoint( const Viewpoint& vp, double duration_s )
         
         _thrown = false;
         _task->_type = TASK_NONE;
-
-        // recalculate the center point.
-        recalculateCenter();
     }
     else
     {
@@ -963,8 +960,6 @@ EarthManipulator::setViewpoint( const Viewpoint& vp, double duration_s )
         osg::Matrix new_rot = osg::Matrixd( azim_q * pitch_q );
 
         _rotation = osg::Matrixd::inverse(new_rot).getRotate();
-
-        recalculateCenter();
     }
 }
 


### PR DESCRIPTION
As noted in this discussion:

http://forum.osgearth.org/recalculateCenter-in-EarthManipulator-setViewpoint-td7580074.html

the calls to EarthManipulator::recalculateCenter() are causing problems for several people, myself included.  Everyone who has had this problem ends up commenting lines out, so here's an official pull request to officially remove them.

Thanks,

--Chris W.
