### PR TITLE
SL: Win32 build fix; Win32 requires cdecl to properly override.

### DIFF
--- a/src/osgEarthSilverLining/SilverLiningContext.cpp
+++ b/src/osgEarthSilverLining/SilverLiningContext.cpp
@@ -47,7 +47,7 @@ public:
         delete _defaultTimer;
     }
 
-    virtual unsigned long GetMilliseconds() const
+    virtual unsigned long SILVERLINING_API GetMilliseconds() const
     {
         osg::ref_ptr<SilverLiningContext> context;
         unsigned long milliseconds = 0;


### PR DESCRIPTION
Instead of adding my own ifdef that mirrored SILVERLINING_API's, I just used SILVERLINING_API.  On _WIN32 it's defined as __cdecl; see SilverLining/MemAlloc.h.