### PR TITLE
Link X11 to fix FTBFS.

### DIFF
--- a/src/applications/osgearth_demo/CMakeLists.txt
+++ b/src/applications/osgearth_demo/CMakeLists.txt
@@ -16,6 +16,7 @@ ELSE()
         ${QT_QTCORE_LIBRARY}
         ${QT_QTGUI_LIBRARY}
         ${QT_QTOPENGL_LIBRARY}
+        X11
     )
 ENDIF()
 

--- a/src/applications/osgearth_package_qt/CMakeLists.txt
+++ b/src/applications/osgearth_package_qt/CMakeLists.txt
@@ -60,6 +60,7 @@ SET(TARGET_ADDED_LIBRARIES
     ${QT_QTCORE_LIBRARY}
     ${QT_QTGUI_LIBRARY}
     ${QT_QTOPENGL_LIBRARY}
+    X11
 )
 
 #### end var setup  ###

--- a/src/applications/osgearth_qt_simple/CMakeLists.txt
+++ b/src/applications/osgearth_qt_simple/CMakeLists.txt
@@ -35,6 +35,7 @@ SET(TARGET_ADDED_LIBRARIES
     ${QT_QTCORE_LIBRARY}
     ${QT_QTGUI_LIBRARY}
     ${QT_QTOPENGL_LIBRARY}
+    X11
 )
 
 #### end var setup  ###

--- a/src/applications/osgearth_qt_windows/CMakeLists.txt
+++ b/src/applications/osgearth_qt_windows/CMakeLists.txt
@@ -30,6 +30,7 @@ SET(TARGET_ADDED_LIBRARIES
     ${QT_QTCORE_LIBRARY}
     ${QT_QTGUI_LIBRARY}
     ${QT_QTOPENGL_LIBRARY}
+    X11
 )
 
 #### end var setup  ###


### PR DESCRIPTION
This patch has been included in Debian package for a while, and originates from the Fedora package.

It fixes this build failure:
 ```
/usr/bin/ld: CMakeFiles/application_osgearth_package_qt.dir/package_qt.cpp.o: undefined reference to symbol 'XInitThreads'
//usr/lib/x86_64-linux-gnu/libX11.so.6: error adding symbols: DSO missing from command line
```
Author: Sandro Mani <manisandro@gmail.com>
Origin: https://kojipkgs.fedoraproject.org//packages/osgearth/2.6/4.fc22/src/osgearth-2.6-4.fc22.src.rpm