### PR TITLE
KML fixes

### DIFF
--- a/src/osgEarthDrivers/kml/KML_Geometry
+++ b/src/osgEarthDrivers/kml/KML_Geometry
@@ -32,8 +32,8 @@ namespace osgEarth_kml
         KML_Geometry() : _extrude(false), _tessellate(false) { }
         virtual void parseCoords( xml_node<>* node, KMLContext& cx );
         virtual void parseStyle( xml_node<>* node, KMLContext& cs, Style& style );
-        virtual void build( xml_node<>* node, KMLContext& cx, const Style& baseStyle );
-        void buildChild( xml_node<>* node, KMLContext& cx, const Style& baseStyle );
+        virtual void build( xml_node<>* node, KMLContext& cx, Style& style );
+        void buildChild( xml_node<>* node, KMLContext& cx, Style& style );
         osg::ref_ptr<Geometry> _geom;
         bool _extrude, _tessellate;
     private:    

--- a/src/osgEarthDrivers/kml/KML_Geometry.cpp
+++ b/src/osgEarthDrivers/kml/KML_Geometry.cpp
@@ -28,18 +28,17 @@
 using namespace osgEarth_kml;
 
 void 
-KML_Geometry::build( xml_node<>* parent, KMLContext& cx, const Style& baseStyle)
+KML_Geometry::build( xml_node<>* parent, KMLContext& cx, Style& style)
 {
 	for (xml_node<>* node = parent->first_node(); node; node = node->next_sibling())
 	{
-		buildChild(node, cx, baseStyle);
+		buildChild(node, cx, style);
 	}
 }
 
 void
-KML_Geometry::buildChild( xml_node<>* node, KMLContext& cx, const Style& baseStyle)
+KML_Geometry::buildChild( xml_node<>* node, KMLContext& cx, Style& style)
 {
-    Style style = baseStyle;
 	std::string name = toLower(node->name());
     if ( name == "point" )
     {

--- a/src/osgEarthDrivers/kml/KML_Placemark.cpp
+++ b/src/osgEarthDrivers/kml/KML_Placemark.cpp
@@ -95,15 +95,8 @@ KML_Placemark::build( xml_node<>* node, KMLContext& cx )
                 IconSymbol*     icon  = style.get<IconSymbol>();
                 TextSymbol*     text  = style.get<TextSymbol>();
 
-                if ( !text && cx._options->defaultTextSymbol().valid() )
-                    text = cx._options->defaultTextSymbol().get();
-
                 // the annotation name:
                 std::string name = getValue(node, "name");
-                if ( text && !name.empty() )
-                {
-                    text->content()->setLiteral( name );
-                }
 
                 AnnotationNode* featureNode = 0L;
                 AnnotationNode* iconNode    = 0L;
@@ -143,9 +136,19 @@ KML_Placemark::build( xml_node<>* node, KMLContext& cx )
                     }
 
                     // is there a label?
-                    else if ( !text && !name.empty() )
+                    else if ( !name.empty() )
                     {
-                        text = style.getOrCreate<TextSymbol>();
+                        if ( !text && cx._options->defaultTextSymbol().valid() )
+                        {
+                            text = cx._options->defaultTextSymbol().get();
+                            style.addSymbol( text );
+
+                        }
+                        else
+                        {
+                            text = style.getOrCreate<TextSymbol>();
+                            text->encoding() = TextSymbol::ENCODING_UTF8;
+                        }
                         text->content()->setLiteral( name );
                     }
 


### PR DESCRIPTION
1) Style was passed to KML_Geometry by const reference. Then KML_Geometry modified the style copy. So AltitudySymbol and ModelSymbols were completely ignored during geometry creation step.

I've changed reference to non-const reference to take into account the style changes.

2) Default text symbol was not added to style for PlaceNode.
```
if ( !text && cx._options->defaultTextSymbol().valid() )
    text = cx._options->defaultTextSymbol().get();
```

3) I suggest to use UTF8 as default encoding for KML files.
```
text = style.getOrCreate<TextSymbol>();
text->encoding() = TextSymbol::ENCODING_UTF8;
```