### PR TITLE
KML and AutoClipPlaneHandler fixes

### DIFF
--- a/src/osgEarthDrivers/kml/KML_Feature.cpp
+++ b/src/osgEarthDrivers/kml/KML_Feature.cpp
@@ -86,10 +86,7 @@ KML_Feature::build( xml_node<>* node, KMLContext& cx, osg::Node* working )
             xml_node<>* data = extdata->first_node("data", 0, false);
             if ( data )
             {
-			    for (xml_node<>* n = data->first_node(); n; n = n->next_sibling())
-			    {
-    				working->setUserValue(getValue(n, "name"), getValue(n, "value"));
-			    }
+                working->setUserValue(getValue(data, "name"), getValue(data, "value"));			    
             }
         }
     }

--- a/src/osgEarthDrivers/kml/KML_Placemark.cpp
+++ b/src/osgEarthDrivers/kml/KML_Placemark.cpp
@@ -26,6 +26,8 @@
 #include <osgEarthAnnotation/ModelNode>
 #include <osgEarthAnnotation/LocalGeometryNode>
 #include <osgEarth/Decluttering>
+#include <osgEarth/ObjectIndex>
+#include <osgEarth/Registry>
 
 #include <osg/Depth>
 #include <osgDB/WriteFile>
@@ -181,6 +183,21 @@ KML_Placemark::build( xml_node<>* node, KMLContext& cx )
 
                     Feature* feature = new Feature(geom, cx._srs.get(), style);
                     featureNode = new FeatureNode( cx._mapNode, feature );
+                }
+
+                if ( iconNode )
+                {
+                    Registry::objectIndex()->tagNode( iconNode, iconNode );
+                }
+
+                if ( modelNode )
+                {
+                    Registry::objectIndex()->tagNode( modelNode, modelNode );
+                }
+
+                if ( featureNode )
+                {
+                    Registry::objectIndex()->tagNode( featureNode, featureNode );
                 }
 
 

--- a/src/osgEarthDrivers/kml/rapidxml_ext.hpp
+++ b/src/osgEarthDrivers/kml/rapidxml_ext.hpp
@@ -33,8 +33,19 @@ inline std::string getChildValue(xml_node<>* node, const std::string& key)
 		xml_node<>* child = node->first_node(key.c_str(), 0, false);
 		if (child)
 		{
-			return child->value();
-		}
+            if (child->value_size() > 0)
+            {
+                return child->value();
+            }
+            else //Try to read CDATA node
+            {
+                child = child->first_node();
+                if (child)
+                {
+                    return child->value();
+                }
+            }
+		}                
 	}
 	return "";
 }

--- a/src/osgEarthUtil/AutoClipPlaneHandler.cpp
+++ b/src/osgEarthUtil/AutoClipPlaneHandler.cpp
@@ -221,7 +221,7 @@ AutoClipPlaneCullCallback::operator()( osg::Node* node, osg::NodeVisitor* nv )
                 CustomProjClamper* c = static_cast<CustomProjClamper*>(clamper.get());
 
                 osg::Vec3d eye, center, up;
-                cam->getViewMatrixAsLookAt( eye, center, up );
+                cv->getModelViewMatrix()->getLookAt( eye, center, up );
 
                 // clamp the far clipping plane to the approximate horizon distance
                 if ( _autoFarPlaneClamping )


### PR DESCRIPTION
Fixed eye computation in AutoClipPlaneHandler to work under RTT camera.

Minor KML fixes: read CDATA node, read extended data.
Added KML annotations to ObjectIndex.