### PR TITLE
Fixed GLSL error in Ground_Scattering_Fragment shader - due to not impli...

### DIFF
--- a/src/osgEarthDrivers/sky_simple/SimpleSkyShaders
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyShaders
@@ -425,7 +425,7 @@ namespace osgEarth { namespace Drivers { namespace SimpleSky
         "    float exposure = atmos_exposure*clamp(1.0-atmos_space, 0.5, 1.0); \n"
 
         "    vec3 atmosColor = 1.0 - exp(-exposure * (atmos_color + sceneColor.rgb * attenuation)); \n"
-        "    color.rgb = gl_FrontMaterial.emission + atmosColor; \n"
+        "    color.rgb = gl_FrontMaterial.emission.rgb + atmosColor; \n"
         "} \n";
 
     //-- BASIC PHONG GROUND LIGHTING ------------------------------------------


### PR DESCRIPTION
...cit conversion of vec4 to vec3:

<log output>
FRAGMENT glCompileShader "atmos_fragment_main" FAILED
FRAGMENT Shader "atmos_fragment_main" infolog:
Fragment shader failed to compile with the following errors:
WARNING: 0:33: warning(#402) Implicit truncation of vector from size: 4 to size: 3
ERROR: 0:33: error(#162) Wrong operand types: no operation "+" exists that takes a left-hand operand of type "uniform 4-component
vector of vec4" and a right operand of type "highp 3-component vector of vec3" (or there is no acceptable conversion)
WARNING: 0:33: warning(#402) Implicit truncation of vector from size: 4 to size: 3
ERROR: error(#273) 1 compilation errors.  No code generated
</log>
