### PR TITLE
Fix unsetting options of CacheBin write in URI class

### DIFF
--- a/src/osgEarth/URI.cpp
+++ b/src/osgEarth/URI.cpp
@@ -531,7 +531,7 @@ namespace
                             if ( result.succeeded() && !result.isFromCache() && bin && cp->isCacheWriteable() )
                             {
                                 OE_DEBUG << LC << "Writing " << uri.cacheKey() << " to cache" << std::endl;
-                                bin->write( uri.cacheKey(), result.getObject(), result.metadata(), 0L );
+                                bin->write( uri.cacheKey(), result.getObject(), result.metadata(), remoteOptions );
                             }
                         }
                     }


### PR DESCRIPTION
@gwaldron added options to most caching functions a month ago, whoever the options did not pass to CacheBin write method.