### PR TITLE
EarthManipulator::_findNodeTraversalMask and related setter/getter methods

### DIFF
--- a/src/osgEarthUtil/EarthManipulator
+++ b/src/osgEarthUtil/EarthManipulator
@@ -636,7 +636,16 @@ namespace osgEarth { namespace Util
          */
         void  setRotation( const osg::Quat& rotation) { _rotation = rotation; }
 
+        /**
+         * Gets the traversal node mask used to find root MapNode and CoordinateSystemNodes. Default is 0x1.
+         */
+        osg::Node::NodeMask getFindNodeTraversalMask( ) { return _findNodeTraversalMask; }
 
+        /**
+         * Sets the traversal node mask used to find root MapNode and CoordinateSystemNode. Default is 0x1. 
+         * Use this method if you change MapNode or CoordinateSystemNode mask and want manipulator to work with them correctly.  
+         */
+        void  setFindNodeTraversalMask( const osg::Node::NodeMask & nodeMask ) { _findNodeTraversalMask = nodeMask; }
 
     public: // osgGA::MatrixManipulator
 
@@ -922,6 +931,8 @@ namespace osgEarth { namespace Util
 
         osg::ref_ptr< TerrainCallback > _terrainCallback;
 
+        // Traversal mask used in established and dtor methods to find MapNode and CoordinateSystemNode
+        osg::Node::NodeMask  _findNodeTraversalMask;
     };
 
 } } // namespace osgEarth::Util

--- a/src/osgEarthUtil/EarthManipulator.cpp
+++ b/src/osgEarthUtil/EarthManipulator.cpp
@@ -431,8 +431,9 @@ EarthManipulator::Settings::setCameraFrustumOffsets( const osg::Vec2s& value )
 
 EarthManipulator::EarthManipulator() :
 osgGA::CameraManipulator(),
-_last_action      ( ACTION_NULL ),
-_frame_count      ( 0 )
+_last_action           ( ACTION_NULL ),
+_frame_count           ( 0 ),
+_findNodeTraversalMask ( 0x01 )
 {
     reinitialize();
     configureDefaultSettings();
@@ -442,7 +443,8 @@ EarthManipulator::EarthManipulator( const EarthManipulator& rhs ) :
 osgGA::CameraManipulator( rhs ),
 _last_action            ( ACTION_NULL ),
 _frame_count            ( 0 ),
-_settings               ( new Settings(*rhs.getSettings()) )
+_settings               ( new Settings(*rhs.getSettings()) ),
+_findNodeTraversalMask  ( rhs._findNodeTraversalMask )
 {
     reinitialize();
 }
@@ -454,7 +456,7 @@ EarthManipulator::~EarthManipulator()
     if (safeNode && _terrainCallback)
     {
         // find a map node.
-        MapNode* mapNode = MapNode::findMapNode( safeNode.get(), 0x01 );
+        MapNode* mapNode = MapNode::findMapNode( safeNode.get(), _findNodeTraversalMask );
         if ( mapNode )
         {             
             mapNode->getTerrain()->removeTerrainCallback( _terrainCallback );
@@ -589,7 +591,7 @@ EarthManipulator::established()
             return false;
 
         // find a map node.
-        MapNode* mapNode = MapNode::findMapNode( safeNode.get(), 0x01 );
+        MapNode* mapNode = MapNode::findMapNode( safeNode.get(), _findNodeTraversalMask );
         if ( mapNode )
         {
             _terrainCallback = new ManipTerrainCallback( this );
@@ -597,7 +599,7 @@ EarthManipulator::established()
         }
 
         // find a CSN node - if there is one, we want to attach the manip to that
-        _csn = findRelativeNodeOfType<osg::CoordinateSystemNode>( safeNode.get(), 0x01 );
+        _csn = findRelativeNodeOfType<osg::CoordinateSystemNode>( safeNode.get(), _findNodeTraversalMask );
 
         if ( _csn.valid() )
         {


### PR DESCRIPTION
Added _findNodeTraversalMask and proper setter / getter methods to change/read mask used by manipulator in internal find node traversals looking for root MapNode and CoordinateSystemNode.
Manipulator functionality is crippled when these nodes cannot be found. So use this variable and these methods when you change MapNode or CoordinateSystemNode masks. 
Default mask is set to 0x1.
