### PR TITLE
osgearth 2.7rc1 Android build

### DIFF
--- a/src/osgEarth/Decluttering.cpp
+++ b/src/osgEarth/Decluttering.cpp
@@ -87,7 +87,7 @@ namespace
 
     typedef std::map<const osg::Drawable*, DrawableInfo> DrawableMemory;
     
-    typedef std::pair<const osg::Node*, osg::BoundingBoxd> RenderLeafBox;
+    typedef std::pair<const osg::Node*, osg::BoundingBox> RenderLeafBox;
 
     // Data structure stored one-per-View.
     struct PerCamInfo

--- a/src/osgEarth/PhongLightingEffect.cpp
+++ b/src/osgEarth/PhongLightingEffect.cpp
@@ -26,6 +26,7 @@
 #include <osgEarth/ShaderFactory>
 #include <osgEarth/StringUtils>
 #include <osgEarth/VirtualProgram>
+#include <osg/Light>
 
 using namespace osgEarth;
 

--- a/src/osgEarth/ThreadingUtils.cpp
+++ b/src/osgEarth/ThreadingUtils.cpp
@@ -38,6 +38,8 @@ unsigned osgEarth::Threading::getCurrentThreadId()
   return (unsigned)::GetCurrentThreadId();
 #elif __APPLE__
   return ::syscall(SYS_thread_selfid);
+#elif __ANDROID__
+  return gettid();
 #else
   return (unsigned)::syscall(SYS_gettid);
 #endif

--- a/src/osgEarthDrivers/script_engine_duktape/duktape.h
+++ b/src/osgEarthDrivers/script_engine_duktape/duktape.h
@@ -200,7 +200,8 @@ static __inline__ unsigned long long duk_rdtsc(void) {
 #if defined(i386) || defined(__i386) || defined(__i386__) || \
     defined(__i486__) || defined(__i586__) || defined(__i686__) || \
     defined(__IA32__) || defined(_M_IX86) || defined(__X86__) || \
-    defined(_X86_) || defined(__THW_INTEL__) || defined(__I86__)
+    defined(_X86_) || defined(__THW_INTEL__) || defined(__I86__) || \
+    defined(__ANDROID__)
 #define DUK_F_X86
 #endif
 

--- a/src/osgEarthUtil/LogarithmicDepthBuffer.cpp
+++ b/src/osgEarthUtil/LogarithmicDepthBuffer.cpp
@@ -52,14 +52,14 @@ namespace
     {
         osg::ref_ptr<osg::Uniform>              _uniform;
         osg::ref_ptr<osg::Camera::DrawCallback> _next;
-        float                                   _C;
+        float                                   _coeff;
 
         SetFarPlaneUniformCallback(osg::Uniform*              uniform,
                                    osg::Camera::DrawCallback* next )
         {
             _uniform = uniform;
             _next    = next;
-            _C       = 1.0f;
+            _coeff   = 1.0f;
         }
 
         void operator () (osg::RenderInfo& renderInfo) const
@@ -70,7 +70,7 @@ namespace
             {
                 float vfov, ar, n, f;
                 proj.getPerspective(vfov, ar, n, f);
-                float fc = (float)(2.0/LOG2(_C*f+1.0));
+                float fc = (float)(2.0/LOG2(_coeff*f+1.0));
                 _uniform->set( fc );
             }
             else // ortho


### PR DESCRIPTION
This pull request contains five changes I had to make to get the 2.7rc1 branch to build for Android, but I still have rendering issues to investigate. Two of these changes I am not particularly happy with and probably require some discussion.

### duktape.h
Duktape was failing to compile because it couldn't determine `intptr` type (duktape.h, line 1006). I followed the #defines back up to the change and check for `__ANDROID__` in the `DUK_F_X86` conditions. This is fine for us because we are only compiling for 32bit platforms. The Duktape documentation says that on Android it needs to be compiled with `-std=c99`, however adding this to my C_FLAGS didn't solve the problem. I couldn't find way to check for 64bit Android at compile time, perhaps `(defined(__ANDROID__) && !defined(__x86_64__))` would work, but I didn't check. There is also the runtime [cpufeatures library](https://developer.android.com/ndk/guides/cpu-features.html). This is probably a problem for the duktape developers. I couldn't spot any CMAKE flags to disable duktape.

### PhongLightingEffect.cpp
> src/osgEarth/PhongLightingEffect.cpp:155:79: error: `GL_LIGHTING` was not declared in this scope

We had the same issue on Windows, `GL_LIGHTING` doesn't exist on GLES2. `<osg/Light>` defines `GL_LIGHTING` if it is not already, allowing us to compile, but I imagine this is the cause of our rendering issues.
