### PR TITLE
-Separate out up vector logic from normal vector. Use case: If you ha…

### DIFF
--- a/src/osgEarthDrivers/engine_rex/RexEngine.vert.glsl
+++ b/src/osgEarthDrivers/engine_rex/RexEngine.vert.glsl
@@ -14,6 +14,8 @@ uniform vec4 oe_terrain_color;
 out vec4 oe_layer_texc;
 out vec4 oe_layer_tilec;
 out vec4 vp_Color;
+out vec3 vp_UpVector;
+out vec3 vp_Normal;
 
 void oe_rexEngine_vert(inout vec4 vertexModel)
 {
@@ -26,4 +28,6 @@ void oe_rexEngine_vert(inout vec4 vertexModel)
 #ifdef OE_REX_USE_TERRAIN_COLOR
     vp_Color = oe_terrain_color;
 #endif
+	
+	vp_UpVector = gl_NormalMatrix*vp_Normal;
 }

--- a/src/osgEarthDrivers/engine_rex/RexEngine.vert.view.glsl
+++ b/src/osgEarthDrivers/engine_rex/RexEngine.vert.view.glsl
@@ -8,7 +8,7 @@
 // Stage globals
 out vec4 oe_layer_tilec;
 out vec4 vp_Vertex;
-out vec3 vp_Normal;
+out vec3 vp_UpVector;
 
 uniform sampler2D oe_tile_elevationTex;
 uniform mat4      oe_tile_elevationTexMatrix;
@@ -20,5 +20,5 @@ void oe_rexEngine_applyElevation(inout vec4 vertexView)
     float elev = texture(oe_tile_elevationTex, elevc.st).r;
 
     // assumption: vp_Normal is normalized
-    vertexView.xyz += vp_Normal*elev;
+    vertexView.xyz += vp_UpVector*elev;
 }


### PR DESCRIPTION
…ve a GS, the up vector describes the vertex displacement, but the lighting uses a different normal (e.g. grass)