### PR TITLE
BUILD: fix FindMiniZip.cmake module to use pkg-config

### DIFF
--- a/CMakeModules/FindMiniZip.cmake
+++ b/CMakeModules/FindMiniZip.cmake
@@ -14,6 +14,7 @@ IF(UNIX)
 			# pkgconfig does not define the singular names
 			SET(MINIZIP_LIBRARY ${MINIZIP_LIBRARIES} CACHE STRING "Minizip libraries to link against")
 			SET(MINIZIP_INCLUDE_DIR ${MINIZIP_INCLUDE_DIRS} CACHE STRING "Minizip include dirs to look for headers")
+			link_directories(${MINIZIP_LIBRARY_DIRS})
 			ADD_DEFINITIONS(-DOSGEARTH_HAVE_MINIZIP)
 		ENDIF(MINIZIP_FOUND)
 	ENDIF(PKG_CONFIG_FOUND)


### PR DESCRIPTION
On some distros the present logic will fail to detect
/usr/include/minizip/zip.h, use proper pkg-config call
to fix this. Regular cmake modules are broken and should
always be fixed to have some pkg-config logic, since it's the
only cross-distro standard to get correct library and include dirs.

If there is no pkg-config the module will fall back to the old find macros.
