### PR TITLE
Fixes to use VerticalDatums with different units

### DIFF
--- a/src/osgEarth/GeoData.cpp
+++ b/src/osgEarth/GeoData.cpp
@@ -1089,7 +1089,7 @@ GeoExtent::expandToInclude( const GeoExtent& rhs )
 GeoExtent
 GeoExtent::intersectionSameSRS( const GeoExtent& rhs ) const
 {
-    if ( isInvalid() || rhs.isInvalid() || !_srs->isEquivalentTo( rhs.getSRS() ) )
+    if ( isInvalid() || rhs.isInvalid() || !_srs->isHorizEquivalentTo( rhs.getSRS() ) )
         return GeoExtent::INVALID;
 
     if ( !intersects(rhs) )

--- a/src/osgEarth/VerticalDatum
+++ b/src/osgEarth/VerticalDatum
@@ -82,13 +82,13 @@ namespace osgEarth
          * Converts an MSL value (height relative to a mean sea level model) to the
          * corresponding HAE value (height above the model's reference ellipsoid)
          */
-        double msl2hae( double lat_deg, double lon_deg, double msl ) const;
+        virtual double msl2hae( double lat_deg, double lon_deg, double msl ) const;
 
         /**
          * Converts an HAE value (height above the model's reference ellipsoid) to the
          * corresponding MSL value (height relative to a mean sea level model)
          */
-        double hae2msl( double lat_deg, double lon_deg, double hae ) const;
+        virtual double hae2msl(double lat_deg, double lon_deg, double hae) const;
 
 
     public: // properties

--- a/src/osgEarth/VerticalDatum.cpp
+++ b/src/osgEarth/VerticalDatum.cpp
@@ -102,7 +102,7 @@ VerticalDatum::transform(const VerticalDatum* from,
     }
 
     Units fromUnits = from ? from->getUnits() : Units::METERS;
-    Units toUnits = to ? to->getUnits() : fromUnits;
+    Units toUnits = to ? to->getUnits() : Units::METERS;
 
     in_out_z = fromUnits.convertTo(toUnits, in_out_z);
 

--- a/src/osgEarthDrivers/gdal/ReaderWriterGDAL.cpp
+++ b/src/osgEarthDrivers/gdal/ReaderWriterGDAL.cpp
@@ -1629,10 +1629,6 @@ public:
         if (v < getNoDataMinValue()) return false;
         if (v > getNoDataMaxValue()) return false;
 
-        //Check within a sensible range
-        if (v < -32000) return false;
-        if (v > 32000) return false;
-
         return true;
     }
 


### PR DESCRIPTION
Comments:

src/osgEarth/GeoData.cpp
_srs has no VerticalDatum
rhs.getSRS() has VerticalDatum
So only horizontal srs should be compared

src/osgEarth/VerticalDatum
virtual methods for more freedom in VerticalDatum subclassing

src/osgEarth/VerticalDatum.cpp
usually we want output units to be meters

 src/osgEarthDrivers/gdal/ReaderWriterGDAL.cpp
these two deleted lines restrict raw heights and duplicate
if (v < getNoDataMinValue()) return false;
if (v > getNoDataMaxValue()) return false;
