### PR TITLE
Option added to modulate image layer in the splat extention

### DIFF
--- a/src/osgEarthExtensions/splat/Splat.frag.glsl
+++ b/src/osgEarthExtensions/splat/Splat.frag.glsl
@@ -12,6 +12,9 @@
 // define to activate GPU-generated noise instead of a noise texture.
 #pragma vp_define "SPLAT_GPU_NOISE"
 
+// define to activate color image layer mixing.
+#pragma vp_define "SPLAT_USE_COLOR_IMAGE"
+
 // include files
 #pragma include "Splat.types.glsl"
 #pragma include "Splat.frag.common.glsl"
@@ -40,6 +43,14 @@ uniform mat4 oe_terrain_tex_matrix;
 uniform float oe_splat_detailRange;
 uniform float oe_splat_noiseScale;
 uniform float oe_splat_useBilinear; // 1=true, -1=false
+
+#ifdef SPLAT_USE_COLOR_IMAGE
+uniform float oe_splat_color_start_dist;
+uniform float oe_splat_color_ratio;
+uniform sampler2D oe_color_tex;
+uniform mat4 oe_color_tex_mat;
+
+#endif
 
 #ifdef SPLAT_EDIT
 uniform float oe_splat_brightness;
@@ -314,6 +325,14 @@ void oe_splat_complex(inout vec4 color)
     }
 
     color = mix(color, texel, texel.a);
+
+#ifdef SPLAT_USE_COLOR_IMAGE
+	vec3 groundColor = texture(oe_color_tex, (oe_color_tex_mat*oe_layer_tilec).st).rgb;
+	float fade_dist = oe_splat_color_start_dist/2.0 + 0.1;
+	float fade = clamp(oe_splat_range, oe_splat_color_start_dist, oe_splat_color_start_dist + fade_dist);
+	fade = (fade-oe_splat_color_start_dist)/fade_dist;
+	color.rgb = mix(color.rgb, color.rgb*(2.0*groundColor), oe_splat_color_ratio*fade);
+#endif
 
     // uncomment to visualize slope.
     //color.rgba = vec4(env.slope,0,0,1);

--- a/src/osgEarthExtensions/splat/SplatTerrainEffect.cpp
+++ b/src/osgEarthExtensions/splat/SplatTerrainEffect.cpp
@@ -150,6 +150,15 @@ SplatTerrainEffect::onInstall(TerrainEngineNode* engine)
             package.define( "SPLAT_GPU_NOISE",   _gpuNoise );
             package.define( "OE_USE_NORMAL_MAP", engine->normalTexturesRequired() );
 
+			bool use_color_map = (::getenv("SPLAT_USE_COLOR_IMAGE") != 0L);
+			package.define( "SPLAT_USE_COLOR_IMAGE", use_color_map );
+			if(use_color_map)
+			{
+				stateset->addUniform(new osg::Uniform("oe_splat_color_ratio",  0.5f));
+				stateset->addUniform(new osg::Uniform("oe_splat_color_start_dist", 1000.0f));
+			}
+
+
             package.replace( "$COVERAGE_TEXMAT_UNIFORM", _coverageLayer->shareTexMatUniformName().get() );
             
             VirtualProgram* vp = VirtualProgram::getOrCreate(stateset);

--- a/tests/splat-imagery.bat
+++ b/tests/splat-imagery.bat
@@ -1,0 +1,12 @@
+setlocal
+set SPLAT_USE_COLOR_IMAGE=1
+%OSG_EARTH_HOME%\bin\osgearth_viewer splat-imagery.earth ^
+	--logdepth2 ^
+	--sky ^
+	--uniform oe_splat_color_ratio 0 1 ^
+	--uniform oe_splat_color_start_dist 0 20000 ^
+	--window 100 100 800 600 ^
+	%*
+endlocal
+
+	

