### PR TITLE
Topic elevation query maxlevel

### DIFF
--- a/src/osgEarth/ElevationQuery.cpp
+++ b/src/osgEarth/ElevationQuery.cpp
@@ -86,13 +86,17 @@ ElevationQuery::getMaxLevel( double x, double y, const SpatialReference* srs, co
                 }
 
                 //Need to convert the layer max of this TileSource to that of the actual profile
-                layerMax = profile->getEquivalentLOD( ts->getProfile(), layerMax );            
-            }
+                layerMax = profile->getEquivalentLOD( ts->getProfile(), layerMax );
 
-            // cap the max to the layer's express max level (if set).
-            if ( i->get()->getTerrainLayerRuntimeOptions().maxLevel().isSet() )
+                // cap the max to the layer's express max level (if set).
+                if ( i->get()->getTerrainLayerRuntimeOptions().maxLevel().isSet() )
+                {
+                    layerMax = std::min( layerMax, *i->get()->getTerrainLayerRuntimeOptions().maxLevel() );
+                }
+            }
+            else if ( i->get()->getTerrainLayerRuntimeOptions().maxLevel().isSet() )
             {
-                layerMax = std::min( layerMax, *i->get()->getTerrainLayerRuntimeOptions().maxLevel() );
+                layerMax = i->get()->getTerrainLayerRuntimeOptions().maxLevel().value();
             }
         }
         else

--- a/src/osgEarthDrivers/vpb/ReaderWriterVPB.cpp
+++ b/src/osgEarthDrivers/vpb/ReaderWriterVPB.cpp
@@ -519,6 +519,19 @@ public:
 
         _vpbDatabase->initialize( _dbOptions.get() );
 
+        unsigned maxLevel;
+        if(_options.maxDataLevelOverride().isSet())
+            maxLevel = _options.maxDataLevelOverride().value();
+        else
+        {
+            int psl = _options.primarySplitLevel().value();
+            int ssl = _options.secondarySplitLevel().value();
+            int calculatedThirdSplitLevel = ssl + (ssl - psl);
+            maxLevel = (unsigned)std::max(psl, std::max(ssl, calculatedThirdSplitLevel));
+        }
+
+        //Push back a single area that encompasses the whole profile going up to the max level
+        this->getDataExtents().push_back(DataExtent(_vpbDatabase->_profile->getExtent(), 0, maxLevel));
         if ( !getProfile() )
         {
             setProfile(_vpbDatabase->_profile.get());

--- a/src/osgEarthDrivers/vpb/VPBOptions
+++ b/src/osgEarthDrivers/vpb/VPBOptions
@@ -48,6 +48,8 @@ namespace osgEarth { namespace Drivers
         optional<int>& secondarySplitLevel() { return _secondarySplitLevel; }
         const optional<int>& secondarySplitLevel() const { return _secondarySplitLevel; }
 
+        optional<unsigned int>& maxDataLevelOverride() { return _maxDataLevelOverride;}
+        const optional<unsigned int>& maxDataLevelOverride() const { return _maxDataLevelOverride;}
         optional<DirectoryStructure>& directoryStructure() { return _dirStruct; }
         const optional<DirectoryStructure>& directoryStructure() const { return _dirStruct; }
 
@@ -92,6 +94,7 @@ namespace osgEarth { namespace Drivers
             conf.updateIfSet("url", _url);
             conf.updateIfSet("primary_split_level", _primarySplitLevel);
             conf.updateIfSet("secondary_split_level", _secondarySplitLevel);
+            conf.updateIfSet( "max_data_level_override", _maxDataLevelOverride);
             conf.updateIfSet("layer", _layer);
             conf.updateIfSet("layer_setname", _layerSetName);
             conf.updateIfSet("num_tiles_wide_at_lod_0", _widthLod0 );
@@ -117,6 +120,7 @@ namespace osgEarth { namespace Drivers
             conf.getIfSet("url", _url);
             conf.getIfSet("primary_split_level", _primarySplitLevel);
             conf.getIfSet("secondary_split_level", _secondarySplitLevel);
+            conf.getIfSet( "max_data_level_override", _maxDataLevelOverride);
             conf.getIfSet("layer", _layer);
             conf.getIfSet("layer_setname", _layerSetName);
             conf.getIfSet("num_tiles_wide_at_lod_0", _widthLod0 );
@@ -133,6 +137,7 @@ namespace osgEarth { namespace Drivers
         optional<URI>         _url;
         optional<std::string> _baseName, _layerSetName;
         optional<int>         _primarySplitLevel, _secondarySplitLevel, _layer, _widthLod0, _heightLod0;
+        optional<unsigned int>       _maxDataLevelOverride;
         optional<DirectoryStructure> _dirStruct;
         optional<int> _terrainTileCacheSize;
     };


### PR DESCRIPTION
The first commit fixes the trouble when an elevation layer has the maxLevel property configured but there are not used when no data extents are available.
The second one adds one big data extent for the VPB globe using the primary and secondary split levels or the new property maxDataLevelOverride.