### PR TITLE
Fix for crash on BuildTextFilter

### DIFF
--- a/src/osgEarthFeatures/BuildTextFilter.cpp
+++ b/src/osgEarthFeatures/BuildTextFilter.cpp
@@ -51,7 +51,7 @@ BuildTextFilter::push( FeatureList& input, FilterContext& context )
     LabelSourceOptions options;
     options.setDriver( "annotation" );
 
-    if( !text->provider()->empty() )
+    if( text && !text->provider()->empty() )
         options.setDriver( *text->provider() );
 
 


### PR DESCRIPTION
We need to test if text is set.
