### PR TITLE
Quote layer name for VRT files

### DIFF
--- a/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp
+++ b/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp
@@ -89,10 +89,11 @@ _filters          ( filters )
         std::string driverName = OGR_Dr_GetName( OGR_DS_GetDriver( dsHandle ) );             
         // Quote the layer name if it is a shapefile, so we can handle any weird filenames like those with spaces or hyphens.
         // Or quote any layers containing spaces for PostgreSQL
-        if (driverName == "ESRI Shapefile" || from.find(" ") != std::string::npos)
-        {                        
+        if (driverName == "ESRI Shapefile" || driverName == "VRT" ||
+            from.find(" ") != std::string::npos)
+        {
             std::string delim = "\"";
-            from = delim + from + delim;                    
+            from = delim + from + delim;
         }
 
         if ( _query.expression().isSet() )


### PR DESCRIPTION
This fixes a bug where using a csv/vrt file pair with the ogr feature driver would cause a SQL Expression error if the file name contained a hyphen.