### PR TITLE
Change so that overlays use accumulated view matrix instead of current c...

### DIFF
--- a/src/osgEarth/ClampingTechnique.cpp
+++ b/src/osgEarth/ClampingTechnique.cpp
@@ -493,8 +493,10 @@ ClampingTechnique::cullOverlayGroup(OverlayDecorator::TechRTTParams& params,
             osg::Matrix::translate(1.0,1.0,1.0) * 
             osg::Matrix::scale    (0.5,0.5,0.5) );
 
+        osg::Matrix vm;
+        vm.invert( *cv->getModelViewMatrix() );
         osg::Matrix cameraViewToDepthView =
-            cv->getCurrentCamera()->getInverseViewMatrix() * 
+            vm *
             params._rttViewMatrix;
 
         osg::Matrix depthViewToDepthClip = 

--- a/src/osgEarth/DrapingTechnique.cpp
+++ b/src/osgEarth/DrapingTechnique.cpp
@@ -578,7 +578,11 @@ DrapingTechnique::cullOverlayGroup(OverlayDecorator::TechRTTParams& params,
             // dispatched to render. So we need to come up with a way to address this.
             // In the meantime, I patched the MP engine to set a DYNAMIC data variance on
             // terrain tiles to work around the problem.
-            local._texGenUniform->set( cv->getCurrentCamera()->getInverseViewMatrix() * VPT );
+            //
+            // Note that we require the InverseViewMatrix, but it is OK to invert the ModelView matrix as the model matrix is identity here.
+            osg::Matrix vm;
+            vm.invert( *cv->getModelViewMatrix() );
+            local._texGenUniform->set( vm * VPT );
         }
 #if 0 // FFP no longer supported.
         else

--- a/src/osgEarth/OverlayDecorator.cpp
+++ b/src/osgEarth/OverlayDecorator.cpp
@@ -382,12 +382,8 @@ OverlayDecorator::cullTerrainAndCalculateRTTParams(osgUtil::CullVisitor* cv,
                                                    PerViewData&          pvd)
 {
     static int s_frame = 1;
-    static osg::Vec3d zero(0.0, 0.0, 0.0);
 
-    osg::Matrixd invViewMatrix = cv->getCurrentCamera()->getInverseViewMatrix();
-    osg::Vec3d eye = zero * invViewMatrix;
-    //osg::Vec3 eye = cv->getEyePoint();
-    eye = cv->getViewPoint();
+    osg::Vec3d eye = cv->getViewPoint();
 
     double eyeLen;
     osg::Vec3d worldUp;


### PR DESCRIPTION
...amera view matrix, fixing incorrect feature display when MapNode is under sub-camera.

Remove some redundant code in OverlayDecorator.cpp.
