### PR TITLE
MapNode and EarthManipulator no longer crash when terrain driver (e.g…

### DIFF
--- a/src/osgEarth/MapNode.cpp
+++ b/src/osgEarth/MapNode.cpp
@@ -48,7 +48,7 @@ using namespace osgEarth;
 
 //---------------------------------------------------------------------------
 
-namespace 
+namespace
 {
     // adapter that lets MapNode listen to Map events
     struct MapNodeMapCallbackProxy : public MapCallback
@@ -101,13 +101,13 @@ public:
       }
 
       virtual void apply(osg::PagedLOD& node)
-      {        
-          //The PagedLOD node will contain two filenames, the first is empty and is the actual geometry of the          
+      {
+          //The PagedLOD node will contain two filenames, the first is empty and is the actual geometry of the
           //tile and the second is the filename of the next tile.
           if (node.getNumFileNames() > 1)
           {
               //Get the child filename
-              const std::string &filename = node.getFileName(1);              
+              const std::string &filename = node.getFileName(1);
               if (osgEarth::Registry::instance()->isBlacklisted(filename))
               {
                   //If the tile is blacklisted, we set the actual geometry, child 0, to always display
@@ -126,16 +126,16 @@ public:
                       if (node.getRangeMode() == osg::LOD::PIXEL_SIZE_ON_SCREEN)
                       {
                           node.setRange( 0, ranges->_minRange, ranges->_maxRange );
-                          node.setRange( 1, ranges->_maxRange, FLT_MAX );                          
+                          node.setRange( 1, ranges->_maxRange, FLT_MAX );
                       }
                       else
-                      {                          
+                      {
                           node.setRange(0, ranges->_minRange, ranges->_maxRange);
                           node.setRange(1, 0, ranges->_minRange);
                       }
-                  }                  
+                  }
               }
-              
+
           }
           traverse(node);
       }
@@ -158,7 +158,7 @@ MapNode::load(osg::ArgumentParser& args)
                 return r.release<MapNode>();
             }
         }
-    }    
+    }
     return 0L;
 }
 
@@ -178,7 +178,7 @@ MapNode::load(osg::ArgumentParser& args, const MapNodeOptions& defaults)
                 return r.release<MapNode>();
             }
         }
-    }    
+    }
     return 0L;
 }
 
@@ -228,7 +228,7 @@ MapNode::init()
     // deleting during startup. It is possible that during startup, a driver
     // will load that will take a reference to the MapNode (like in a
     // ModelSource node operation) and we don't want that deleting the MapNode
-    // out from under us. 
+    // out from under us.
     // This is paired by an unref_nodelete() at the end of this method.
     this->ref();
 
@@ -259,14 +259,14 @@ MapNode::init()
     // will make their way to any read* calls down the pipe
     const osgDB::Options* global_options = _map->getGlobalOptions();
 
-    osg::ref_ptr<osgDB::Options> local_options = global_options ? 
+    osg::ref_ptr<osgDB::Options> local_options = global_options ?
         Registry::instance()->cloneOrCreateOptions( global_options ) :
         NULL;
 
     if ( local_options.valid() )
     {
         OE_INFO << LC
-            << "Options string = " 
+            << "Options string = "
             << (local_options.valid()? local_options->getOptionString() : "<empty>")
             << std::endl;
     }
@@ -293,8 +293,8 @@ MapNode::init()
         _terrainEngineContainer->getOrCreateStateSet()->addUniform(
             Registry::shaderFactory()->createUniformForGLMode(GL_LIGHTING, *terrainOptions.enableLighting()) );
 
-        _terrainEngineContainer->getOrCreateStateSet()->setMode( 
-            GL_LIGHTING, 
+        _terrainEngineContainer->getOrCreateStateSet()->setMode(
+            GL_LIGHTING,
             terrainOptions.enableLighting().value() ? 1 : 0 );
     }
 
