### PR TITLE
Added correct naming for osgEarthUtil on all platforms and build type

### DIFF
--- a/src/osgEarthDrivers/earth/ReaderWriterOsgEarth.cpp
+++ b/src/osgEarthDrivers/earth/ReaderWriterOsgEarth.cpp
@@ -37,14 +37,25 @@ using namespace osgEarth;
 #define Q2(x) #x
 #define Q(x)  Q2(x)
 
-#if defined(_DEBUG) && defined(OSGEARTH_DEBUG_POSTFIX)
-#    define LIBNAME_UTIL "osgEarthUtil" ## Q(OSGEARTH_DEBUG_POSTFIX)
+#if (defined(_DEBUG) || defined(QT_DEBUG)) && defined(OSGEARTH_DEBUG_POSTFIX)
+#   define LIBNAME_UTIL_POSTFIX Q(OSGEARTH_DEBUG_POSTFIX)
 #elif defined(OSGEARTH_RELEASE_POSTFIX)
-#    define LIBNAME_UTIL "osgEarthUtil" ## Q(OSGEARTH_RELEASE_POSTFIX)
+#   define LIBNAME_UTIL_POSTFIX Q(OSGEARTH_RELEASE_POSTFIX)
 #else
-#    define LIBNAME_UTIL "osgEarthUtil"
+#   define LIBNAME_UTIL_POSTFIX ""
 #endif
 
+#if defined(WIN32)
+#   define LIBNAME_UTIL "osgEarthUtil"
+#   define LIBNAME_UTIL_EXTENSION ".dll"
+#else
+#   define LIBNAME_UTIL "libosgEarthUtil"
+#   if defined(__APPLE__)
+#       define LIBNAME_UTIL_EXTENSION ".dylib"
+#   else
+#       define LIBNAME_UTIL_EXTENSION ".so"
+#   endif
+#endif
 
 
 class ReaderWriterEarth : public osgDB::ReaderWriter
@@ -55,8 +66,8 @@ class ReaderWriterEarth : public osgDB::ReaderWriter
             // force the loading of other osgEarth libraries that might be needed to 
             // deserialize an earth file. 
             // osgEarthUtil: contains ColorFilter implementations
-            OE_DEBUG << LC << "Forced load: " << LIBNAME_UTIL << std::endl;
-            osgDB::Registry::instance()->loadLibrary( LIBNAME_UTIL );
+            OE_DEBUG << LC << "Forced load: " << LIBNAME_UTIL LIBNAME_UTIL_POSTFIX LIBNAME_UTIL_EXTENSION << std::endl;
+            osgDB::Registry::instance()->loadLibrary( LIBNAME_UTIL LIBNAME_UTIL_POSTFIX LIBNAME_UTIL_EXTENSION );
         }
 
         virtual const char* className()


### PR DESCRIPTION
Under MacOS I couldn't load .earth files since, the osgDB Reader needed to dynamically load osgEarthUtil but failed to do so since the name is different than on windows targets.

On a side note, I was also wondering why the need to dynamically load it opposed to linking with it directly ?
