### PR TITLE
Allow overriding unRefImageDataAfterApply policy at TileSourceOptions level

### DIFF
--- a/src/osgEarth/Registry
+++ b/src/osgEarth/Registry
@@ -240,7 +240,9 @@ namespace osgEarth
 
         /**
          * Sets the policy for calling osg::Texture::setUnRefImageDataAfterApply
-         * in the osgEarth terrain engine.
+         * in the osgEarth terrain engine. This can also be controlled
+         * individually at for each TileSource via TileSourceOptions. The
+         * options at TileSource level take precedence, if set.
          */
         optional<bool>& unRefImageDataAfterApply() { return _unRefImageDataAfterApply; }
         const optional<bool>& unRefImageDataAfterApply() const { return _unRefImageDataAfterApply; }

--- a/src/osgEarth/TileSource
+++ b/src/osgEarth/TileSource
@@ -91,6 +91,15 @@ namespace osgEarth
         optional<unsigned>& maxDataLevel() { return _maxDataLevel; }
         const optional<unsigned>& maxDataLevel() const { return _maxDataLevel; }
 
+        /**
+         * Sets the policy for calling osg::Texture::setUnRefImageDataAfterApply
+         * in the osgEarth terrain engine. This can also be controlled
+         * globally via Registry, the option at TileSource level takes
+         * precedence, if set.
+         */
+        optional<bool>& unRefImageDataAfterApply() { return _unRefImageDataAfterApply; }
+        const optional<bool>& unRefImageDataAfterApply() const { return _unRefImageDataAfterApply; }
+
     public:
         /** For backwards-compatibility; use minValidValue() instead 
          *  @deprecated */
@@ -124,6 +133,7 @@ namespace osgEarth
         optional<int>            _L2CacheSize;
         optional<bool>           _bilinearReprojection;
         optional<unsigned>       _maxDataLevel;
+        optional<bool>           _unRefImageDataAfterApply;
     };
 
 

--- a/src/osgEarth/TileSource.cpp
+++ b/src/osgEarth/TileSource.cpp
@@ -170,6 +170,7 @@ TileSourceOptions::getConfig() const
     conf.updateIfSet( "l2_cache_size", _L2CacheSize );
     conf.updateIfSet( "bilinear_reprojection", _bilinearReprojection );
     conf.updateIfSet( "max_data_level", _maxDataLevel );
+    conf.updateIfSet( "unref_image_data_after_apply", _unRefImageDataAfterApply );
     conf.updateObjIfSet( "profile", _profileOptions );
     return conf;
 }
@@ -194,6 +195,7 @@ TileSourceOptions::fromConfig( const Config& conf )
     conf.getIfSet( "l2_cache_size", _L2CacheSize );
     conf.getIfSet( "bilinear_reprojection", _bilinearReprojection );
     conf.getIfSet( "max_data_level", _maxDataLevel );
+    conf.getIfSet( "unref_image_data_after_apply", _unRefImageDataAfterApply );
     conf.getObjIfSet( "profile", _profileOptions );
 }
 

--- a/src/osgEarthDrivers/engine_mp/TileModel.cpp
+++ b/src/osgEarthDrivers/engine_mp/TileModel.cpp
@@ -203,7 +203,10 @@ _fallbackData( fallbackData )
 
 
     const optional<bool>& unRefPolicy = Registry::instance()->unRefImageDataAfterApply();
-    if ( unRefPolicy.isSet() )
+    const optional<bool>& layerUnRefPolicy = _layer->getTileSource()->getOptions().unRefImageDataAfterApply();
+    if ( layerUnRefPolicy.isSet() )
+        _texture->setUnRefImageDataAfterApply( layerUnRefPolicy.get() );
+    else if ( unRefPolicy.isSet() )
         _texture->setUnRefImageDataAfterApply( unRefPolicy.get() );
 
     _texture->setWrap( osg::Texture::WRAP_S, osg::Texture::CLAMP_TO_EDGE );


### PR DESCRIPTION
For dynamic `TileSource`s, I think it makes sense to be able to set the `unRefImageDataAfterApply` option individually for such a `TileSource`, instead of having to set it globally at `Registry` level.

See also http://forum.osgearth.org/Dynamic-tile-source-cache-problems-td7587520.html