### PR TITLE
Call osg::Program::releaseGLObjects from within VirtualProgram::releaseG...

### DIFF
--- a/src/osgEarth/VirtualProgram
+++ b/src/osgEarth/VirtualProgram
@@ -177,6 +177,11 @@ namespace osgEarth
         osg::Program* getTemplate() { return _template.get(); }
         const osg::Program* getTemplate() const { return _template.get(); }
 
+        /** If State is non-zero, this function releases any associated OpenGL objects for
+           * the specified graphics context. Otherwise, releases OpenGL objects
+           * for all graphics contexts. */
+        virtual void releaseGLObjects(osg::State* pState) const;
+
     public:
         typedef std::vector< osg::ref_ptr<osg::Shader> > ShaderVector;
 

--- a/src/osgEarth/VirtualProgram.cpp
+++ b/src/osgEarth/VirtualProgram.cpp
@@ -220,6 +220,18 @@ VirtualProgram::applyAttributeAliases(osg::Shader*             shader,
     shader->setShaderSource( src );
 }
 
+void
+VirtualProgram::releaseGLObjects(osg::State* pState) const
+{
+  Threading::ScopedReadLock shared( _programCacheMutex );
+
+  for (ProgramMap::const_iterator i = _programCache.begin();
+    i != _programCache.end(); ++i)
+  {
+    i->second->releaseGLObjects(pState);
+  }
+}
+
 osg::Shader*
 VirtualProgram::getShader( const std::string& shaderID ) const
 {


### PR DESCRIPTION
I believe VirtualProgram is not properly cleaning up during a shutdown.  This is preventing me from destroying my viewer (and graph) and starting another.  This change causes the VP to release the GL objects contained in its osg::Programs when told.
