### PR TITLE
Modified WFS MIME checks to allow for a subtype or optional parameter

### DIFF
--- a/src/osgEarthDrivers/feature_wfs/FeatureSourceWFS.cpp
+++ b/src/osgEarthDrivers/feature_wfs/FeatureSourceWFS.cpp
@@ -275,17 +275,11 @@ public:
     {
         //OGR is particular sometimes about the extension of files when it's reading them so it's good to have
         //the temp file have an appropriate extension
-        if (startsWith(mime, "text/xml"))
+        if (isGML(mime))
         {
             return ".xml";
         }        
-        else if (startsWith(mime, "application/json") ||
- 				 startsWith(mime, "json") ||            
- 				 startsWith(mime, "application/x-javascript") ||
-				 startsWith(mime, "text/javascript") ||
-				 startsWith(mime, "text/x-javascript") ||
-				 startsWith(mime, "text/x-json")
-                )
+		else if (isJSON(mime))
         {
             return ".json";
         }        


### PR DESCRIPTION
I modified the WFS MIME checks for JSON to use startsWith (like the GML check) because I discovered the Content-Type for text types may include an optional parameter charset on some web servers.

I also modified the checks in the getExtensionForMimeType method to use the isGML and isJSON methods to ensure the same results when checking the MIME types.
