### PR TITLE
Added minimum and maximum scale property for auto-scale model

### DIFF
--- a/src/osgEarthAnnotation/GeoPositionNodeAutoScaler
+++ b/src/osgEarthAnnotation/GeoPositionNodeAutoScaler
@@ -41,7 +41,7 @@ namespace osgEarth { namespace Annotation
     class OSGEARTHANNO_EXPORT GeoPositionNodeAutoScaler : public osg::NodeCallback
     {
     public:
-        GeoPositionNodeAutoScaler(const osg::Vec3d& baseScale = osg::Vec3d(1,1,1));
+        GeoPositionNodeAutoScaler(const osg::Vec3d& baseScale = osg::Vec3d(1,1,1), double minScale = 0.0, double maxScale = DBL_MAX);
 
     public: // osg::NodeCallback
 
@@ -49,6 +49,8 @@ namespace osgEarth { namespace Annotation
 
     protected:
         osg::Vec3d _baseScale;
+		double _minScale;
+		double _maxScale;
     };
 
 } } // namespace

--- a/src/osgEarthAnnotation/GeoPositionNodeAutoScaler.cpp
+++ b/src/osgEarthAnnotation/GeoPositionNodeAutoScaler.cpp
@@ -30,8 +30,10 @@ using namespace osgEarth;
 using namespace osgEarth::Annotation;
 
 
-GeoPositionNodeAutoScaler::GeoPositionNodeAutoScaler(const osg::Vec3d& baseScale) :
-_baseScale( baseScale )
+GeoPositionNodeAutoScaler::GeoPositionNodeAutoScaler(const osg::Vec3d& baseScale, double minScale, double maxScale) :
+_baseScale( baseScale ),
+_minScale( minScale ),
+_maxScale( maxScale )
 {
     //nop
 }
@@ -42,6 +44,10 @@ GeoPositionNodeAutoScaler::operator()(osg::Node* node, osg::NodeVisitor* nv)
     GeoPositionNode* geo = static_cast<GeoPositionNode*>(node);
     osgUtil::CullVisitor* cs = static_cast<osgUtil::CullVisitor*>(nv);
     double size = 1.0/cs->pixelSize( node->getBound().center(), 0.5f );
+	if (size < _minScale)
+		size = _minScale;
+	else if (size>_maxScale)
+		size = _maxScale;
     geo->getPositionAttitudeTransform()->setScale( osg::componentMultiply(_baseScale, osg::Vec3d(size,size,size)) );
     traverse(node, nv);
 }

--- a/src/osgEarthAnnotation/ModelNode.cpp
+++ b/src/osgEarthAnnotation/ModelNode.cpp
@@ -142,7 +142,7 @@ ModelNode::init()
                 // auto scaling?
                 if ( sym->autoScale() == true )
                 {
-                    this->addCullCallback( new GeoPositionNodeAutoScaler() );
+                    this->addCullCallback( new GeoPositionNodeAutoScaler( osg::Vec3d(1,1,1), sym->minAutoScale().value(), sym->maxAutoScale().value() ));
                 } 
 
                 // rotational offsets?

--- a/src/osgEarthSymbology/ModelSymbol
+++ b/src/osgEarthSymbology/ModelSymbol
@@ -60,6 +60,14 @@ namespace osgEarth { namespace Symbology
         optional<bool>& autoScale() { return _autoScale; }
         const optional<bool>& autoScale() const { return _autoScale; }
 
+		/** minimum scale of the model when autoscale is enabled */
+        optional<double>& minAutoScale() { return _minAutoScale; }
+        const optional<double>& minAutoScale() const { return _minAutoScale; }
+		
+		/** maximum scale of the model when autoscale is enabled */
+        optional<double>& maxAutoScale() { return _maxAutoScale; }
+        const optional<double>& maxAutoScale() const { return _maxAutoScale; }
+		
         /** Name of a specific model in the catalog */
         optional<StringExpression>& name() { return _name; }
         const optional<StringExpression>& name() const { return _name; }
@@ -104,6 +112,8 @@ namespace osgEarth { namespace Symbology
         optional<NumericExpression>  _pitch;
         optional<NumericExpression>  _roll;
         optional<bool>               _autoScale;
+		optional<double>			 _minAutoScale;
+		optional<double>			 _maxAutoScale;
         osg::ref_ptr<osg::Node>      _node;
         optional<StringExpression>   _name;
         optional<float>              _maxSizeX;

--- a/src/osgEarthSymbology/ModelSymbol.cpp
+++ b/src/osgEarthSymbology/ModelSymbol.cpp
@@ -31,6 +31,8 @@ _heading(rhs._heading),
 _pitch(rhs._pitch),
 _roll(rhs._roll),
 _autoScale(rhs._autoScale),
+_minAutoScale(rhs._minAutoScale),
+_maxAutoScale(rhs._maxAutoScale),
 _name(rhs._name),
 _node(rhs._node),
 _maxSizeX(rhs._maxSizeX),
@@ -48,6 +50,8 @@ _heading  ( NumericExpression(0.0) ),
 _pitch    ( NumericExpression(0.0) ),
 _roll     ( NumericExpression(0.0) ),
 _autoScale( false ),
+_minAutoScale	( 0.0 ),
+_maxAutoScale	( DBL_MAX ),
 _maxSizeX ( FLT_MAX ),
 _maxSizeY ( FLT_MAX ),
 _scaleX    ( NumericExpression(1.0) ),
@@ -68,6 +72,8 @@ ModelSymbol::getConfig() const
     conf.addObjIfSet( "name",       _name );
     
     conf.addIfSet( "auto_scale", _autoScale );
+	conf.addIfSet( "min_auto_scale", _minAutoScale );
+	conf.addIfSet( "max_auto_scale", _maxAutoScale );
     conf.addIfSet( "alias_map", _uriAliasMap );
 
     conf.addIfSet( "max_size_x", _maxSizeX );
@@ -93,6 +99,8 @@ ModelSymbol::mergeConfig( const Config& conf )
     conf.getIfSet( "max_size_y", _maxSizeY );
 
     conf.getIfSet( "auto_scale", _autoScale );
+	conf.getIfSet( "min_auto_scale", _minAutoScale);
+	conf.getIfSet( "max_auto_scale", _maxAutoScale);
     conf.getIfSet( "alias_map", _uriAliasMap );
     
     conf.getObjIfSet( "scale_x", _scaleX );
@@ -140,6 +148,12 @@ ModelSymbol::parseSLD(const Config& c, Style& style)
         else
             style.getOrCreate<ModelSymbol>()->scale() = NumericExpression(c.value());
     }
+	else if (match(c.key(), "model-min-auto-scale")) {
+		style.getOrCreate<ModelSymbol>()->minAutoScale() = as<double>(c.value(), 0.0f);
+	}
+	else if (match(c.key(), "model-max-auto-scale")) {
+		style.getOrCreate<ModelSymbol>()->maxAutoScale() = as<double>(c.value(), DBL_MAX);
+	}
     else if ( match(c.key(), "model-scale-x") ) {
         style.getOrCreate<ModelSymbol>()->scaleX() = NumericExpression(c.value());
     }


### PR DESCRIPTION
Usage:
style.getOrCreate<osgEarth::Annotation::ModelSymbol>()->minAutoScale()=3.0;
style.getOrCreate<osgEarth::Annotation::ModelSymbol>()->maxAutoScale()=100.0;