--- a/tests/splat-test_imagery.earth
+++ b/tests/splat-test_imagery.earth
@@ -1,0 +1,72 @@
+<!--
+|  Texture splatting test.
+|
+|  Run with splat.bat, (or splat-edit.bat for tweakery)
+-->
+
+<map>
+     
+    <options>
+        <terrain driver="mp" max_lod="18" min_normal_map_lod="7"/>
+		<!--<cache type="filesystem">
+            <path>L:/OSGEarthCache</path>
+        </cache>-->
+    </options>
+    
+    <elevation name="readymap_elevation" driver="tms" enabled="true">
+        <url>http://readymap.org/readymap/tiles/1.0.0/116/</url>
+    </elevation>
+	
+	
+    
+    <!--<elevation driver="gdal" enabled="false">
+        <url>H:/data/ned/ned19_n47x00_w121x75_wa_mounttrainier_2008/ned19_n47x00_w121x75_wa_mounttrainier_2008.tif</url>
+    </elevation>-->
+    
+    <image name="GLOBCOVER" driver="gdal" shared="true" visible="false" coverage="true" enabled="true">
+        <url>c:/temp/GLOBCOVER_L4_200901_200912_V2.3_tiled.tif</url>
+        <cache_policy usage="none"/>
+    </image>
+	
+	 <image name="readymap_imagery" driver="tms" shared="true" visible="false" max_data_level="9">
+        <url>http://readymap.org/readymap/tiles/1.0.0/22/</url>
+		<shared_sampler>oe_color_tex</shared_sampler>
+        <shared_matrix>oe_color_tex_mat</shared_matrix>
+     </image>
+
+    <extensions>
+        
+        <normalmap/>    
+
+        <!--
+        <bumpmap>
+            <image>../data/rock_hard.jpg</image>
+            <octaves>16</octaves>
+            <intensity>1.0</intensity>
+        </bumpmap>
+        -->
+    
+        <splat>
+            <coverage>GLOBCOVER</coverage>
+            <legend>../data/splat/GLOBCOVER_legend.xml</legend>
+            <catalog>../data/splat/splat_catalog.xml</catalog>
+        </splat>
+        
+        <viewpoints>
+		    <viewpoint name="San Francisco" heading="8.806974516644791" height="4465.397310772911" lat="57.266666" long="13.616667" pitch="-34.79540299384382" range="78142.53643278375" srs="+proj=longlat +ellps=WGS84 +towgs84=0,0,0,0,0,0,0 +no_defs " />
+            <viewpoint name="Wash St. 430K" heading="-1.002577141807595" height="3694.875054217875" lat="46.85393268075167" long="-121.7764141794478" pitch="-89.85464953482169" range="426454.3850159062"/>
+            <viewpoint name="Mt R. Nadir 30K" heading="0.5013023037097585" height="4101.627114404924" lat="46.85909894548915" long="-121.7598368518208" pitch="-89.43249895879129" range="29029.34246828893"/>
+            <viewpoint name="Mt R. Oblique 30K" heading="17.33521725357022" height="2462.60273069609" lat="46.82181702111031" long="-121.7814936386096" pitch="-21.29241356548601" range="23926.75258864516"/>
+            <viewpoint name="Mt R. Closeup" heading="-109.6842970297122" height="3843.486737414263" lat="46.85528453766688" long="-121.7455004166102" pitch="-4.617466338845979" range="951.4780720092711"/>
+            <viewpoint name="Mt R. Trees" heading="-98.36122712710565" height="1639.304918398149" lat="46.78673277044066" long="-121.743286318636" pitch="-10.85365380742088" range="257.5853045645545"/>
+            <viewpoint name="Nepal" heading="-72.70835146844568" height="6334.845537136309" lat="27.94213038800919" long="86.9936567556778" pitch="-18.63803872963365" range="13611.24948464565"/>
+            <viewpoint name="Nepal NF" heading="-49.14546953546358" height="6334.332569343038" lat="27.9421778947837" long="86.9935949004298" pitch="-3.643325527310435" range="13302.81192964212"/>
+            <viewpoint name="Matterhorn" heading="-1.429462844200832" height="2282.858508689329" lat="45.95106319557" long="7.642741711675961" pitch="-25.12269405854052" range="26690.10606054494"/>
+            <viewpoint name="blocky normals" heading="41.48089457252855" height="-0.00066352728754282" lat="27.93663025540099" long="87.00142602046928" pitch="-43.11163222073184" range="31796.01501911692"/>
+        </viewpoints>
+        
+        <sky driver="simple" hours="18.6" atmospheric_lighting="true"/>
+        
+    </extensions>
+
+</map>


### PR DESCRIPTION
Environment variable option added to the splat extention to include imagery in the splat fragment shader. This way the we get some color variation to break up the tiling effects from the detail textures.

No imagery
![splat02](https://cloud.githubusercontent.com/assets/8537351/8605291/89ed1c3a-2684-11e5-8ee5-30bd0d8dcc91.jpg)

Readymap imagery modulated
![splat01](https://cloud.githubusercontent.com/assets/8537351/8605290/89eb8c76-2684-11e5-9482-36dc243d1e98.jpg)