@@ -302,7 +302,7 @@ MapNode::init()
     {
         // inform the terrain engine of the map information now so that it can properly
         // initialize it's CoordinateSystemNode. This is necessary in order to support
-        // manipulators and to set up the texture compositor prior to frame-loop 
+        // manipulators and to set up the texture compositor prior to frame-loop
         // initialization.
         _terrainEngine->preInitialize( _map.get(), terrainOptions );
         _terrainEngineContainer->addChild( _terrainEngine );
@@ -373,11 +373,11 @@ MapNode::init()
     if ( _mapNodeOptions.enableLighting().isSet() )
     {
         stateset->addUniform(Registry::shaderFactory()->createUniformForGLMode(
-            GL_LIGHTING, 
+            GL_LIGHTING,
             _mapNodeOptions.enableLighting().value() ? 1 : 0));
 
-        stateset->setMode( 
-            GL_LIGHTING, 
+        stateset->setMode(
+            GL_LIGHTING,
             _mapNodeOptions.enableLighting().value() ? 1 : 0);
     }
 
@@ -388,14 +388,22 @@ MapNode::init()
         OE_INFO << LC << "Adding ellipsoid uniforms.\n";
 
         // for a geocentric map, use an ellipsoid unit-frame transform and its inverse:
-        osg::Vec3d ellipFrameInverse(
-            _map->getSRS()->getEllipsoid()->getRadiusEquator(),
-            _map->getSRS()->getEllipsoid()->getRadiusEquator(),
-            _map->getSRS()->getEllipsoid()->getRadiusPolar());
-        stateset->addUniform( new osg::Uniform("oe_ellipsoidFrameInverse", osg::Vec3f(ellipFrameInverse)) );
+        if (_map->getSRS() != NULL && _map->getSRS()->getEllipsoid() != NULL)
+        {
+            osg::Vec3d ellipFrameInverse(
+                _map->getSRS()->getEllipsoid()->getRadiusEquator(),
+                _map->getSRS()->getEllipsoid()->getRadiusEquator(),
+                _map->getSRS()->getEllipsoid()->getRadiusPolar());
+            stateset->addUniform( new osg::Uniform("oe_ellipsoidFrameInverse", osg::Vec3f(ellipFrameInverse)) );
 
-        osg::Vec3d ellipFrame = osg::componentDivide(osg::Vec3d(1.0,1.0,1.0), ellipFrameInverse);
-        stateset->addUniform( new osg::Uniform("oe_ellipsoidFrame", osg::Vec3f(ellipFrame)) );
+            osg::Vec3d ellipFrame = osg::componentDivide(osg::Vec3d(1.0,1.0,1.0), ellipFrameInverse);
+            stateset->addUniform( new osg::Uniform("oe_ellipsoidFrame", osg::Vec3f(ellipFrame)) );
+        }
+        else
+        {
+            stateset->addUniform( new osg::Uniform("oe_ellipsoidFrameInverse", osg::Vec3f()) );
+            stateset->addUniform( new osg::Uniform("oe_ellipsoidFrame", osg::Vec3f()) );
+        }
     }
 
     // install the default rendermode uniform:
@@ -417,7 +425,7 @@ MapNode::~MapNode()
 
     ModelLayerVector modelLayers;
     _map->getModelLayers( modelLayers );
-    //Remove our model callback from any of the model layers in the map    
+    //Remove our model callback from any of the model layers in the map
     for (osgEarth::ModelLayerVector::iterator itr = modelLayers.begin(); itr != modelLayers.end(); ++itr)
     {
         this->onModelLayerRemoved( itr->get() );
@@ -460,6 +468,8 @@ MapNode::getMapSRS() const
 Terrain*
 MapNode::getTerrain()
 {
+    if (getTerrainEngine() == NULL)
+          return NULL;
     return getTerrainEngine()->getTerrain();
 }
 
@@ -495,7 +505,7 @@ MapNode::addExtension(Extension* extension, const osgDB::Options* options)
 
         else if ( getMap()->getDBOptions() )
             extension->setDBOptions( getMap()->getDBOptions() );
-        
+
         // start it.
         ExtensionInterface<MapNode>* extensionIF = ExtensionInterface<MapNode>::get(extension);
         if ( extensionIF )
@@ -577,13 +587,13 @@ MapNode::onModelLayerAdded( ModelLayer* layer, unsigned int index )
 {
     if ( !layer->getEnabled() )
         return;
-    
+
     // install a noe operation that will associate this mapnode with
     // any MapNodeObservers loaded by the model layer:
     ModelSource* modelSource = layer->getModelSource();
     if ( modelSource )
     {
-        // install a post-processing callback on the ModelLayer's source 
+        // install a post-processing callback on the ModelLayer's source
         // so we can update the MapNode on new data that comes in:
         modelSource->addPostMergeOperation( new MapNodeObserverInstaller(this) );
     }
@@ -597,7 +607,7 @@ MapNode::onModelLayerAdded( ModelLayer* layer, unsigned int index )
         if ( _modelLayerNodes.find( layer ) != _modelLayerNodes.end() )
         {
             OE_WARN
-                << "Illegal: tried to add the name model layer more than once: " 
+                << "Illegal: tried to add the name model layer more than once: "
                 << layer->getName()
                 << std::endl;
         }
@@ -660,10 +670,10 @@ MapNode::onModelLayerRemoved( ModelLayer* layer )
             {
                 _models->removeChild( node );
             }
-            
+
             _modelLayerNodes.erase( i );
         }
-        
+
         dirtyBound();
     }
 }
