### PR TITLE
Improve Profile selection logic in GDAL driver

### DIFF
--- a/src/osgEarth/GeoData.cpp
+++ b/src/osgEarth/GeoData.cpp
@@ -1533,7 +1533,7 @@ namespace
         //Create a dataset from the source image
         GDALDataset* srcDS = createDataSetFromImage(srcImage, srcMinX, srcMinY, srcMaxX, srcMaxY, srcWKT);
 
-        OE_DEBUG << LC << "Source image is " << srcImage->s() << "x" << srcImage->t() << std::endl;
+        OE_DEBUG << LC << "Source image is " << srcImage->s() << "x" << srcImage->t() << " in " << srcWKT << std::endl;
 
 
         if (width == 0 || height == 0)
@@ -1550,7 +1550,7 @@ namespace
                 0);
             GDALDestroyGenImgProjTransformer(transformer);
         }
-	    OE_DEBUG << "Creating warped output of " << width <<"x" << height << std::endl;
+	    OE_DEBUG << "Creating warped output of " << width <<"x" << height << " in " << destWKT << std::endl;
        
         GDALDataset* destDS = createMemDS(width, height, destMinX, destMinY, destMaxX, destMaxY, destWKT);
 

--- a/src/osgEarth/TerrainLayer.cpp
+++ b/src/osgEarth/TerrainLayer.cpp
@@ -656,6 +656,7 @@ TerrainLayer::initTileSource()
     {
         if ( !_profile.valid() && !_tileSourceInitFailed )
         {
+            OE_DEBUG << LC << "Get Profile from tile source" << std::endl;
             _profile = _tileSource->getProfile();
         }
 

--- a/src/osgEarth/TileSource.cpp
+++ b/src/osgEarth/TileSource.cpp
@@ -726,6 +726,8 @@ TileSourceFactory::create(const TileSourceOptions& options)
         OE_WARN << LC << "Failed to load TileSource driver \"" << driver << "\"" << std::endl;
     }
 
+    OE_DEBUG << LC << "Tile source Profile = " << (result->getProfile() ? result->getProfile()->toString() : "NULL") << std::endl;
+
     // apply an Override Profile if provided.
     if ( result && options.profile().isSet() )
     {

--- a/src/osgEarthDrivers/gdal/ReaderWriterGDAL.cpp
+++ b/src/osgEarthDrivers/gdal/ReaderWriterGDAL.cpp
@@ -912,6 +912,10 @@ public:
         else if ( !srcProj.empty() )
         {
             src_srs = SpatialReference::create( srcProj );
+            if ( !src_srs.valid() )
+            {
+                OE_DEBUG << LC << "Cannot create source SRS from its projection info: " << srcProj << std::endl;
+            }
         }
 
         // assert SRS is present
@@ -948,17 +952,26 @@ public:
         if ( warpProfile )
         {
             profile = warpProfile;
+            if ( profile )
+            {
+                OE_DEBUG << LC << INDENT << "Using warp Profile: " << profile->toString() <<  std::endl;
+            }
         }
 
         // If we have an override profile, just take it.
         if ( getProfile() )
         {
             profile = getProfile();
+            if ( profile )
+            {
+                OE_DEBUG << LC << INDENT << "Using override Profile: " << profile->toString() <<  std::endl;
+            }
         }
 
         // If neither a warp nor override profile were provided, work out the profile from the source's own SRS.
         if ( !profile && src_srs->isGeographic() )
         {
+            OE_DEBUG << LC << INDENT << "Creating Profile from source's geographic SRS: " << src_srs->getName() <<  std::endl;
             profile = Profile::create(src_srs.get(), -180.0, -90.0, 180.0, 90.0, 2u, 1u);
             if ( !profile )
             {
@@ -1012,6 +1025,7 @@ public:
         //Get the _geotransform
         if ( getProfile() )
         {
+            OE_DEBUG << LC << INDENT << "Get geotransform from Override Profile" <<  std::endl;
             _geotransform[0] =  getProfile()->getExtent().xMin(); //Top left x
             _geotransform[1] =  getProfile()->getExtent().width() / (double)_warpedDS->GetRasterXSize();//pixel width
             _geotransform[2] =  0;
@@ -1023,6 +1037,7 @@ public:
         }
         else
         {
+            OE_DEBUG << LC << INDENT << "Get geotransform from warped dataset" <<  std::endl;
             _warpedDS->GetGeoTransform(_geotransform);
         }
 
@@ -1123,6 +1138,7 @@ public:
 
         //Set the profile
         setProfile( profile );
+        OE_DEBUG << LC << INDENT << "Set Profile to " << (profile ? profile->toString() : "NULL") <<  std::endl;
 
         return STATUS_OK;
     }


### PR DESCRIPTION
If neither a "warp profile" nor "override profile" are supplied, create a profile from the dataset's own SRS, and return an error if this fails.  Do not fall back to the global geodetic (or global mercator) profile.

Also, add some OE_DEBUG log statements to help users diagnose Profile/SRS issues.

See http://forum.osgearth.org/GDAL-driver-Profile-selection-td7587267.html