### PR TITLE
fixed MapNode.cpp to ensure that a handle to osgEarth::TerrainEngineNode...

### DIFF
--- a/src/osgEarth/MapNode
+++ b/src/osgEarth/MapNode
@@ -24,12 +24,12 @@
 #include <osgEarth/Map>
 #include <osgEarth/MapNodeOptions>
 #include <osgEarth/SpatialReference>
+#include <osgEarth/TerrainEngineNode>
 
 namespace osgEarth
 {
     class OverlayDecorator;
     class Terrain;
-    class TerrainEngineNode;
 
     /**
      * OSG Node that forms the root of an osgEarth map. This node is a "view" component
@@ -204,7 +204,7 @@ namespace osgEarth
         ModelLayerNodeMap        _modelLayerNodes;
         osg::Group*              _maskLayerNode;
         unsigned                 _lastNumBlacklistedFilenames;
-        TerrainEngineNode*       _terrainEngine;
+        osg::ref_ptr<TerrainEngineNode> _terrainEngine;
         bool                     _terrainEngineInitialized;
         osg::Group*              _terrainEngineContainer;
 


### PR DESCRIPTION
... is held, particularly during initialization of the map node.  Exception can occur without this change when loading the osgearth scene graph from a thread, as update/render occurs in the main thread.

The culprit is in osgViewer/Viewer.cpp here...
    // update the Registry object cache.
    osgDB::Registry::instance()->updateTimeStampOfObjectsInCacheWithExternalReferences(_getFrameStamp());
    osgDB::Registry::instance()->removeExpiredObjectsInCache(_getFrameStamp());

... removeExpiredObjectsInCache() deletes the TerrainEngineNode and causes the exception.
