### PR TITLE
WCS 1.1 bounds

### DIFF
--- a/CMakeModules/FindLibNoise.cmake
+++ b/CMakeModules/FindLibNoise.cmake
@@ -43,7 +43,7 @@ FIND_LIBRARY(LIBNOISE_LIBRARY
 )
 
 FIND_LIBRARY(LIBNOISE_LIBRARY
-  NAMES libnoise
+  NAMES libnoise noise
   PATHS
     ~/Library/Frameworks
     /Library/Frameworks


### PR DESCRIPTION
Fix for getting the elevation values of neighboring tiles to line up over WCS. Discovered while integrating with Luciad Fusion.
