### PR TITLE
Apply referrer on DBOptions only if referrer is not an empty string

### DIFF
--- a/src/osgEarth/URI.cpp
+++ b/src/osgEarth/URI.cpp
@@ -121,8 +121,11 @@ URIContext::apply( osgDB::Options* options )
 {
     if ( options )
     {
-        options->setDatabasePath( _referrer );
-        options->setPluginStringData( "osgEarth::URIContext::referrer", _referrer );
+        if (_referrer.empty() == false)
+        {
+            options->setDatabasePath( _referrer );
+            options->setPluginStringData( "osgEarth::URIContext::referrer", _referrer );
+        }
     }
 }
 


### PR DESCRIPTION
Some 3ds files used as model in a ModelSymbol cannot find their texture : texture filname are relative, but since the DatabasePath are always filed with referrer (even if it is an empty string), the 3ds plugin search for texture files in the wrong location.

I don't know who is wrong : I the 3ds plugin or osgEarth, but my guess is that osgDB::Options should not contains an empty string as a database path.
