### PR TITLE
Rotation on LabelNode and PlaceNode

### DIFF
--- a/src/osgEarth/Decluttering
+++ b/src/osgEarth/Decluttering
@@ -55,6 +55,7 @@ namespace osgEarth
     public:
         float      _priority;
         osg::Vec2s _pixelOffset;
+        float      _localRotationRad;
     public:
         virtual ~LayoutData() { }
     };

--- a/src/osgEarthAnnotation/LabelNode
+++ b/src/osgEarthAnnotation/LabelNode
@@ -26,6 +26,7 @@
 #include <osgEarthAnnotation/GeoPositionNode>
 #include <osgEarthSymbology/Style>
 #include <osgEarth/MapNode>
+#include <osgEarth/Decluttering>
 #include <osg/Geode>
 
 namespace osgEarth { namespace Annotation
@@ -92,6 +93,9 @@ namespace osgEarth { namespace Annotation
             const Config&         conf,
             const osgDB::Options* dbOptions );
 
+        /**
+         * Destructor
+         */
         virtual ~LabelNode() { }
 
         /**
@@ -119,12 +123,20 @@ namespace osgEarth { namespace Annotation
 
         virtual Config getConfig() const;
 
+        virtual void traverse(osg::NodeVisitor &nv);
+
     protected:
         void init(const Style& style);
 
         std::string              _text;
         Style                    _style;
         osg::ref_ptr<osg::Geode> _geode;
+        osg::ref_ptr<LayoutData> _dataLayout;
+
+        /** rotation of the label **/
+        float                    _labelRotationRad;
+        bool                     _followFixedCourse;
+        GeoPoint                 _geoPointProj;
 
         /** Copy constructor */
         LabelNode(const LabelNode& rhs, const osg::CopyOp& op = osg::CopyOp::DEEP_COPY_ALL) : GeoPositionNode(rhs, op) { }

--- a/src/osgEarthAnnotation/PlaceNode
+++ b/src/osgEarthAnnotation/PlaceNode
@@ -24,6 +24,7 @@
 
 #include <osgEarthAnnotation/GeoPositionNode>
 #include <osgEarthSymbology/Style>
+#include <osgEarth/Decluttering>
 
 namespace osgEarth { namespace Annotation
 {
@@ -118,6 +119,8 @@ namespace osgEarth { namespace Annotation
 
         virtual Config getConfig() const;
 
+        virtual void traverse(osg::NodeVisitor &nv);
+
     protected:
 
         virtual ~PlaceNode() { }
@@ -128,6 +131,12 @@ namespace osgEarth { namespace Annotation
         Style                              _style;
         class osg::Geode*                  _geode;
         osg::ref_ptr<const osgDB::Options> _dbOptions;
+        osg::ref_ptr<LayoutData>           _dataLayout;
+
+        /** rotation of the label **/
+        float                    _labelRotationRad;
+        bool                     _followFixedCourse;
+        GeoPoint                 _geoPointProj;
 
         void init();
 

--- a/src/osgEarthAnnotation/PlaceNode.cpp
+++ b/src/osgEarthAnnotation/PlaceNode.cpp
@@ -28,7 +28,7 @@
 #include <osgEarth/Utils>
 #include <osgEarth/Registry>
 #include <osgEarth/ShaderGenerator>
-#include <osgEarth/Decluttering>
+#include <osgEarth/GeoMath>
 
 #include <osg/Depth>
 #include <osgText/Text>
@@ -51,7 +51,9 @@ GeoPositionNode( mapNode, position ),
 _image   ( image ),
 _text    ( text ),
 _style   ( style ),
-_geode   ( 0L )
+_geode            ( 0L ),
+_labelRotationRad ( 0. ),
+_followFixedCourse( false )
 {
     init();
 }
@@ -64,7 +66,9 @@ PlaceNode::PlaceNode(MapNode*           mapNode,
 GeoPositionNode( mapNode, position ),
 _text    ( text ),
 _style   ( style ),
-_geode   ( 0L )
+_geode            ( 0L ),
+_labelRotationRad ( 0. ),
+_followFixedCourse( false )
 {
     init();
 }
@@ -75,7 +79,9 @@ PlaceNode::PlaceNode(MapNode*              mapNode,
                      const osgDB::Options* dbOptions ) :
 GeoPositionNode ( mapNode, position ),
 _style    ( style ),
-_dbOptions( dbOptions )
+_dbOptions        ( dbOptions ),
+_labelRotationRad ( 0. ),
+_followFixedCourse( false )
 {
     init();
 }
@@ -95,10 +101,42 @@ PlaceNode::init()
 
     osg::Drawable* text = 0L;
 
+    const TextSymbol* symbol = _style.get<TextSymbol>();
+
     // If there's no explicit text, look to the text symbol for content.
-    if ( _text.empty() && _style.has<TextSymbol>() )
+    if ( _text.empty() && symbol )
     {
-        _text = _style.get<TextSymbol>()->content()->eval();
+        _text = symbol->content()->eval();
+    }
+
+    // Handle the rotation if any
+    if ( symbol && symbol->onScreenRotation().isSet() )
+    {
+        _labelRotationRad = osg::DegreesToRadians(symbol->onScreenRotation()->eval());
+    }
+
+    // In case of a label must follow a course on map, we project a point from the position
+    // with the given bearing. Then during culling phase we compute both points on the screen
+    // and then we can deduce the screen rotation
+    // may be optimized...
+    else if ( symbol && symbol->geographicCourse().isSet() )
+    {
+        _followFixedCourse = true;
+        _labelRotationRad = osg::DegreesToRadians ( symbol->geographicCourse()->eval() );
+
+        double latRad;
+        double longRad;
+        GeoMath::destination( osg::DegreesToRadians( getPosition().y() ),
+                              osg::DegreesToRadians( getPosition().x() ),
+                              _labelRotationRad,
+                              2500.,
+                              latRad,
+                              longRad );
+        _geoPointProj.set ( osgEarth::SpatialReference::get("wgs84"),
+                                       osg::RadiansToDegrees(longRad),
+                                       osg::RadiansToDegrees(latRad),
+                                       0,
+                                       osgEarth::ALTMODE_ABSOLUTE );
     }
 
     osg::ref_ptr<const InstanceSymbol> instance = _style.get<InstanceSymbol>();
@@ -257,15 +295,23 @@ PlaceNode::setPriority(float value)
 void
 PlaceNode::updateLayoutData()
 {
-    osg::ref_ptr<LayoutData> data = new LayoutData();
-    data->_priority = getPriority();
-    const TextSymbol* ts = getStyle().get<TextSymbol>();
-    if (ts) data->_pixelOffset = ts->pixelOffset().get();
+    if ( ! _dataLayout.valid() )
+    {
+        _dataLayout = new LayoutData();
 
     // re-apply annotation drawable-level stuff as neccesary.
     for (unsigned i = 0; i<_geode->getNumDrawables(); ++i)
     {
-        _geode->getDrawable(i)->setUserData(data.get());
+            _geode->getDrawable(i)->setUserData(_dataLayout.get());
+        }
+    }
+
+    _dataLayout->_priority = getPriority();
+    const TextSymbol* ts = getStyle().get<TextSymbol>();
+    if (ts)
+    {
+        _dataLayout->_pixelOffset = ts->pixelOffset().get();
+        _dataLayout->_localRotationRad = _labelRotationRad;
     }
 }
 
@@ -329,7 +375,40 @@ PlaceNode::setDynamic( bool value )
     }
 }
 
+void
+PlaceNode::traverse(osg::NodeVisitor &nv)
+{
+    if(_followFixedCourse)
+    {
+        osgUtil::CullVisitor* cv = NULL;
+        if ( nv.getVisitorType() == osg::NodeVisitor::CULL_VISITOR )
+        {
+            cv = Culling::asCullVisitor(nv);
+            osg::Camera* camera = cv->getCurrentCamera();
 
+            osg::Matrix matrix;
+            matrix.postMult(camera->getViewMatrix());
+            matrix.postMult(camera->getProjectionMatrix());
+            if (camera->getViewport())
+                matrix.postMult(camera->getViewport()->computeWindowMatrix());
+
+            GeoPoint pos( osgEarth::SpatialReference::get("wgs84"),
+                          getPosition().x(),
+                          getPosition().y(),
+                          0,
+                          osgEarth::ALTMODE_ABSOLUTE );
+
+            osg::Vec3d refOnWorld; pos.toWorld(refOnWorld);
+            osg::Vec3d projOnWorld; _geoPointProj.toWorld(projOnWorld);
+            osg::Vec3d refOnScreen = refOnWorld * matrix;
+            osg::Vec3d projOnScreen = projOnWorld * matrix;
+            projOnScreen -= refOnScreen;
+            _labelRotationRad = atan2 (projOnScreen.y(), projOnScreen.x());
+            updateLayoutData();
+        }
+    }
+    GeoPositionNode::traverse(nv);
+}
 
 //-------------------------------------------------------------------
 
@@ -340,7 +419,9 @@ PlaceNode::PlaceNode(MapNode*              mapNode,
                      const Config&         conf,
                      const osgDB::Options* dbOptions) :
 GeoPositionNode ( mapNode, conf ),
-_dbOptions( dbOptions )
+_dbOptions( dbOptions ),
+_labelRotationRad ( 0. ),
+_followFixedCourse( false )
 {
     conf.getObjIfSet( "style",  _style );
     conf.getIfSet   ( "text",   _text );

--- a/src/osgEarthDrivers/label_annotation/AnnotationLabelSource.cpp
+++ b/src/osgEarthDrivers/label_annotation/AnnotationLabelSource.cpp
@@ -61,6 +61,8 @@ public:
         StringExpression  textContentExpr ( text ? *text->content()  : StringExpression() );
         NumericExpression textPriorityExpr( text ? *text->priority() : NumericExpression() );
         NumericExpression textSizeExpr    ( text ? *text->size()     : NumericExpression() );
+        NumericExpression textRotationExpr( text ? *text->onScreenRotation() : NumericExpression() );
+        NumericExpression textCourseExpr  ( text ? *text->geographicCourse() : NumericExpression() );
         StringExpression  iconUrlExpr     ( icon ? *icon->url()      : StringExpression() );
         NumericExpression iconScaleExpr   ( icon ? *icon->scale()    : NumericExpression() );
         NumericExpression iconHeadingExpr ( icon ? *icon->heading()  : NumericExpression() );
@@ -102,6 +104,12 @@ public:
 
                 if ( text->size().isSet() )
                     tempStyle.get<TextSymbol>()->size()->setLiteral( feature->eval(textSizeExpr, &context) );
+
+                if ( text->onScreenRotation().isSet() )
+                    tempStyle.get<TextSymbol>()->onScreenRotation()->setLiteral( feature->eval(textRotationExpr, &context) );
+
+                if ( text->geographicCourse().isSet() )
+                    tempStyle.get<TextSymbol>()->geographicCourse()->setLiteral( feature->eval(textCourseExpr, &context) );
             }
 
             if ( icon )

--- a/src/osgEarthSymbology/TextSymbol
+++ b/src/osgEarthSymbology/TextSymbol
@@ -111,6 +111,14 @@ namespace osgEarth { namespace Symbology
         optional<osg::Vec2s>& pixelOffset() { return _pixelOffset; }
         const optional<osg::Vec2s>& pixelOffset() const { return _pixelOffset; }
 
+        /** On screen rotation **/
+        optional<NumericExpression>& onScreenRotation() { return _onScreenRotation; }
+        const optional<NumericExpression>& onScreenRotation() const { return _onScreenRotation; }
+
+        /** Label orientation for following a fixed course on the map. */
+        optional<NumericExpression>& geographicCourse() { return _geographicCourse; }
+        const optional<NumericExpression>& geographicCourse() const { return _geographicCourse; }
+
         /** Alignment of the label relative to (0,0) pixels */
         optional<Alignment>& alignment() { return _alignment; }
         const optional<Alignment>& alignment() const { return _alignment; }
@@ -158,6 +166,8 @@ namespace osgEarth { namespace Symbology
         optional<NumericExpression> _priority;
         optional<bool>              _removeDuplicateLabels;
         optional<osg::Vec2s>        _pixelOffset;
+        optional<NumericExpression> _onScreenRotation;
+        optional<NumericExpression> _geographicCourse;
         optional<std::string>       _provider;
         optional<Encoding>          _encoding;
         optional<Alignment>         _alignment;

--- a/src/osgEarthSymbology/TextSymbol.cpp
+++ b/src/osgEarthSymbology/TextSymbol.cpp
@@ -38,6 +38,8 @@ _content(rhs._content),
 _priority(rhs._priority),
 _removeDuplicateLabels(rhs._removeDuplicateLabels),
 _pixelOffset(rhs._pixelOffset),
+_onScreenRotation(rhs._onScreenRotation),
+_geographicCourse(rhs._geographicCourse),
 _provider(rhs._provider),
 _encoding(rhs._encoding),
 _alignment(rhs._alignment),
@@ -114,6 +116,9 @@ TextSymbol::getConfig() const
         conf.add( "pixel_offset_y", toString(_pixelOffset->y()) );
     }
 
+    conf.addObjIfSet( "rotation", _onScreenRotation );
+    conf.addObjIfSet( "geographic-course", _geographicCourse );
+
     conf.addIfSet( "text-occlusion-cull", _occlusionCull );
     conf.addIfSet( "text-occlusion-cull-altitude", _occlusionCullAltitude );
 
@@ -165,6 +170,9 @@ TextSymbol::mergeConfig( const Config& conf )
         _pixelOffset = osg::Vec2s( conf.value<short>("pixel_offset_x",0), 0 );
     if ( conf.hasValue( "pixel_offset_y" ) )
         _pixelOffset = osg::Vec2s( _pixelOffset->x(), conf.value<short>("pixel_offset_y",0) );
+
+    conf.getObjIfSet( "rotation", _onScreenRotation );
+    conf.getObjIfSet( "geographic-course", _geographicCourse );
 
     conf.getIfSet( "text-occlusion-cull", _occlusionCull );
     conf.getIfSet( "text-occlusion-cull-altitude", _occlusionCullAltitude );
@@ -280,5 +288,11 @@ TextSymbol::parseSLD(const Config& c, Style& style)
     }
     else if ( match(c.key(), "text-offset-y") ) {
         style.getOrCreate<TextSymbol>()->pixelOffset()->y() = as<double>(c.value(), defaults.pixelOffset()->y() );
+    }
+    else if ( match(c.key(), "text-rotation") ) {
+        style.getOrCreate<TextSymbol>()->onScreenRotation() = NumericExpression( c.value() );
+    }
+    else if ( match(c.key(), "text-geographic-course") ) {
+        style.getOrCreate<TextSymbol>()->geographicCourse() = NumericExpression( c.value() );
     }
 }

--- a/tests/annotation.earth
+++ b/tests/annotation.earth
@@ -175,7 +175,12 @@ osgEarth Sample - Annotations
                     render-lighting:     false;
                 </style>
             </feature>
-            <label text="Tessellated line" lat="35" long="10"/>
+            <label text="Tessellated line" lat="35" long="10">
+                <style type="text/css">
+                    text-align:              center_center;
+					text-geographic-course:  0;
+                </style>
+			</label>
             
         </annotations>
         


### PR DESCRIPTION
Two new attributes on TextSymbol:
- text-rotation: absolute on-screen rotation
- text-geographic-course: compute the on-screen rotation for following
  a fixed course on ground (use for naming rivers or roads)

Can be tested with annotation.earth (see the tesselated line)