### PR TITLE
EarthManipulator: OPTION_DURATION for Settings::bindScroll()

### DIFF
--- a/src/osgEarthUtil/EarthManipulator
+++ b/src/osgEarthUtil/EarthManipulator
@@ -322,7 +322,7 @@ namespace osgEarth { namespace Util
              *
              * @param options
              *      Action options. Valid options are:
-             *      OPTION_SCALE_Y
+             *      OPTION_SCALE_Y, OPTION_DURATION
              */
             void bindScroll(
                 ActionType action, int scrolling_motion,

--- a/src/osgEarthUtil/EarthManipulator.cpp
+++ b/src/osgEarthUtil/EarthManipulator.cpp
@@ -1766,7 +1766,7 @@ EarthManipulator::handle(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapt
                 resetMouse( aa );
                 addMouseEvent( ea );
                 action = _settings->getAction( ea.getEventType(), ea.getScrollingMotion(), ea.getModKeyMask() );
-                if ( handleScrollAction( action, 0.2 ) )
+                if ( handleScrollAction( action, action.getDoubleOption(OPTION_DURATION, 0.2) ) )
                     aa.requestRedraw();
                 handled = true;
                 break;


### PR DESCRIPTION
Default value remains at 0.2 seconds, so impact on existing projects is unlikely.