### PR TITLE
Added a custom bounding box option to the TFSPackager

### DIFF
--- a/src/applications/osgearth_tfs/osgearth_tfs.cpp
+++ b/src/applications/osgearth_tfs/osgearth_tfs.cpp
@@ -51,7 +51,8 @@ usage( const std::string& msg )
         << "    --expression       ; The expression to run on the feature source, specific to the feature source" << std::endl
         << "    --order-by         ; Sort the features, if not already included in the expression. Append DESC for descending order!" << std::endl
         << "    --crop             ; Crops features instead of doing a centroid check.  Features can be added to multiple tiles when cropping is enabled" << std::endl
-        << "    --dest-srs         ;The destination SRS string in any format osgEarth can understand (wkt, proj4, epsg).  If none is specified the source data SRS will be used" << std::endl
+        << "    --dest-srs         ; The destination SRS string in any format osgEarth can understand (wkt, proj4, epsg).  If none is specified the source data SRS will be used" << std::endl
+        << "    --bounds minx miny maxx maxy ; The bounding box to use as Level 0.  Feature extent will be used by default" << std::endl
         << std::endl;
 
     return -1;
@@ -105,6 +106,17 @@ int main(int argc, char** argv)
 
     std::string destSRS;
     while(arguments.read("--dest-srs", destSRS));
+
+    // Custom bounding box
+    Bounds bounds;
+    double xmin=DBL_MAX, ymin=DBL_MAX, xmax=DBL_MIN, ymax=DBL_MIN;
+    while (arguments.read("--bounds", xmin, ymin, xmax, ymax ))
+    {
+        bounds.xMin() = xmin;
+        bounds.yMin() = ymin;
+        bounds.xMax() = xmax;
+        bounds.yMax() = ymax;
+    }
     
     std::string filename;
 
@@ -114,6 +126,7 @@ int main(int argc, char** argv)
         if (!arguments.isOption(pos))
         {
             filename  = arguments[ pos ];
+            break;
         }
     }
 
@@ -177,6 +190,8 @@ int main(int argc, char** argv)
     packager.setQuery( query );
     packager.setMethod( cropMethod );    
     packager.setDestSRS( destSRS );
+    if (bounds.isValid())
+        packager.setLod0Extent(GeoExtent(features->getFeatureProfile()->getSRS(), bounds));
     packager.package( features, destination, layer, description );
     osg::Timer_t endTime = osg::Timer::instance()->tick();
     OE_NOTICE << "Completed in " << osg::Timer::instance()->delta_s( startTime, endTime ) << " s " << std::endl;

--- a/src/osgEarthUtil/TFSPackager
+++ b/src/osgEarthUtil/TFSPackager
@@ -80,6 +80,13 @@ namespace osgEarth { namespace Util {
         void setDestSRS(const std::string& srs ) { _destSRSString = srs; }
 
         /**
+         * A GeoExtent to use for LOD Level 0, in the SRS of the input dataset.  If not set the
+         * GeoExtent of the FeatureSource will be used
+         */
+        const GeoExtent getLod0Extent() const { return _customExtent; }
+        void setLod0Extent(const GeoExtent& extent) { _customExtent = extent; }
+
+        /**
          * Package the given feature source
          * @param features
          *     The feature source to package
@@ -103,7 +110,7 @@ namespace osgEarth { namespace Util {
         CropFilter::Method _method;
         std::string _destSRSString;
         osg::ref_ptr< const SpatialReference > _srs;
-
+        GeoExtent _customExtent;
     };
 
 } } // namespace osgEarth::Util

--- a/src/osgEarthUtil/TFSPackager.cpp
+++ b/src/osgEarthUtil/TFSPackager.cpp
@@ -296,9 +296,14 @@ void
     {
         _srs = features->getFeatureProfile()->getSRS();
     }
-
+	
+    //Get the extent of the dataset, or use the custom extent value
+    GeoExtent srsExtent = _customExtent;
+    if (!srsExtent.isValid())
+        srsExtent = features->getFeatureProfile()->getExtent();
+        
     //Transform to lat/lon extents
-    GeoExtent extent = features->getFeatureProfile()->getExtent().transform( _srs.get() );
+    GeoExtent extent = srsExtent.transform( _srs.get() );
 
     osg::ref_ptr< const osgEarth::Profile > profile = osgEarth::Profile::create(extent.getSRS(), extent.xMin(), extent.yMin(), extent.xMax(), extent.yMax(), 1, 1);
 
@@ -351,6 +356,16 @@ void
         }
     }   
     OE_NOTICE << "Added=" << added << " Skipped=" << skipped << " Failed=" << failed << std::endl;
+
+#if 1
+    // Print the width of tiles at each level
+    for (int i = 0; i <= highestLevel; ++i)
+    {
+        TileKey tileKey(i, 0, 0, profile);
+        GeoExtent tileExtent = tileKey.getExtent();
+        OE_NOTICE << "Level " << i << " tile size: " << tileExtent.width() << std::endl;
+    }
+#endif
 
     WriteFeaturesVisitor write(features, destination, _method, _srs);
     root->accept( &write );


### PR DESCRIPTION
Made a simple modification to the TFSPackager and the osgearth_tfs tool so I can control the size of the tiles in the quadtree.  Optionally print the width of tiles in each level to the console.

Tagged as Issue #180: https://github.com/gwaldron/osgearth/issues/180