@@ -682,7 +692,7 @@ MapNode::onModelLayerMoved( ModelLayer* layer, unsigned int oldIndex, unsigned i
             _models->removeChild( node.get() );
             _models->insertChild( newIndex, node.get() );
         }
-        
+
         dirtyBound();
     }
 }
@@ -703,7 +713,7 @@ namespace
 
 void
 MapNode::addTerrainDecorator(osg::Group* decorator)
-{    
+{
     if ( _terrainEngine )
     {
         decorator->addChild( _terrainEngine );

--- a/src/osgEarthAnnotation/FeatureNode.cpp
+++ b/src/osgEarthAnnotation/FeatureNode.cpp
@@ -62,7 +62,7 @@ _styleSheet        ( styleSheet )
     _features.push_back( feature );
 
     FeatureNode::setMapNode( mapNode );
-    
+
     Style style = in_style;
     if (style.empty() && feature->style().isSet())
     {
@@ -72,7 +72,7 @@ _styleSheet        ( styleSheet )
     setStyle( style );
 }
 
-FeatureNode::FeatureNode(MapNode* mapNode, 
+FeatureNode::FeatureNode(MapNode* mapNode,
                          FeatureList& features,
                          const Style& style,
                          const GeometryCompilerOptions& options,
@@ -108,7 +108,7 @@ FeatureNode::build()
 
     // compilation options.
     GeometryCompilerOptions options = _options;
-    
+
     // figure out what kind of altitude manipulation we need to perform.
     AnnotationUtils::AltitudePolicy ap;
     AnnotationUtils::getAltitudePolicy( style, ap );
@@ -175,7 +175,7 @@ FeatureNode::build()
         {
             node = AnnotationUtils::installTwoPassAlpha( node );
         }
-        
+
         _attachPoint = new osg::Group();
         _attachPoint->addChild( node );
 
@@ -201,7 +201,7 @@ FeatureNode::build()
             }
         }
 
-        else 
+        else
         {
             this->addChild( _attachPoint );
 
@@ -211,14 +211,17 @@ FeatureNode::build()
             applyRenderSymbology( style );
         }
 
-        if ( ap.sceneClamping )
+        if ( getMapNode()->getTerrain() )
         {
-            getMapNode()->getTerrain()->addTerrainCallback( _clampCallback.get() );
-            clamp( getMapNode()->getTerrain(), getMapNode()->getTerrain()->getGraph() );
-        }
-        else
-        {
-            getMapNode()->getTerrain()->removeTerrainCallback( _clampCallback.get() );
+            if ( ap.sceneClamping )
+            {
+                getMapNode()->getTerrain()->addTerrainCallback( _clampCallback.get() );
+                clamp( getMapNode()->getTerrain(), getMapNode()->getTerrain()->getGraph() );
+            }
+            else
+            {
+                getMapNode()->getTerrain()->removeTerrainCallback( _clampCallback.get() );
+            }
         }
     }
 }
@@ -228,7 +231,7 @@ FeatureNode::setMapNode( MapNode* mapNode )
 {
     if ( getMapNode() != mapNode )
     {
-        if (_clampCallback.valid() && getMapNode())
+        if (_clampCallback.valid() && getMapNode() && getMapNode()->getTerrain())
             getMapNode()->getTerrain()->removeTerrainCallback( _clampCallback.get() );
 
         AnnotationNode::setMapNode( mapNode );
@@ -292,8 +295,8 @@ void FeatureNode::init()
 
 // This will be called by AnnotationNode when a new terrain tile comes in.
 void
-FeatureNode::onTileAdded(const TileKey&          key, 
-                         osg::Node*              tile, 
+FeatureNode::onTileAdded(const TileKey&          key,
+                         osg::Node*              tile,
                          TerrainCallbackContext& context)
 {
     if ( !tile || _featurePolytope.contains( tile->getBound() ) )
@@ -338,7 +341,7 @@ AnnotationNode(conf)
         if ( !geom.valid() )
             OE_WARN << LC << "Config is missing required 'geometry' element" << std::endl;
     }
-    
+
     osg::ref_ptr<const SpatialReference> srs;
     srs = SpatialReference::create( conf.value("srs"), conf.value("vdatum") );
     if ( !srs.valid() )
@@ -364,7 +367,7 @@ AnnotationNode(conf)
 
 Config
 FeatureNode::getConfig() const
-{    
+{
     Config conf("feature");
 
     if ( !_features.empty() )

--- a/src/osgEarthUtil/EarthManipulator.cpp
+++ b/src/osgEarthUtil/EarthManipulator.cpp
@@ -536,7 +536,7 @@ _findNodeTraversalMask  ( rhs._findNodeTraversalMask )
 EarthManipulator::~EarthManipulator()
 {
     osg::ref_ptr<MapNode> mapNode = _mapNode;
-    if (mapNode.valid() && _terrainCallback)
+    if (mapNode.valid() && _terrainCallback && mapNode->getTerrain())
     {
         mapNode->getTerrain()->removeTerrainCallback( _terrainCallback );
     }
@@ -677,12 +677,13 @@ EarthManipulator::established()
         return false;
 
     // resetablish the terrain callback on the map node:
-    if ( _terrainCallback.valid() )
+    if ( _terrainCallback.valid() && _mapNode->getTerrain() )
     {
         _mapNode->getTerrain()->removeTerrainCallback( _terrainCallback.get() );
     }
     _terrainCallback = new ManipTerrainCallback( this );
-    _mapNode->getTerrain()->addTerrainCallback( _terrainCallback );
+    if (_mapNode->getTerrain())
+        _mapNode->getTerrain()->addTerrainCallback( _terrainCallback );
 
     // Cache the SRS.
     _srs = _mapNode->getMapSRS();
@@ -1327,7 +1328,7 @@ bool
 EarthManipulator::intersect(const osg::Vec3d& start, const osg::Vec3d& end, osg::Vec3d& intersection, osg::Vec3d& normal) const
 {
     osg::ref_ptr<MapNode> mapNode;
-    if ( _mapNode.lock(mapNode) )
+    if ( _mapNode.lock(mapNode) && mapNode->getTerrainEngine() )
     {
 		osg::ref_ptr<osgUtil::LineSegmentIntersector> lsi = NULL;
 
@@ -1356,7 +1357,7 @@ EarthManipulator::intersectLookVector(osg::Vec3d& out_eye,
     bool success = false;
 
     osg::ref_ptr<MapNode> mapNode;
-    if ( _mapNode.lock(mapNode) )
+    if ( _mapNode.lock(mapNode) && mapNode->getTerrainEngine() )
     {
         double R = _centerHeight;
 
@@ -2605,7 +2606,7 @@ EarthManipulator::screenToWorld(float x, float y, osg::View* theView, osg::Vec3d
         return false;
 
     osg::ref_ptr<MapNode> mapNode;
-    if ( !_mapNode.lock(mapNode) )
+    if ( !_mapNode.lock(mapNode) || !mapNode->getTerrain() )
         return false;
 
     return mapNode->getTerrain()->getWorldCoordsUnderMouse(view, x, y, out_coords);


### PR DESCRIPTION
…. engine_mp) is not found.

Was getting a crash when the MP driver was explicitly used in configurations when the engine_mp plug-in was not found (typically due to end user misconfiguration).  This resolves the hard crash by adding NULL checks.