### PR TITLE
Allow text-provider to be something other than "annotation" if it's set.

### DIFF
--- a/src/osgEarthFeatures/BuildTextFilter.cpp
+++ b/src/osgEarthFeatures/BuildTextFilter.cpp
@@ -50,6 +50,12 @@ BuildTextFilter::push( FeatureList& input, FilterContext& context )
 
     LabelSourceOptions options;
     options.setDriver( "annotation" );
+
+    if( !text->provider()->empty() )
+        options.setDriver( *text->provider() );
+
+
+
     //options.setDriver( text ? (*text->provider()) : (*icon->provider()) );
     osg::ref_ptr<LabelSource> source = LabelSourceFactory::create( options );
     if ( source.valid() )


### PR DESCRIPTION
If the Text-Provider is set, switch from the default of "annotation" to the one specified.
