### PR TITLE
add loading priority to simple model driver

### DIFF
--- a/src/osgEarthDrivers/model_simple/SimpleModelOptions
+++ b/src/osgEarthDrivers/model_simple/SimpleModelOptions
@@ -46,6 +46,12 @@ namespace osgEarth { namespace Drivers
         optional<ShaderPolicy>& shaderPolicy() { return _shaderPolicy; }
         const optional<ShaderPolicy>& shaderPolicy() const { return _shaderPolicy; }
         
+        optional<float>& loadingPriorityScale() { return _loadingPriorityScale; }
+        const optional<float>& loadingPriorityScale() const { return _loadingPriorityScale; }
+
+        optional<float>& loadingPriorityOffset() { return _loadingPriorityOffset; }
+        const optional<float>& loadingPriorityOffset() const { return _loadingPriorityOffset; }
+        
         /**
          If specified, use this node instead try to load from url
         */
@@ -57,7 +63,10 @@ namespace osgEarth { namespace Drivers
     public:
         SimpleModelOptions( const ConfigOptions& options=ConfigOptions() )
             : ModelSourceOptions( options ),
-              _shaderPolicy( SHADERPOLICY_GENERATE )
+              _lod_scale(1.0f),
+              _shaderPolicy( SHADERPOLICY_GENERATE ),
+              _loadingPriorityScale(1.0f),
+              _loadingPriorityOffset(0.0f)
         {
             setDriver( "simple" );
             fromConfig( _conf );
@@ -72,6 +81,8 @@ namespace osgEarth { namespace Drivers
             conf.updateIfSet( "lod_scale", _lod_scale );
             conf.updateIfSet( "location", _location );
             conf.updateIfSet( "orientation", _orientation);
+            conf.updateIfSet( "loading_priority_scale", _loadingPriorityScale );
+            conf.updateIfSet( "loading_priority_offset", _loadingPriorityOffset );
 
             conf.addIfSet( "shader_policy", "disable",  _shaderPolicy, SHADERPOLICY_DISABLE );
             conf.addIfSet( "shader_policy", "inherit",  _shaderPolicy, SHADERPOLICY_INHERIT );
@@ -93,6 +104,8 @@ namespace osgEarth { namespace Drivers
             conf.getIfSet( "lod_scale", _lod_scale );
             conf.getIfSet( "location", _location);
             conf.getIfSet( "orientation", _orientation);
+            conf.getIfSet( "loading_priority_scale", _loadingPriorityScale );
+            conf.getIfSet( "loading_priority_offset", _loadingPriorityOffset );
 
             conf.getIfSet( "shader_policy", "disable",  _shaderPolicy, SHADERPOLICY_DISABLE );
             conf.getIfSet( "shader_policy", "inherit",  _shaderPolicy, SHADERPOLICY_INHERIT );
@@ -106,6 +119,8 @@ namespace osgEarth { namespace Drivers
         optional<osg::Vec3> _location;
         optional<osg::Vec3> _orientation;
         optional<ShaderPolicy> _shaderPolicy;
+        optional<float> _loadingPriorityScale;
+        optional<float> _loadingPriorityOffset;
         osg::ref_ptr<osg::Node> _node;
     };
 

--- a/src/osgEarthDrivers/model_simple/SimpleModelSource.cpp
+++ b/src/osgEarthDrivers/model_simple/SimpleModelSource.cpp
@@ -25,6 +25,7 @@
 #include <osgEarth/FileUtils>
 #include <osgEarth/AutoScale>
 #include <osg/LOD>
+#include <osg/ProxyNode>
 #include <osg/Notify>
 #include <osg/MatrixTransform>
 #include <osg/io_utils>
@@ -67,6 +68,33 @@ namespace
 
     private:
         float m_lodScale;
+    };
+
+    class SetLoadPriorityVisitor : public osg::NodeVisitor
+    {
+    public:
+        SetLoadPriorityVisitor(float scale=1.0f, float offset=0.0f)
+            : osg::NodeVisitor(osg::NodeVisitor::TRAVERSE_ALL_CHILDREN)
+            , m_scale(scale)
+            , m_offset(offset)
+        {}
+
+        virtual void apply(osg::PagedLOD& node)
+        {
+            for(unsigned n = 0; n < node.getNumFileNames(); n++)
+            {
+                float old;
+                old = node.getPriorityScale(n);
+                node.setPriorityScale(n, old * m_scale);
+                old = node.getPriorityOffset(n);
+                node.setPriorityOffset(n, old + m_offset);
+            }
+            traverse(node);
+        }
+
+    private:
+        float m_scale;
+        float m_offset;
     };
 }
 
@@ -143,17 +171,23 @@ public:
             }
         }
 
-        if(_options.lodScale().isSet())
-        {
-            LODScaleOverrideNode * node = new LODScaleOverrideNode;
-            node->setLODScale(_options.lodScale().value());
-            node->addChild(result.release());
-            result = node;
-        }
-
         // generate a shader program to render the model.
         if ( result.valid() )
         {
+            if(_options.loadingPriorityScale().isSet() || _options.loadingPriorityOffset().isSet())
+            {
+                SetLoadPriorityVisitor slpv(_options.loadingPriorityScale().value(), _options.loadingPriorityOffset().value());
+                result->accept(slpv);
+            }
+    
+            if(_options.lodScale().isSet())
+            {
+                LODScaleOverrideNode * node = new LODScaleOverrideNode;
+                node->setLODScale(_options.lodScale().value());
+                node->addChild(result.release());
+                result = node;
+            }
+
             if ( _options.shaderPolicy() == SHADERPOLICY_GENERATE )
             {
                 ShaderGenerator gen;


### PR DESCRIPTION
add options to specify a loading priority for the models. this can be used to tell the database pager to prioritize certain model layers and adjust the order in which the models are loaded.
