### PR TITLE
Fix: PlaceNode setText() not applying text encoding style

### DIFF
--- a/src/osgEarthAnnotation/AnnotationUtils
+++ b/src/osgEarthAnnotation/AnnotationUtils
@@ -25,6 +25,7 @@
 #include <osg/AutoTransform>
 #include <osg/Drawable>
 #include <osg/Geometry>
+#include <osgText/TextBase>
 
 namespace osgEarth { namespace Annotation
 {
@@ -43,6 +44,9 @@ namespace osgEarth { namespace Annotation
         static const std::string& UNIFORM_FADE();
 
         static const std::string& PROGRAM_NAME();
+
+		static osgText::String::Encoding convertTextSymbolEncoding (
+			const osgEarth::Symbology::TextSymbol::Encoding encoding );
 
         /**
          * Creates a drawable representing a symbolized text label in

--- a/src/osgEarthAnnotation/AnnotationUtils.cpp
+++ b/src/osgEarthAnnotation/AnnotationUtils.cpp
@@ -65,6 +65,22 @@ AnnotationUtils::UNIFORM_FADE()
   return s;
 }
 
+osgText::String::Encoding
+AnnotationUtils::convertTextSymbolEncoding (const TextSymbol::Encoding encoding) {
+	osgText::String::Encoding text_encoding = osgText::String::ENCODING_UNDEFINED;
+
+	switch(encoding)
+	{
+	case TextSymbol::ENCODING_ASCII: text_encoding = osgText::String::ENCODING_ASCII; break;
+	case TextSymbol::ENCODING_UTF8: text_encoding = osgText::String::ENCODING_UTF8; break;
+	case TextSymbol::ENCODING_UTF16: text_encoding = osgText::String::ENCODING_UTF16; break;
+	case TextSymbol::ENCODING_UTF32: text_encoding = osgText::String::ENCODING_UTF32; break;
+	default: text_encoding = osgText::String::ENCODING_UNDEFINED; break;
+	}
+
+	return text_encoding;
+}
+
 osg::Drawable* 
 AnnotationUtils::createTextDrawable(const std::string& text,
                                     const TextSymbol*  symbol,
@@ -72,20 +88,15 @@ AnnotationUtils::createTextDrawable(const std::string& text,
                                     
 {
     osgText::Text* t = new osgText::Text();
-    osgText::String::Encoding text_encoding = osgText::String::ENCODING_UNDEFINED;
+    
+	osgText::String::Encoding text_encoding = osgText::String::ENCODING_UNDEFINED;
     if ( symbol && symbol->encoding().isSet() )
     {
-        switch(symbol->encoding().value())
-        {
-        case TextSymbol::ENCODING_ASCII: text_encoding = osgText::String::ENCODING_ASCII; break;
-        case TextSymbol::ENCODING_UTF8: text_encoding = osgText::String::ENCODING_UTF8; break;
-        case TextSymbol::ENCODING_UTF16: text_encoding = osgText::String::ENCODING_UTF16; break;
-        case TextSymbol::ENCODING_UTF32: text_encoding = osgText::String::ENCODING_UTF32; break;
-        default: text_encoding = osgText::String::ENCODING_UNDEFINED; break;
-        }
+		text_encoding = convertTextSymbolEncoding(symbol->encoding().value());
     }
+    
+	t->setText( text, text_encoding );
 
-    t->setText( text, text_encoding );
     if ( symbol && symbol->layout().isSet() )
     {
         if(symbol->layout().value() == TextSymbol::LAYOUT_RIGHT_TO_LEFT)

--- a/src/osgEarthAnnotation/PlaceNode.cpp
+++ b/src/osgEarthAnnotation/PlaceNode.cpp
@@ -230,7 +230,14 @@ PlaceNode::setText( const std::string& text )
         osgText::Text* d = dynamic_cast<osgText::Text*>( i->get() );
         if ( d )
         {
-            d->setText( text );
+			TextSymbol* symbol =  _style.getOrCreate<TextSymbol>();
+			osgText::String::Encoding text_encoding = osgText::String::ENCODING_UNDEFINED;
+			if ( symbol && symbol->encoding().isSet() )
+			{
+				text_encoding = AnnotationUtils::convertTextSymbolEncoding(symbol->encoding().value());
+			}
+
+            d->setText( text, text_encoding );
             break;
         }
     }


### PR DESCRIPTION
Fixed a problem in PlaceNode discussed here http://forum.osgearth.org/Problem-with-PlaceNode-or-osgText-tp7581563.html
