### PR TITLE
fix for finding geos on Ubuntu 14.04

### DIFF
--- a/CMakeModules/FindGEOS.cmake
+++ b/CMakeModules/FindGEOS.cmake
@@ -5,13 +5,13 @@
 # GEOS_FOUND, if false, do not try to link to geos
 # GEOS_INCLUDE_DIR, where to find the headers
 
-FIND_PATH(GEOS_INCLUDE_DIR geos.h
+FIND_PATH(GEOS_INCLUDE_DIR geos/geom/Geometry.h
   $ENV{GEOS_DIR}
   NO_DEFAULT_PATH
     PATH_SUFFIXES include
 )
 
-FIND_PATH(GEOS_INCLUDE_DIR geos.h
+FIND_PATH(GEOS_INCLUDE_DIR geos/geom/Geometry.h
   PATHS
   ~/Library/Frameworks/geos/Headers
   /Library/Frameworks/geos/Headers


### PR DESCRIPTION
Here's the fix I'm using for issue #529.  I've tested it with geos 3.4.2 on Ubuntu 14.04, geos 3.3.3 on debian wheezy and geos 3.3.8 on RHEL 6.5.
