### PR TITLE
Fix bug detected by asan on linux

### DIFF
--- a/src/osgEarth/ModelLayer
+++ b/src/osgEarth/ModelLayer
@@ -52,8 +52,14 @@ namespace osgEarth
             const std::string&        name, 
             const ModelSourceOptions& driverOptions =ModelSourceOptions() );
 
+        /** Copy ctor*/
+        ModelLayerOptions(const ModelLayerOptions& rhs);
+
         /** dtor */
         virtual ~ModelLayerOptions() { }
+
+        /** Assignment operator */
+        ModelLayerOptions& operator = (const ModelLayerOptions&);
 
         /**
          * The readable name of the layer.

--- a/src/osgEarth/ModelLayer.cpp
+++ b/src/osgEarth/ModelLayer.cpp
@@ -48,6 +48,8 @@ namespace
 
 //------------------------------------------------------------------------
 
+namespace osgEarth
+{
 ModelLayerOptions::ModelLayerOptions( const ConfigOptions& options ) :
 ConfigOptions( options )
 {
@@ -62,6 +64,41 @@ ConfigOptions()
     fromConfig( _conf );
     _name = name;
     _driver = driverOptions;
+}
+
+ModelLayerOptions::ModelLayerOptions(const ModelLayerOptions& rhs) :
+ConfigOptions(rhs.getConfig())
+{
+    _name = optional<std::string>(rhs._name);
+    _driver = optional<ModelSourceOptions>(rhs._driver);
+    _enabled = optional<bool>(rhs._enabled);
+    _visible = optional<bool>(rhs._visible);
+    _opacity = optional<float>(rhs._opacity);
+    _lighting = optional<bool>(rhs._lighting);
+    _maskOptions = optional<MaskSourceOptions>(rhs._maskOptions);
+    _maskMinLevel = optional<unsigned>(rhs._maskMinLevel);
+    _terrainPatch = optional<bool>(rhs._terrainPatch);
+    _cachePolicy = optional<CachePolicy>(rhs._cachePolicy);
+    _cacheId = optional<std::string>(rhs._cacheId);
+}
+
+ModelLayerOptions& ModelLayerOptions::operator =(const ModelLayerOptions& rhs)
+{
+    ConfigOptions::operator =(rhs);
+
+    _name = optional<std::string>(rhs._name);
+    _driver = optional<ModelSourceOptions>(rhs._driver);
+    _enabled = optional<bool>(rhs._enabled);
+    _visible = optional<bool>(rhs._visible);
+    _opacity = optional<float>(rhs._opacity);
+    _lighting = optional<bool>(rhs._lighting);
+    _maskOptions = optional<MaskSourceOptions>(rhs._maskOptions);
+    _maskMinLevel = optional<unsigned>(rhs._maskMinLevel);
+    _terrainPatch = optional<bool>(rhs._terrainPatch);
+    _cachePolicy = optional<CachePolicy>(rhs._cachePolicy);
+    _cacheId = optional<std::string>(rhs._cacheId);
+
+    return *this;
 }
 
 void
@@ -461,4 +498,5 @@ ModelLayer::getOrCreateMaskBoundary(float                   heightScale,
     }
 
     return _maskBoundary.get();
+}
 }


### PR DESCRIPTION
==16201==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7ffc7003efe0 at pc 0x7f6c52fddcbc bp 0x7ffc7003e4b0 sp 0x7ffc7003e4a0

WRITE of size 8 at 0x7ffc7003efe0 thread T0

    #0 0x7f6c52fddcbb in osgEarth::optional<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::optional() /home/agelas/debug/install/include/osgEarth/optional:33

    #1 0x7f6c4181ae2d in osgEarth::ModelLayerOptions::ModelLayerOptions(osgEarth::ConfigOptions const&) /home/agelas/source/osgearth/src/osgEarth/ModelLayer.cpp:52

Add copy constructor and assignment operator to avoid implicit convertion