### PR TITLE
Arcgis Fixes

### DIFF
--- a/src/osgEarthDrivers/arcgis/ArcGISOptions
+++ b/src/osgEarthDrivers/arcgis/ArcGISOptions
@@ -41,6 +41,10 @@ namespace osgEarth { namespace Drivers
         /** Override the image format read from the server metadata */
         optional<std::string>& format() { return _format; }
         const optional<std::string>& format() const { return _format; }
+        
+        /** Override the layers read from the server metadata */
+        optional<std::string>& layers() { return _layers; }
+        const optional<std::string>& layers() const { return _layers; }
 
     public:
         ArcGISOptions( const TileSourceOptions& opt =TileSourceOptions() ) : TileSourceOptions( opt )
@@ -58,6 +62,7 @@ namespace osgEarth { namespace Drivers
             conf.updateIfSet("url", _url );
             conf.updateIfSet("token", _token );
             conf.updateIfSet("format", _format );
+            conf.updateIfSet("layers", _layers );
             return conf;
         }
 
@@ -70,12 +75,14 @@ namespace osgEarth { namespace Drivers
             conf.getIfSet( "url", _url );
             conf.getIfSet( "token", _token);
             conf.getIfSet( "format", _format);
+            conf.getIfSet( "layers", _layers);
         }
 
     private:
         optional<URI>         _url;
         optional<std::string> _token;
         optional<std::string> _format;
+        optional<std::string> _layers;
     };
 
 } } // namespace osgEarth::Drivers

--- a/src/osgEarthDrivers/arcgis/ReaderWriterArcGIS.cpp
+++ b/src/osgEarthDrivers/arcgis/ReaderWriterArcGIS.cpp
@@ -38,6 +38,8 @@
 using namespace osgEarth;
 using namespace osgEarth::Drivers;
 
+#define LC "[ReaderWriterArcGIS] "
+
 //#define PROPERTY_URL        "url"
 //#define PROPERTY_PROFILE    "profile"
 
@@ -51,21 +53,37 @@ public:
     {
         //TODO: allow single layers vs. "fused view"
         if ( _layer.empty() )
+		{
             _layer = "_alllayers"; // default to the AGS "fused view"
+		}
+		else
+		{
+			_layer = *_options.layers();
+		}
 
-        if ( _options.format().isSet() ) 
+        if ( _options.format().isSet() )
+		{
             _format = *_options.format();
+		}
         else
+		{
             _format = _map_service.getTileInfo().getFormat();
+		}
 
         std::transform( _format.begin(), _format.end(), _format.begin(), tolower );
         if ( _format.length() > 3 && _format.substr( 0, 3 ) == "png" )
+		{
             _format = "png";
+		}
 
         if ( _format == "mixed" )
+		{
             _format = "";
+		}
         if ( !_format.empty() )
+		{
             _dot_format = "." + _format;
+		}
     }
 
     // override
@@ -73,6 +91,10 @@ public:
     {
         // add the security token to the URL if necessary:
         URI url = _options.url().value();
+
+		OE_DEBUG << LC << "Initial URL: " << url.full() << std::endl;
+
+		// append token to url in query string is set
         if (_options.token().isSet())
         {
             std::string token = _options.token().value();
@@ -82,10 +104,34 @@ public:
                 url = url.append( sep + std::string("token=") + token );
             }
         }
+		else
+		{
+			OE_DEBUG << LC << "Token not set" << std::endl;
+		}
+
+		// append layers to url in query string is set .. format is show:1,2,3
+		if (_options.layers().isSet())
+        {
+			std::string layers = _options.layers().value();
+			OE_DEBUG << LC << "_Layers: " << layers << std::endl;
+			if (!layers.empty())
+			{
+				std::string sep = url.full().find( "?" ) == std::string::npos ? "?" : "&";
+				url = url.append( sep + std::string("layers=show:") + layers );
+			}
+		}
+		else
+		{
+			OE_DEBUG << LC << "Layer options not set" << std::endl;
+		}
+
+		OE_DEBUG << LC << "_map_service URL: " << url.full() << std::endl;
 
         // read map service metadata from the server
         if ( !_map_service.init(url, dbOptions) )
         {
+			OE_INFO << LC << "_map_service.init failed: " << _map_service.getError() << std::endl;
+
             return Status::Error( Stringify()
                 << "[osgearth] [ArcGIS] map service initialization failed: "
                 << _map_service.getError() );
@@ -167,6 +213,19 @@ public:
                 str = buf.str();
                 std::string sep = str.find( "?" ) == std::string::npos ? "?" : "&";
                 buf << sep << "token=" << token;
+            }
+        }
+
+		//Add the layers if necessary
+        if (_options.layers().isSet())
+        {
+            std::string layers = _options.layers().value();
+            if (!layers.empty())
+            {
+                std::string str;
+                str = buf.str();
+                std::string sep = str.find( "?" ) == std::string::npos ? "?" : "&";
+				buf << sep << "layers=show:" << layers;
             }
         }
 


### PR DESCRIPTION
Hi lads,
I have been working with clients trying to resolve some issues they were having with loading some of their ArcGis layers in osgearth. Main feature requests/additions were being able to specify which layers to load instead of the default of all of them & being able to load a layer with a wkt string for a spatial reference instead of only an integer wkid. I also extended the extent check as not all layers contain a fullExtent attribute in the json returned which was causing the loading of the layer to fail (0 for min.max/x/y values). Summary below:
- Add support for loading individual layers (comma separated string) via a <layers> option for
  Arcgis image layers. Default is still _allLayers if none specified in the earth file.
- Add support for loading a layer if it uses a wkt string for the spatial reference.
- Fix an issue where if a layer did not contain a fullExtent attribute, then it would fall back looking for an extent or initialExtent to determine the min/max/x/y values.

Check out the changes & have a play with them. I've incorporated them into our local copy of the project but would prefer to have them integrated into osgearth as i think they will extend the capabilities of the ArcGis plugin nicely for other users. 
