### PR TITLE
add support for the Chinese character in the file name and attributes in shapefile

### DIFF
--- a/src/osgEarth/Registry.cpp
+++ b/src/osgEarth/Registry.cpp
@@ -62,6 +62,10 @@ _cacheDriver        ( "filesystem" )
     // set up GDAL and OGR.
     OGRRegisterAll();
     GDALAllRegister();
+    
+    // support Chinese character in the file name and attributes in ESRI's shapefile
+    CPLSetConfigOption("GDAL_FILENAME_IS_UTF8","NO");
+    CPLSetConfigOption("SHAPE_ENCODING","");
 
     // global initialization for CURL (not thread safe)
     HTTPClient::globalInit();


### PR DESCRIPTION
I think it's helpful for users who use Chinese Operation System.
