### PR TITLE
use user supplied value for buffer as fallback

### DIFF
--- a/src/osgEarth/Pickers.cpp
+++ b/src/osgEarth/Pickers.cpp
@@ -100,7 +100,7 @@ Picker::pick( float x, float y, Hits& results ) const
         osg::Vec3d bufferLocal(local_x + buffer_x, local_y + buffer_y, 0.0);
         osg::Vec3d bufferModel = bufferLocal * modelInverse;
 
-        double buffer = osg::maximum((bufferModel - startModel).length(), 5.0);  //TODO: Setting a minimum of 4.0 may need revisited
+        double buffer = osg::maximum((bufferModel - startModel).length(), (double)_buffer);
 
         OE_DEBUG
             << "local_x:" << local_x << ", local_y:" << local_y


### PR DESCRIPTION
in my application i need a very precise hit test when grabbing a dragger, so the user does not hit an close-by dragger by accident. To accomplish that i needed to change the default maximum in Pickers.cpp to the user supplied value of buffer. In my case i use 0 as buffer value (or a value close to zero) to get a very precise hit test.

This is only a suggestion, but as the previous comment suggested the value of 4 or 5 is quite random.