### PR TITLE
Remove radian conversion when using SilverLining SetLongitude and SetLatitude functions

### DIFF
--- a/src/osgEarthDrivers/sky_silverlining/SilverLiningContext.cpp
+++ b/src/osgEarthDrivers/sky_silverlining/SilverLiningContext.cpp
@@ -220,8 +220,8 @@ SilverLiningContext::updateLocation()
 
         ::SilverLining::Location loc;
         loc.SetAltitude ( latLonAlt.z() );
-        loc.SetLongitude( osg::DegreesToRadians(latLonAlt.x()) );
-        loc.SetLatitude ( osg::DegreesToRadians(latLonAlt.y()) );
+        loc.SetLongitude( latLonAlt.x() );
+        loc.SetLatitude ( latLonAlt.y() );
 
         _atmosphere->GetConditions()->SetLocation( loc );
 

--- a/src/osgEarthDrivers/sky_silverlining/SilverLiningNode.cpp
+++ b/src/osgEarthDrivers/sky_silverlining/SilverLiningNode.cpp
@@ -33,9 +33,10 @@
 using namespace osgEarth::SilverLining;
 
 SilverLiningNode::SilverLiningNode(const osgEarth::Map*       map,
-                                   const SilverLiningOptions& options) :
-_options     (options),
-_lastAltitude(DBL_MAX)
+                                   const SilverLiningOptions& options)
+	: SkyNode(options)
+	, _options(options)
+	, _lastAltitude(DBL_MAX)
 {
     // Create a new Light for the Sun.
     _light = new osg::Light();


### PR DESCRIPTION
SilverLining Location SetLongitude and SetLatitude accept degrees and not radians. Removed degrees to radians conversion.