### PR TITLE
Modify OverlayDecorator for use with cameras that go under ground.

### DIFF
--- a/src/osgEarth/DrapingTechnique.cpp
+++ b/src/osgEarth/DrapingTechnique.cpp
@@ -516,10 +516,10 @@ DrapingTechnique::cullOverlayGroup(OverlayDecorator::TechRTTParams& params,
             osg::Matrix::scale(0.5,0.5,0.5);
 
         // resolution weighting based on camera distance.
-        if ( _maxFarNearRatio > 1.0 )
-        {
-            optimizeProjectionMatrix( params, _maxFarNearRatio );
-        }
+//        if ( _maxFarNearRatio > 1.0 )
+//        {
+//            optimizeProjectionMatrix( params, _maxFarNearRatio );
+//        }
 
         params._rttCamera->setViewMatrix      ( params._rttViewMatrix );
         params._rttCamera->setProjectionMatrix( params._rttProjMatrix );


### PR DESCRIPTION
Glenn,
This addresses issue #431, znear > zfar from OverlayDecorator when the camera is underground. Basically, it looks like OverlayDecorator::cullTerrainAndCalculateRTTParams has been written assuming that the osgEarth Manipulator is being used, ie above ground and camera vertical. The attached extends this to allow for the camera to be in any orientation.
I had to comment out the call to optimizeProjectionMatrix(). This function is marked as experimental and states that it assumes no roll in the camera, plus, I don't really understand what it does very well. Results still look good without it.
Cheers,
Roland
