### PR TITLE
fix compilation on mingw

### DIFF
--- a/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp
+++ b/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp
@@ -54,7 +54,7 @@ namespace
         for (Geometry::iterator i = geometry->begin(); i != geometry->end(); ++i)
         {
             // a "NaN" Z value is automatically changed to zero:
-            if (::isnan(i->z()))
+            if (std::isnan(i->z()))
                 i->z() = 0.0;
 
             // then we test for a valid point.


### PR DESCRIPTION
C:/source/osgearth/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp: In function 'bool {anonymous}::validateGeometry(osgEarth::Symbology::Geometry*)':
C:/source/osgearth/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp:57:17: error: '::isnan' has not been declared
             if (::isnan(i->z()))

C:/source/osgearth/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp:57:17: note: suggested alternative:
In file included from C:/install/include/osg/Math:17:0,
                 from C:/install/include/osg/Vec2f:17,
                 from C:/install/include/osg/Vec3f:17,
                 from C:/install/include/osg/Vec3:17,
                 from C:/source/osgearth/src/osgEarth/StringUtils:23,
                 from C:/source/osgearth/src/osgEarth/Config:24,
                 from C:/source/osgearth/src/osgEarthFeatures/ScriptEngine:24,
                 from C:/source/osgearth/src/osgEarthFeatures/Session:24,
                 from C:/source/osgearth/src/osgEarthFeatures/FilterContext:24,
                 from C:/source/osgearth/src/osgEarthFeatures/Feature:23,
                 from C:/source/osgearth/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR:22,
                 from C:/source/osgearth/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp:19:
C:/msys64/mingw64/include/c++/4.9.2/cmath:837:5: note:   'std::isnan'
     isnan(_Tp __f)
     ^