### PR TITLE
Fix 'becuase' typo.

### DIFF
--- a/src/osgEarth/ImageLayer.cpp
+++ b/src/osgEarth/ImageLayer.cpp
@@ -196,7 +196,7 @@ ImageLayerTileProcessor::process( osg::ref_ptr<osg::Image>& image ) const
     }
 
     // If this is a compressed image, uncompress it IF the image is not already in the
-    // target profile...becuase if it's not in the target profile, we will have to do
+    // target profile...because if it's not in the target profile, we will have to do
     // some mosaicing...and we can't mosaic a compressed image.
     if (!_layerInTargetProfile &&
         ImageUtils::isCompressed(image.get()) &&

--- a/src/osgEarth/TextureCompositor.cpp
+++ b/src/osgEarth/TextureCompositor.cpp
@@ -383,7 +383,7 @@ TextureCompositor::applyMapModelChange( const MapModelChange& change )
     if ( disableLODBlending && layer->getImageLayerOptions().lodBlending() == true )
     {
         OE_WARN << LC << "LOD blending disabled for layer \"" << layer->getName()
-            << "\" becuase it uses Mercator fast-path rendering" << std::endl;
+            << "\" because it uses Mercator fast-path rendering" << std::endl;
     }
 
     _layout.applyMapModelChange(

--- a/src/osgEarthDrivers/engine_osgterrain/OSGTerrainEngineNode.cpp
+++ b/src/osgEarthDrivers/engine_osgterrain/OSGTerrainEngineNode.cpp
@@ -833,7 +833,7 @@ OSGTerrainEngineNode::traverse( osg::NodeVisitor& nv )
         if ( nv.getVisitorType() == osg::NodeVisitor::CULL_VISITOR )
         {
             // update the cull-thread map frame if necessary. (We don't need to sync the
-            // update_mapf becuase that happens in response to a map callback.)
+            // update_mapf because that happens in response to a map callback.)
 
             // TODO: address the fact that this can happen from multiple threads.
             // Really we need a _cull_mapf PER view. -gw

--- a/src/osgEarthUtil/Controls.cpp
+++ b/src/osgEarthUtil/Controls.cpp
@@ -808,7 +808,7 @@ LabelControl::calcSize(const ControlContext& cx, osg::Vec2f& out_size)
         LabelText* t = new LabelText();
 
         t->setText( _text, _encoding );
-        // yes, object coords. screen coords won't work becuase the bounding box will be wrong.
+        // yes, object coords. screen coords won't work because the bounding box will be wrong.
         t->setCharacterSizeMode( osgText::Text::OBJECT_COORDS );
         t->setCharacterSize( _fontSize );
 


### PR DESCRIPTION
While working on the Debian packaging for osgearth 2.4 the QA tool lintian reported a typo in one of the binaries. It's displayed in a warning message, and used in comments a couple of times.
