### PR TITLE
OpenGL ES 2.0 fixes

### DIFF
--- a/src/osgEarth/ShaderUtils.cpp
+++ b/src/osgEarth/ShaderUtils.cpp
@@ -317,6 +317,22 @@ void osg_LightSourceParameters::setUniformsFromOsgLight(const osg::Light* light,
                                                       light->getSpecular().z() * frontSpecular.z(),
                                                       light->getSpecular().w() * frontSpecular.w()));
         }
+        else {
+            _frontLightProduct.ambient->set(osg::Vec4(light->getAmbient().x(),
+                                                      light->getAmbient().y(),
+                                                      light->getAmbient().z(),
+                                                      light->getAmbient().w()));
+            
+            _frontLightProduct.diffuse->set(osg::Vec4(light->getDiffuse().x(),
+                                                      light->getDiffuse().y(),
+                                                      light->getDiffuse().z(),
+                                                      light->getDiffuse().w()));
+            
+            _frontLightProduct.specular->set(osg::Vec4(light->getSpecular().x(),
+                                                      light->getSpecular().y(),
+                                                      light->getSpecular().z(),
+                                                      light->getSpecular().w()));
+        }
     }
 }
 

--- a/src/osgEarthAnnotation/AnnotationNode.cpp
+++ b/src/osgEarthAnnotation/AnnotationNode.cpp
@@ -423,11 +423,13 @@ AnnotationNode::applyGeneralSymbology(const Style& style)
                 (render->backfaceCulling() == true? osg::StateAttribute::ON : osg::StateAttribute::OFF) | osg::StateAttribute::OVERRIDE );
         }
 
+#ifndef OSG_GLES2_AVAILABLE
         if ( render->clipPlane().isSet() )
         {
             GLenum mode = GL_CLIP_PLANE0 + render->clipPlane().value();
             getOrCreateStateSet()->setMode(mode, 1);
         }
+#endif
 
         if ( render->order().isSet() || render->renderBin().isSet() )
         {

--- a/src/osgEarthFeatures/FeatureModelSource.cpp
+++ b/src/osgEarthFeatures/FeatureModelSource.cpp
@@ -259,11 +259,13 @@ FeatureNodeFactory::getOrCreateStyleGroup(const Style& style,
                 (render->backfaceCulling() == true ? osg::StateAttribute::ON : osg::StateAttribute::OFF) | osg::StateAttribute::OVERRIDE );
         }
 
+#ifndef OSG_GLES2_AVAILABLE
         if ( render->clipPlane().isSet() )
         {
             GLenum mode = GL_CLIP_PLANE0 + (render->clipPlane().value());
             group->getOrCreateStateSet()->setMode(mode, 1);
         }
+#endif
 
         if ( render->minAlpha().isSet() )
         {

--- a/src/osgEarthUtil/Sky.cpp
+++ b/src/osgEarthUtil/Sky.cpp
@@ -54,6 +54,8 @@ SkyNode::baseInit(const SkyOptions& options)
     _starsVisible = true;
     _minimumAmbient.set(0.0f, 0.0f, 0.0f, 0.0f);
 
+    _lightingUniformsHelper = new UpdateLightingUniformsHelper();
+
     setLighting( osg::StateAttribute::ON );
 
     if ( options.hours().isSet() )


### PR DESCRIPTION
OpenGL ES 2.0 on Windows discussion: http://forum.osgearth.org/OpenGL-ES-2-0-on-Windows-td7587158.html

Some fixes:
* **GL_CLIP_PLANE0** is not available in OpenGL ES 2.0
* **_lightingUniformsHelper** field in **Sky** class is never initialized
* Nodes without Material attribute are shown black because **_frontLightProduct** has zero vectors.

I tested this changes with osgEarth 2.6 version.