### PR TITLE
Fix some really minor typos in docs

### DIFF
--- a/docs/source/data.rst
+++ b/docs/source/data.rst
@@ -78,7 +78,7 @@ Tips for Preparing your own Data
     
     **Reproject your data**
 
-    osgEarth will reproject your data on your fly if it does not have the necessary
+    osgEarth will reproject your data on-the-fly if it does not have the necessary
     coordinate system.  For instance, if you are trying to view a UTM image on a
     geodetic globe (epsg:4326).  However, osgEarth will run much faster if your data
     is already in the correct coordinate system.  You can use any tool you want to 

--- a/docs/source/developer/utilities.rst
+++ b/docs/source/developer/utilities.rst
@@ -29,7 +29,7 @@ DataScanner
 
 The ``DataScanner`` will recursively search a directory tree on the local filesystem
 for files that it can load as ``ImageLayer`` objects. It is a quick and easy way to 
-load a full directory of images at layers.
+load a full directory of images as layers.
 
 **NOTE** that only the *MP Terrain Engine* supports an unlimited number of image layers,
 so it is wise to use that engine in conjunction with the DataScanner.
@@ -51,7 +51,7 @@ DetailTexture
 -------------
 
 ``DetailTexture`` is a terrain controller that will apply a non-geospatial texture
-cross the terrain. This is an old trick that you can use to generate "noise" that makes
+across the terrain. This is an old trick that you can use to generate "noise" that makes
 a low resolution terrain appear more detailed::
 
     DetailTexture* detail = new DetailTexture();
@@ -158,7 +158,7 @@ You can also specify options for the output string:
 MGRSFormatter
 ~~~~~~~~~~~~~
 
-The ``MGRSFormatter`` echos a string according to the `Military Grid Reference System`_. 
+The ``MGRSFormatter`` constructs a string according to the `Military Grid Reference System`_. 
 Technically, an MGRS coordinate represents a *region* rather than an exact point, so you
 have to specifiy a *precision* qualifier to control the size of the represented region.
 Example::

--- a/docs/source/references/drivers/cache/filesystem.rst
+++ b/docs/source/references/drivers/cache/filesystem.rst
@@ -22,7 +22,7 @@ Notes::
 	property on map layers to customize the naming to some extent.
 	
 	This cache supports expiration, but does NOT support size limits --
-	there is to way to cap the size of the cache.
+	there is no way to cap the size of the cache.
 	
 	Cache access is serialized since we are reading and writing
 	individual files on disk.

--- a/docs/source/references/earthfile.rst
+++ b/docs/source/references/earthfile.rst
@@ -117,7 +117,7 @@ These options control the rendering of the terrain surface.
 +-----------------------+--------------------------------------------------------------------+
 | min_tile_range_factor | Determines how close you need to be to a terrain tile for it to    |
 |                       | display. The value is the ratio of a tile's extent to its          |
-|                       | For example, if a tile is 10km is radius, and the MTRF=6, then the |
+|                       | For example, if a tile has a 10km radius, and the MTRF=6, then the |
 |                       | tile will become visible at a range of about 60km.                 |
 +-----------------------+--------------------------------------------------------------------+
 | min_lod               | The lowest level of detail that the terrain is guaranteed to       |
@@ -424,7 +424,7 @@ tiling scheme that it should use to render map tiles.
 | Property              | Description                                                        |
 +=======================+====================================================================+
 | srs                   | Spatial reference system of the map. This can be a WKT string, an  |
-|                       | ESPG code, a PROJ4 initialization string, or a stock profile name. |
+|                       | EPSG code, a PROJ4 initialization string, or a stock profile name. |
 |                       | Please refer to :doc:`/user/spatialreference` for details.         |
 +-----------------------+--------------------------------------------------------------------+
 | vdatum                | Vertical datum of the profile, which describes how to treat        |

--- a/docs/source/references/symbology.rst
+++ b/docs/source/references/symbology.rst
@@ -40,7 +40,7 @@ property includes the value type in parantheses following its description.
   :integer:               Integral number
   :numeric_expr:          Expression (simple or JavaScript) resolving to a number
   :string:                Simple text string
-  :string_expr:           Expression (simple or JacaScript) resolving to a text string
+  :string_expr:           Expression (simple or JavaScript) resolving to a text string
   :uri_string:            String denoting a resource location (like a URL or file path).
                           URIs can be absolute or relative; relative URIs are always
                           relative to the location of the *referrer*, i.e. the entity
@@ -128,7 +128,7 @@ the terrain under its location.
 |                       |   :gpu:    clamp geometry to the terrain on the GPU                |
 |                       |   :scene:  re-clamp geometry to new paged tiles (annotations only) |
 +-----------------------+--------------------------------------------------------------------+
-| altitude-binding      | Granulatiry at which to sample the terrain when                    |
+| altitude-binding      | Granularity at which to sample the terrain when                    |
 |                       | ``altitude-technique`` is ``map``:                                 |
 |                       |   :vertex:   clamp every vertex                                    |
 |                       |   :centroid: only clamp the centroid of each feature               |

--- a/docs/source/user/caching.rst
+++ b/docs/source/user/caching.rst
@@ -47,7 +47,7 @@ In code you can set a global cache in the osgEarth resgistry::
 
 Caching Policies
 ----------------
-Once you have a cache set up, osgEarth will use it be default for all your
+Once you have a cache set up, osgEarth will use it by default for all your
 imagery and elevation layers. If you want to override this behavior, you can
 use a *cache policy*. A cache policy tells osgEarth if and how a certain object 
 should utilize the cache.


### PR DESCRIPTION
These just caught my eye while I was reading the docs, so I thought I would put them to rest.