### PR TITLE
Backdrop type and implementation optionals added to TextSymbol.

### DIFF
--- a/src/osgEarthAnnotation/AnnotationUtils.cpp
+++ b/src/osgEarthAnnotation/AnnotationUtils.cpp
@@ -87,13 +87,13 @@ AnnotationUtils::convertTextSymbolEncoding (const TextSymbol::Encoding encoding)
     return text_encoding;
 }
 
-osg::Drawable* 
+osg::Drawable*
 AnnotationUtils::createTextDrawable(const std::string& text,
                                     const TextSymbol*  symbol,
-                                    const osg::BoundingBox& box)                                    
+                                    const osg::BoundingBox& box)
 {
     osgText::Text* t = new osgText::Text();
-    
+
     osgText::String::Encoding text_encoding = osgText::String::ENCODING_UNDEFINED;
     if ( symbol && symbol->encoding().isSet() )
     {
@@ -162,17 +162,17 @@ AnnotationUtils::createTextDrawable(const std::string& text,
         pos.x() = box.xMin();
         pos.y() = box.yMax();
         break;
-        
+
     case osgText::Text::CENTER_TOP:
         pos.x() = box.center().x();
         pos.y() = box.yMin();
-        break;        
+        break;
     case osgText::Text::CENTER_BOTTOM:
     case osgText::Text::CENTER_BOTTOM_BASE_LINE:
     case osgText::Text::CENTER_BASE_LINE:
         pos.x() = box.center().x();
         pos.y() = box.yMax();
-        break;        
+        break;
     case osgText::Text::CENTER_CENTER:
     default:
         pos = box.center();
@@ -218,7 +218,19 @@ AnnotationUtils::createTextDrawable(const std::string& text,
     if ( symbol && symbol->halo().isSet() )
     {
         t->setBackdropColor( symbol->halo()->color() );
-        t->setBackdropType( osgText::Text::OUTLINE );
+        if ( symbol->haloBackdropType().isSet() )
+        {
+            t->setBackdropType( *symbol->haloBackdropType() );
+        }
+        else
+        {
+            t->setBackdropType( osgText::Text::OUTLINE );
+        }
+
+        if ( symbol->haloImplementation().isSet() )
+        {
+            t->setBackdropImplementation( *symbol->haloImplementation() );
+        }
 
         if ( symbol->haloOffset().isSet() )
         {
@@ -266,7 +278,7 @@ AnnotationUtils::createImageGeometry(osg::Image*       image,
 
     // set up the geoset.
     osg::Geometry* geom = new osg::Geometry();
-    geom->setUseVertexBufferObjects(true);    
+    geom->setUseVertexBufferObjects(true);
     geom->setStateSet(dstate);
 
     float s = scale * image->s();
@@ -325,7 +337,7 @@ AnnotationUtils::createHighlightUniform()
     return u;
 }
 
-osg::Node* 
+osg::Node*
 AnnotationUtils::createSphere( float r, const osg::Vec4& color, float maxAngle )
 {
     osg::Geometry* geom = new osg::Geometry();
@@ -384,7 +396,7 @@ AnnotationUtils::createSphere( float r, const osg::Vec4& color, float maxAngle )
       return geode;
 }
 
-osg::Node* 
+osg::Node*
 AnnotationUtils::createHemisphere( float r, const osg::Vec4& color, float maxAngle )
 {
     osg::Geometry* geom = new osg::Geometry();
@@ -439,10 +451,10 @@ AnnotationUtils::createHemisphere( float r, const osg::Vec4& color, float maxAng
 
 // constructs an ellipsoidal mesh
 osg::Geometry*
-AnnotationUtils::createEllipsoidGeometry(float xRadius, 
+AnnotationUtils::createEllipsoidGeometry(float xRadius,
                                          float yRadius,
                                          float zRadius,
-                                         const osg::Vec4f& color, 
+                                         const osg::Vec4f& color,
                                          float maxAngle,
                                          float minLat,
                                          float maxLat,
@@ -494,7 +506,7 @@ AnnotationUtils::createEllipsoidGeometry(float xRadius,
             float sin_u = sinf(u);
             float cos_v = cosf(v);
             float sin_v = sinf(v);
-            
+
             verts->push_back(osg::Vec3(
                 xRadius * cos_u * cos_v,
                 yRadius * sin_u * cos_v,
@@ -538,11 +550,11 @@ AnnotationUtils::createEllipsoidGeometry(float xRadius,
     return geom;
 }
 
-osg::Node* 
-AnnotationUtils::createEllipsoid(float xRadius, 
+osg::Node*
+AnnotationUtils::createEllipsoid(float xRadius,
                                  float yRadius,
                                  float zRadius,
-                                 const osg::Vec4f& color, 
+                                 const osg::Vec4f& color,
                                  float maxAngle,
                                  float minLat,
                                  float maxLat,
@@ -573,7 +585,7 @@ AnnotationUtils::createEllipsoid(float xRadius,
     return geode;
 }
 
-osg::Node* 
+osg::Node*
 AnnotationUtils::createFullScreenQuad( const osg::Vec4& color )
 {
     osg::Geometry* geom = new osg::Geometry();
@@ -727,7 +739,7 @@ AnnotationUtils::installTwoPassAlpha(osg::Node* node)
 }
 
 
-bool 
+bool
 AnnotationUtils::styleRequiresAlphaBlending( const Style& style )
 {
     if (style.has<PolygonSymbol>() &&
@@ -771,7 +783,7 @@ AnnotationUtils::getAltitudePolicy(const Style& style, AltitudePolicy& out)
         const AltitudeSymbol* alt = style.get<AltitudeSymbol>();
         if ( alt )
         {
-            if (alt->clamping() == AltitudeSymbol::CLAMP_TO_TERRAIN || 
+            if (alt->clamping() == AltitudeSymbol::CLAMP_TO_TERRAIN ||
                 alt->clamping() == AltitudeSymbol::CLAMP_RELATIVE_TO_TERRAIN )
             {
                 out.sceneClamping = alt->technique() == AltitudeSymbol::TECHNIQUE_SCENE;

--- a/src/osgEarthSymbology/TextSymbol
+++ b/src/osgEarthSymbology/TextSymbol
@@ -20,6 +20,7 @@
 #ifndef OSGEARTHSYMBOLOGY_TEXT_SYMBOL_H
 #define OSGEARTHSYMBOLOGY_TEXT_SYMBOL_H 1
 
+#include <osgText/Text>
 #include <osgEarthSymbology/Symbol>
 #include <osgEarthSymbology/Expression>
 #include <osgEarthSymbology/Fill>
@@ -53,16 +54,16 @@ namespace osgEarth { namespace Symbology
             ALIGN_RIGHT_TOP,
             ALIGN_RIGHT_CENTER,
             ALIGN_RIGHT_BOTTOM,
-            
+
             ALIGN_LEFT_BASE_LINE,
             ALIGN_CENTER_BASE_LINE,
             ALIGN_RIGHT_BASE_LINE,
-        
+
             ALIGN_LEFT_BOTTOM_BASE_LINE,
             ALIGN_CENTER_BOTTOM_BASE_LINE,
             ALIGN_RIGHT_BOTTOM_BASE_LINE,
-        
-            ALIGN_BASE_LINE = ALIGN_LEFT_BASE_LINE /// default.        
+
+            ALIGN_BASE_LINE = ALIGN_LEFT_BASE_LINE /// default.
         };
 
         enum Layout {
@@ -90,6 +91,14 @@ namespace osgEarth { namespace Symbology
         /** Text outline offset */
         optional<float>& haloOffset() { return _haloOffset; }
         const optional<float>& haloOffset() const { return _haloOffset; }
+
+        /** Halo backdrop type */
+        optional<osgText::Text::BackdropType>& haloBackdropType() { return _haloBackdropType; }
+        const optional<osgText::Text::BackdropType>& haloBackdropType() const { return _haloBackdropType; }
+
+        /** Halo backdrop implementation */
+        optional<osgText::Text::BackdropImplementation>& haloImplementation() { return _haloImplementation; }
+        const optional<osgText::Text::BackdropImplementation>& haloImplementation() const { return _haloImplementation; }
 
         /** Name of text font. */
         optional<std::string>& font() { return _font; }
@@ -152,6 +161,8 @@ namespace osgEarth { namespace Symbology
         optional<Fill>              _fill;
         optional<Stroke>            _halo;
         optional<float>             _haloOffset;
+        optional<osgText::Text::BackdropType> _haloBackdropType;
+        optional<osgText::Text::BackdropImplementation> _haloImplementation;
         optional<std::string>       _font;
         optional<NumericExpression> _size;
         optional<StringExpression>  _content;

--- a/src/osgEarthSymbology/TextSymbol.cpp
+++ b/src/osgEarthSymbology/TextSymbol.cpp
@@ -32,6 +32,8 @@ Symbol(rhs, copyop),
 _fill(rhs._fill),
 _halo(rhs._halo),
 _haloOffset(rhs._haloOffset),
+_haloBackdropType(rhs._haloBackdropType),
+_haloImplementation(rhs._haloImplementation),
 _font(rhs._font),
 _size(rhs._size),
 _content(rhs._content),
@@ -53,6 +55,8 @@ Symbol                ( conf ),
 _fill                 ( Fill( 1, 1, 1, 1 ) ),
 _halo                 ( Stroke( 0.3, 0.3, 0.3, 1) ),
 _haloOffset           ( 0.0625f ),
+_haloBackdropType     ( osgText::Text::OUTLINE ),
+_haloImplementation   ( osgText::Text::DELAYED_DEPTH_WRITES ),
 _size                 ( 16.0f ),
 _removeDuplicateLabels( false ),
 _alignment            ( ALIGN_BASE_LINE ),
@@ -66,7 +70,7 @@ _occlusionCullAltitude( 200000 )
     mergeConfig(conf);
 }
 
-Config 
+Config
 TextSymbol::getConfig() const
 {
     Config conf = Symbol::getConfig();
@@ -74,6 +78,21 @@ TextSymbol::getConfig() const
     conf.addObjIfSet( "fill", _fill );
     conf.addObjIfSet( "halo", _halo );
     conf.addIfSet( "halo_offset", _haloOffset );
+    conf.addIfSet( "halo_backdrop_type", "bottom_right",  _haloBackdropType, osgText::Text::DROP_SHADOW_BOTTOM_RIGHT );
+    conf.addIfSet( "halo_backdrop_type", "center_right",  _haloBackdropType, osgText::Text::DROP_SHADOW_CENTER_RIGHT );
+    conf.addIfSet( "halo_backdrop_type", "top_right",     _haloBackdropType, osgText::Text::DROP_SHADOW_TOP_RIGHT );
+    conf.addIfSet( "halo_backdrop_type", "bottom_center", _haloBackdropType, osgText::Text::DROP_SHADOW_BOTTOM_CENTER );
+    conf.addIfSet( "halo_backdrop_type", "top_center",    _haloBackdropType, osgText::Text::DROP_SHADOW_TOP_CENTER );
+    conf.addIfSet( "halo_backdrop_type", "bottom_left",   _haloBackdropType, osgText::Text::DROP_SHADOW_BOTTOM_LEFT );
+    conf.addIfSet( "halo_backdrop_type", "center_left",   _haloBackdropType, osgText::Text::DROP_SHADOW_CENTER_LEFT );
+    conf.addIfSet( "halo_backdrop_type", "top_left",      _haloBackdropType, osgText::Text::DROP_SHADOW_TOP_LEFT );
+    conf.addIfSet( "halo_backdrop_type", "outline",       _haloBackdropType, osgText::Text::OUTLINE );
+    conf.addIfSet( "halo_backdrop_type", "none",          _haloBackdropType, osgText::Text::NONE );
+    conf.addIfSet( "halo_implementation", "polygon_offset",       _haloImplementation, osgText::Text::POLYGON_OFFSET );
+    conf.addIfSet( "halo_implementation", "no_depth_buffer",      _haloImplementation, osgText::Text::NO_DEPTH_BUFFER );
+    conf.addIfSet( "halo_implementation", "depth_range",          _haloImplementation, osgText::Text::DEPTH_RANGE );
+    conf.addIfSet( "halo_implementation", "stencil_buffer",       _haloImplementation, osgText::Text::STENCIL_BUFFER );
+    conf.addIfSet( "halo_implementation", "delayed_depth_writes", _haloImplementation, osgText::Text::DELAYED_DEPTH_WRITES );
     conf.addIfSet( "font", _font );
     conf.addObjIfSet( "size", _size );
     conf.addObjIfSet( "content", _content );
@@ -120,12 +139,27 @@ TextSymbol::getConfig() const
     return conf;
 }
 
-void 
+void
 TextSymbol::mergeConfig( const Config& conf )
 {
     conf.getObjIfSet( "fill", _fill );
     conf.getObjIfSet( "halo", _halo );
     conf.getIfSet( "halo_offset", _haloOffset );
+    conf.getIfSet( "halo_backdrop_type", "right_bottom",  _haloBackdropType, osgText::Text::DROP_SHADOW_BOTTOM_RIGHT );
+    conf.getIfSet( "halo_backdrop_type", "right_center",  _haloBackdropType, osgText::Text::DROP_SHADOW_CENTER_RIGHT );
+    conf.getIfSet( "halo_backdrop_type", "right_top",     _haloBackdropType, osgText::Text::DROP_SHADOW_TOP_RIGHT );
+    conf.getIfSet( "halo_backdrop_type", "center_bottom", _haloBackdropType, osgText::Text::DROP_SHADOW_BOTTOM_CENTER );
+    conf.getIfSet( "halo_backdrop_type", "center_top",    _haloBackdropType, osgText::Text::DROP_SHADOW_TOP_CENTER );
+    conf.getIfSet( "halo_backdrop_type", "left_bottom",   _haloBackdropType, osgText::Text::DROP_SHADOW_BOTTOM_LEFT );
+    conf.getIfSet( "halo_backdrop_type", "left_center",   _haloBackdropType, osgText::Text::DROP_SHADOW_CENTER_LEFT );
+    conf.getIfSet( "halo_backdrop_type", "left_top",      _haloBackdropType, osgText::Text::DROP_SHADOW_TOP_LEFT );
+    conf.getIfSet( "halo_backdrop_type", "outline",       _haloBackdropType, osgText::Text::OUTLINE );
+    conf.getIfSet( "halo_backdrop_type", "none",          _haloBackdropType, osgText::Text::NONE );
+    conf.getIfSet( "halo_implementation", "polygon_offset",       _haloImplementation, osgText::Text::POLYGON_OFFSET );
+    conf.getIfSet( "halo_implementation", "no_depth_buffer",      _haloImplementation, osgText::Text::NO_DEPTH_BUFFER );
+    conf.getIfSet( "halo_implementation", "depth_range",          _haloImplementation, osgText::Text::DEPTH_RANGE );
+    conf.getIfSet( "halo_implementation", "stencil_buffer",       _haloImplementation, osgText::Text::STENCIL_BUFFER );
+    conf.getIfSet( "halo_implementation", "delayed_depth_writes", _haloImplementation, osgText::Text::DELAYED_DEPTH_WRITES );
     conf.getIfSet( "font", _font );
     conf.getObjIfSet( "size", _size );
     conf.getObjIfSet( "content", _content );
@@ -194,44 +228,78 @@ TextSymbol::parseSLD(const Config& c, Style& style)
     else if ( match(c.key(), "text-halo-offset") ) {
         style.getOrCreate<TextSymbol>()->haloOffset() = as<float>(c.value(), defaults.haloOffset().get() );
     }
+    else if ( match(c.key(), "text-halo-backdrop-type") ) {
+        if      ( match(c.value(), "right-bottom") )
+            style.getOrCreate<TextSymbol>()->haloBackdropType() = osgText::Text::DROP_SHADOW_BOTTOM_RIGHT;
+        else if ( match(c.value(), "right-center") )
+            style.getOrCreate<TextSymbol>()->haloBackdropType() = osgText::Text::DROP_SHADOW_CENTER_RIGHT;
+        else if ( match(c.value(), "right-top") )
+            style.getOrCreate<TextSymbol>()->haloBackdropType() = osgText::Text::DROP_SHADOW_TOP_RIGHT;
+        else if ( match(c.value(), "center-bottom") )
+            style.getOrCreate<TextSymbol>()->haloBackdropType() = osgText::Text::DROP_SHADOW_BOTTOM_CENTER;
+        else if ( match(c.value(), "center-top") )
+            style.getOrCreate<TextSymbol>()->haloBackdropType() = osgText::Text::DROP_SHADOW_TOP_CENTER;
+        else if ( match(c.value(), "left-bottom") )
+            style.getOrCreate<TextSymbol>()->haloBackdropType() = osgText::Text::DROP_SHADOW_BOTTOM_LEFT;
+        else if ( match(c.value(), "left-center") )
+            style.getOrCreate<TextSymbol>()->haloBackdropType() = osgText::Text::DROP_SHADOW_CENTER_LEFT;
+        else if ( match(c.value(), "left-top") )
+            style.getOrCreate<TextSymbol>()->haloBackdropType() = osgText::Text::DROP_SHADOW_TOP_LEFT;
+        else if ( match(c.value(), "outline") )
+            style.getOrCreate<TextSymbol>()->haloBackdropType() = osgText::Text::OUTLINE;
+        else if ( match(c.value(), "none") )
+            style.getOrCreate<TextSymbol>()->haloBackdropType() = osgText::Text::NONE;
+    }
+    else if ( match(c.key(), "text-halo-implementation") ) {
+        if      ( match(c.value(), "polygon-offset") )
+            style.getOrCreate<TextSymbol>()->haloImplementation() = osgText::Text::POLYGON_OFFSET;
+        else if ( match(c.value(), "no-depth-buffer") )
+            style.getOrCreate<TextSymbol>()->haloImplementation() = osgText::Text::NO_DEPTH_BUFFER;
+        else if ( match(c.value(), "depth-range") )
+            style.getOrCreate<TextSymbol>()->haloImplementation() = osgText::Text::DEPTH_RANGE;
+        else if ( match(c.value(), "stencil-buffer") )
+            style.getOrCreate<TextSymbol>()->haloImplementation() = osgText::Text::STENCIL_BUFFER;
+        else if ( match(c.value(), "delayed-depth-writes") )
+            style.getOrCreate<TextSymbol>()->haloImplementation() = osgText::Text::DELAYED_DEPTH_WRITES;
+    }
     else if ( match(c.key(), "text-remove-duplicate-labels") ) {
         if ( c.value() == "true" )
             style.getOrCreate<TextSymbol>()->removeDuplicateLabels() = true;
         else if (c.value() == "false")
             style.getOrCreate<TextSymbol>()->removeDuplicateLabels() = false;
-    } 
+    }
     else if ( match(c.key(), "text-align") ) {
-        if      ( match(c.value(), "left-top") ) 
+        if      ( match(c.value(), "left-top") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_LEFT_TOP;
-        else if ( match(c.value(), "left-center") ) 
+        else if ( match(c.value(), "left-center") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_LEFT_CENTER;
-        else if ( match(c.value(), "left-bottom") ) 
+        else if ( match(c.value(), "left-bottom") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_LEFT_BOTTOM;
-        else if ( match(c.value(), "center-top")  ) 
+        else if ( match(c.value(), "center-top")  )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_CENTER_TOP;
-        else if ( match(c.value(), "center-center") ) 
+        else if ( match(c.value(), "center-center") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_CENTER_CENTER;
-        else if ( match(c.value(), "center-bottom") ) 
+        else if ( match(c.value(), "center-bottom") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_CENTER_BOTTOM;
-        else if ( match(c.value(), "right-top") ) 
+        else if ( match(c.value(), "right-top") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_RIGHT_TOP;
-        else if ( match(c.value(), "right-center") ) 
+        else if ( match(c.value(), "right-center") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_RIGHT_CENTER;
-        else if ( match(c.value(), "right-bottom") ) 
+        else if ( match(c.value(), "right-bottom") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_RIGHT_BOTTOM;
-        else if ( match(c.value(), "left-base-line") ) 
+        else if ( match(c.value(), "left-base-line") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_LEFT_BASE_LINE;
-        else if ( match(c.value(), "center-base-line") ) 
+        else if ( match(c.value(), "center-base-line") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_CENTER_BASE_LINE;
-        else if ( match(c.value(), "right-base-line") ) 
+        else if ( match(c.value(), "right-base-line") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_RIGHT_BASE_LINE;
-        else if ( match(c.value(), "left-bottom-base-line") ) 
+        else if ( match(c.value(), "left-bottom-base-line") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_LEFT_BOTTOM_BASE_LINE;
-        else if ( match(c.value(), "center-bottom-base-line") ) 
+        else if ( match(c.value(), "center-bottom-base-line") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_CENTER_BOTTOM_BASE_LINE;
-        else if ( match(c.value(), "right-bottom-base-line") ) 
+        else if ( match(c.value(), "right-bottom-base-line") )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_RIGHT_BOTTOM_BASE_LINE;
-        else if ( match(c.value(), "base-line" ) ) 
+        else if ( match(c.value(), "base-line" ) )
             style.getOrCreate<TextSymbol>()->alignment() = TextSymbol::ALIGN_BASE_LINE;
     }
     else if ( match(c.key(), "text-layout") ) {
@@ -242,7 +310,7 @@ TextSymbol::parseSLD(const Config& c, Style& style)
         else if ( match(c.value(), "vertical" ) )
             style.getOrCreate<TextSymbol>()->layout() = TextSymbol::LAYOUT_VERTICAL;
     }
-    else if ( match(c.key(), "text-content") || match(c.key(), "text") ) {        
+    else if ( match(c.key(), "text-content") || match(c.key(), "text") ) {
         style.getOrCreate<TextSymbol>()->content() = StringExpression( c.value() );
     }
     else if ( match(c.key(), "text-priority") ) {
@@ -252,15 +320,15 @@ TextSymbol::parseSLD(const Config& c, Style& style)
         style.getOrCreate<TextSymbol>()->provider() = c.value();
     }
     else if ( match(c.key(), "text-encoding") ) {
-        if      (match(c.value(), "utf-8"))  
+        if      (match(c.value(), "utf-8"))
             style.getOrCreate<TextSymbol>()->encoding() = TextSymbol::ENCODING_UTF8;
-        else if (match(c.value(), "utf-16")) 
+        else if (match(c.value(), "utf-16"))
             style.getOrCreate<TextSymbol>()->encoding() = TextSymbol::ENCODING_UTF16;
-        else if (match(c.value(), "utf-32")) 
+        else if (match(c.value(), "utf-32"))
             style.getOrCreate<TextSymbol>()->encoding() = TextSymbol::ENCODING_UTF32;
-        else if (match(c.value(), "ascii"))  
+        else if (match(c.value(), "ascii"))
             style.getOrCreate<TextSymbol>()->encoding() = TextSymbol::ENCODING_ASCII;
-        else 
+        else
             style.getOrCreate<TextSymbol>()->encoding() = TextSymbol::ENCODING_ASCII;
     }
     else if ( match(c.key(), "text-declutter") ) {
@@ -270,7 +338,7 @@ TextSymbol::parseSLD(const Config& c, Style& style)
         style.getOrCreate<TextSymbol>()->occlusionCull() = as<bool>(c.value(), defaults.occlusionCull().get() );
     }
     else if ( match(c.key(), "text-occlusion-cull-altitude") ) {
-        style.getOrCreate<TextSymbol>()->occlusionCullAltitude() = as<double>(c.value(), defaults.occlusionCullAltitude().get() );    
+        style.getOrCreate<TextSymbol>()->occlusionCullAltitude() = as<double>(c.value(), defaults.occlusionCullAltitude().get() );
     }
     else if ( match(c.key(), "text-script") ) {
         style.getOrCreate<TextSymbol>()->script() = StringExpression(c.value());


### PR DESCRIPTION
Added access to osgText::Text's backdropType() and backdropImplementation() in TextSymbol.  This allows users of annotation text to change from outline to different backdrop styles.