### PR TITLE
Use OGR api tests spatial index availability before build it. The spatial index is built only if it doesn't exist or if force_rebuild option is ON

### DIFF
--- a/src/osgEarthDrivers/feature_ogr/FeatureSourceOGR.cpp
+++ b/src/osgEarthDrivers/feature_ogr/FeatureSourceOGR.cpp
@@ -201,14 +201,21 @@ public:
                     // assuming we successfully opened the layer, build a spatial index if requested.
                     if ( _options.buildSpatialIndex() == true )
                     {
-                        OE_INFO << LC << "Building spatial index for " << getName() << std::endl;
-                        std::stringstream buf;
-                        const char* name = OGR_FD_GetName( OGR_L_GetLayerDefn( _layerHandle ) );
-                        buf << "CREATE SPATIAL INDEX ON " << name; 
-                        std::string bufStr;
-                        bufStr = buf.str();
-                        OE_DEBUG << LC << "SQL: " << bufStr << std::endl;
-                        OGR_DS_ExecuteSQL( _dsHandle, bufStr.c_str(), 0L, 0L );
+                        if ( (_options.forceRebuildSpatialIndex() == true) || (OGR_L_TestCapability(_layerHandle, OLCFastSpatialFilter) == 0) )
+                        {
+                            OE_INFO << LC << "Building spatial index for " << getName() << std::endl;
+                            std::stringstream buf;
+                            const char* name = OGR_FD_GetName( OGR_L_GetLayerDefn( _layerHandle ) );
+                            buf << "CREATE SPATIAL INDEX ON " << name;
+                            std::string bufStr;
+                            bufStr = buf.str();
+                            OE_DEBUG << LC << "SQL: " << bufStr << std::endl;
+                            OGR_DS_ExecuteSQL( _dsHandle, bufStr.c_str(), 0L, 0L );
+                        }
+                        else
+                        {
+                            OE_INFO << LC << "Use existing spatial index for " << getName() << std::endl;
+                        }
                     }
 
                     //Get the feature count

--- a/src/osgEarthDrivers/feature_ogr/OGRFeatureOptions
+++ b/src/osgEarthDrivers/feature_ogr/OGRFeatureOptions
@@ -42,6 +42,9 @@ namespace osgEarth { namespace Drivers
         optional<bool>& buildSpatialIndex() { return _buildSpatialIndex; }
         const optional<bool>& buildSpatialIndex() const { return _buildSpatialIndex; }
 
+        optional<bool>& forceRebuildSpatialIndex() { return _forceRebuildSpatialIndex; }
+        const optional<bool>& forceRebuildSpatialIndex() const { return _forceRebuildSpatialIndex; }
+
         optional<Config>& geometryConfig() { return _geometryConf; }
         const optional<Config>& geometryConfig() const { return _geometryConf; }
 
@@ -70,6 +73,7 @@ namespace osgEarth { namespace Drivers
             conf.updateIfSet( "connection", _connection );
             conf.updateIfSet( "ogr_driver", _ogrDriver );
             conf.updateIfSet( "build_spatial_index", _buildSpatialIndex );
+            conf.updateIfSet( "force_rebuild_spatial_index", _forceRebuildSpatialIndex );
             conf.updateIfSet( "geometry", _geometryConf );    
             conf.updateIfSet( "geometry_url", _geometryUrl );
             conf.updateIfSet( "layer", _layer );
@@ -89,6 +93,7 @@ namespace osgEarth { namespace Drivers
             conf.getIfSet( "connection", _connection );
             conf.getIfSet( "ogr_driver", _ogrDriver );
             conf.getIfSet( "build_spatial_index", _buildSpatialIndex );
+            conf.getIfSet( "force_rebuild_spatial_index", _forceRebuildSpatialIndex );
             conf.getIfSet( "geometry", _geometryConf );
             conf.getIfSet( "geometry_url", _geometryUrl );
             conf.getIfSet( "layer", _layer);
@@ -99,6 +104,7 @@ namespace osgEarth { namespace Drivers
         optional<std::string>             _connection;
         optional<std::string>             _ogrDriver;
         optional<bool>                    _buildSpatialIndex;
+        optional<bool>                    _forceRebuildSpatialIndex;
         optional<Config>                  _geometryConf;
         optional<Config>                  _geometryProfileConf;
         optional<std::string>             _geometryUrl;


### PR DESCRIPTION
I often get messages from OGR like this one in the console : "Failed to delete file xxxyyyzzz.qix. Permission denied"

This happen when an OGR dataset (or more specifically a shapefile) is already opened.

I added a test to build the spatial index only if necessary :
- spatial index is asked but doesn't exists
- spatial index "force_rebuild" is ON

This can also give a little more performances on large shape files, since the spatial index was rebuilt at every  "shapefile first open"
