### PR TITLE
use tileSource->hasData()

### DIFF
--- a/src/osgEarth/ImageLayer.cpp
+++ b/src/osgEarth/ImageLayer.cpp
@@ -643,39 +643,26 @@ ImageLayer::createImageFromTileSource(const TileKey&    key,
         return assembleImageFromTileSource( key, progress, out_isFallback );
     }
 
-    // Fail is the image is blacklisted.
-    // ..unless there will be a fallback attempt.
-    if ( source->getBlacklist()->contains( key.getTileId() ) && !forceFallback )
-    {
-        OE_DEBUG << LC << "createImageFromTileSource: blacklisted(" << key.str() << ")" << std::endl;
-        return GeoImage::INVALID;
-    }
-
-    // Fail if no data is available for this key.
-    if ( !source->hasDataAtLOD( key.getLevelOfDetail() ) && !forceFallback )
-    {
-        OE_DEBUG << LC << "createImageFromTileSource: hasDataAtLOD(" << key.str() << ") == false" << std::endl;
-        return GeoImage::INVALID;
-    }
-
-    if ( !source->hasDataInExtent( key.getExtent() ) )
-    {
-        OE_DEBUG << LC << "createImageFromTileSource: hasDataInExtent(" << key.str() << ") == false" << std::endl;
-        return GeoImage::INVALID;
-    }
-
     // Good to go, ask the tile source for an image:
     osg::ref_ptr<TileSource::ImageOperation> op = _preCacheOp;
 
     osg::ref_ptr<osg::Image> result;
-    TileKey finalKey = key;
-    bool fellBack = false;
 
     if ( forceFallback )
-    {        
+    {
+        // check if the tile source has any data coverage for the requested key.
+        // the LOD is ignore here and checked later
+        if ( !source->hasDataInExtent( key.getExtent() ) )
+        {
+            OE_DEBUG << LC << "createImageFromTileSource: hasDataInExtent(" << key.str() << ") == false" << std::endl;
+            return GeoImage::INVALID;
+        }
+
+        TileKey finalKey = key;
         while( !result.valid() && finalKey.valid() )
         {
-            if ( !source->getBlacklist()->contains( finalKey.getTileId() ) )
+            if ( !source->getBlacklist()->contains( finalKey.getTileId() ) &&
+                source->hasDataForFallback(finalKey))
             {
                 result = source->createImage( finalKey, op.get(), progress );
                 if ( result.valid() )
@@ -688,7 +675,6 @@ ImageLayer::createImageFromTileSource(const TileKey&    key,
                         GeoImage raw( result.get(), finalKey.getExtent() );
                         GeoImage cropped = raw.crop( key.getExtent(), true, raw.getImage()->s(), raw.getImage()->t(), *_runtimeOptions.driver()->bilinearReprojection() );
                         result = cropped.takeImage();
-                        fellBack = true;
                     }
                 }
             }
@@ -706,9 +692,20 @@ ImageLayer::createImageFromTileSource(const TileKey&    key,
             finalKey = key;
         }
     }
-
     else
     {
+        // Fail is the image is blacklisted.
+        if ( source->getBlacklist()->contains( key.getTileId() ) )
+        {
+            OE_DEBUG << LC << "createImageFromTileSource: blacklisted(" << key.str() << ")" << std::endl;
+            return GeoImage::INVALID;
+        }
+    
+        if ( !source->hasData( key ) )
+        {
+            OE_DEBUG << LC << "createImageFromTileSource: hasData(" << key.str() << ") == false" << std::endl;
+            return GeoImage::INVALID;
+        }
         result = source->createImage( key, op.get(), progress );
     }
 

--- a/src/osgEarth/TileSource
+++ b/src/osgEarth/TileSource
@@ -320,6 +320,12 @@ namespace osgEarth
         virtual bool hasData(const TileKey& key) const;
 
         /**
+         * Whether or not the source has data to create fallback tile for 
+         * the given TileKey
+         */
+        virtual bool hasDataForFallback(const TileKey& key) const;
+
+        /**
          * Whether the tile source can generate data for the specified LOD.
          */
         virtual bool hasDataAtLOD( unsigned lod ) const;

--- a/src/osgEarth/TileSource.cpp
+++ b/src/osgEarth/TileSource.cpp
@@ -475,6 +475,31 @@ TileSource::hasData(const osgEarth::TileKey& key) const
     return intersectsData;
 }
 
+bool
+TileSource::hasDataForFallback(const osgEarth::TileKey& key) const
+{
+    //sematics: might have data.
+
+    //If no data extents are provided, just return true
+    if (_dataExtents.size() == 0) 
+        return true;
+
+    const osgEarth::GeoExtent& keyExtent = key.getExtent();
+    bool intersectsData = false;
+
+    for (DataExtentList::const_iterator itr = _dataExtents.begin(); itr != _dataExtents.end(); ++itr)
+    {
+        if ((keyExtent.intersects( *itr )) && 
+            (!itr->minLevel().isSet() || itr->minLevel() <= key.getLOD()))
+        {
+            intersectsData = true;
+            break;
+        }
+    }
+
+    return intersectsData;
+}
+
 TileBlacklist*
 TileSource::getBlacklist()
 {


### PR DESCRIPTION
 to check if tileSource has data for the requested key. Add tileSource->hasDataForFallback() for cases when fallback data is requested

I added the method hasDataForFallback() to the TileSource. This might now be the best solution, but i hope that i didn't missed any use-case.
