### PR TITLE
Icon Symbol: Force reading image to support more osg image libraries

### DIFF
--- a/src/osgEarthSymbology/IconResource.cpp
+++ b/src/osgEarthSymbology/IconResource.cpp
@@ -114,7 +114,7 @@ IconResource::createNodeFromURI( const URI& uri, const osgDB::Options* dbOptions
 {
     osg::Node* node = 0L;
 
-    ReadResult r = uri.readObject( dbOptions );
+    ReadResult r = uri.readImage( dbOptions );
     if ( r.succeeded() )
     {
         if ( r.getImage() )


### PR DESCRIPTION
http://forum.osgearth.org/MACOSX-Symbology-IconResource-createNodeFromURI-behavior-with-some-Image-plugins-td7580826.html
