### PR TITLE
对于空间标注信息其实 style的iconSymbol里面已经包含了

### DIFF
--- a/src/osgEarthAnnotation/PlaceNode.cpp
+++ b/src/osgEarthAnnotation/PlaceNode.cpp
@@ -349,12 +349,6 @@ PlaceNode::getConfig() const
     conf.add   ( "text",   _text );
     conf.addObj( "style",  _style );
     conf.addObj( "position", getPosition() );
-    if ( _image.valid() ) {
-        if ( !_image->getFileName().empty() )
-            conf.add( "icon", _image->getFileName() );
-        else if ( !_image->getName().empty() )
-            conf.add( "icon", _image->getName() );
-    }
-
+    
     return conf;
 }


### PR DESCRIPTION
去除冗余信息，Don't need to save "icon"  this  style  IconSymbol is saved.