### PR TITLE
Avoid an infinite loop on Spatialite driver

### DIFF
--- a/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR
+++ b/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR
@@ -75,6 +75,7 @@ private:
     std::queue< osg::ref_ptr<Feature> > _queue;
     osg::ref_ptr<Feature>               _lastFeatureReturned;
     const FeatureFilterList&            _filters;
+    bool                                _resultSetEndReached;
 
 private:
     void readChunk();    

--- a/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp
+++ b/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp
@@ -76,6 +76,7 @@ _spatialFilter    ( 0L ),
 _query            ( query ),
 _chunkSize        ( 500 ),
 _nextHandleToQueue( 0L ),
+_resultSetEndReached(false),
 _profile          ( profile ),
 _filters          ( filters )
 {
@@ -225,12 +226,10 @@ FeatureCursorOGR::readChunk()
     
     OGR_SCOPED_LOCK;
 
-    bool resultSetEndReached = false;
-
-    while( _queue.size() < _chunkSize && !resultSetEndReached )
+    while( _queue.size() < _chunkSize && !_resultSetEndReached )
     {
         FeatureList filterList;
-        while( filterList.size() < _chunkSize && !resultSetEndReached )
+        while( filterList.size() < _chunkSize && !_resultSetEndReached )
         {
             OGRFeatureH handle = OGR_L_GetNextFeature( _resultSetHandle );
             if ( handle )
@@ -247,7 +246,7 @@ FeatureCursorOGR::readChunk()
             }
             else
             {
-                resultSetEndReached = true;
+                _resultSetEndReached = true;
             }
         }
 


### PR DESCRIPTION
It is similar to the commit f255796eb347687fffe54286a2b0af42eb2bd957 which
seems to having been lost during refactor operations