### PR TITLE
Fix spelling errors.

### DIFF
--- a/docs/source/user/tools.rst
+++ b/docs/source/user/tools.rst
@@ -95,7 +95,7 @@ The most common usage of osgearth_cache is to populate a cache in a non-interact
 +-------------------------------------+--------------------------------------------------------------------+
 | ``--mt``                            | Use multithreading to process the tiles.                           |
 +-------------------------------------+--------------------------------------------------------------------+
-| ``--concurrency``                   | The number of threads or proceses to use if --mp or --mt           |
+| ``--concurrency``                   | The number of threads or processes to use if --mp or --mt          |
 |                                     | are provided                                                       | 
 +-------------------------------------+--------------------------------------------------------------------+
 | ``--min-level level``               | Lowest LOD level to seed (default=0)                               |
@@ -160,7 +160,7 @@ osgearth_package creates a redistributable `TMS`_ based package from an earth fi
 +------------------------------------+--------------------------------------------------------------------+
 | ``--mt``                           | Use multithreading to process the tiles.                           |
 +------------------------------------+--------------------------------------------------------------------+
-| ``--concurrency``                  | The number of threads or proceses to use if --mp or --mt           |
+| ``--concurrency``                  | The number of threads or processes to use if --mp or --mt          |
 |                                    | are provided                                                       | 
 +------------------------------------+--------------------------------------------------------------------+
 | ``--alpha-mask``                   | Mask out imagery that isn't in the provided extents.               |

--- a/src/applications/osgearth_package/osgearth_package.cpp
+++ b/src/applications/osgearth_package/osgearth_package.cpp
@@ -71,7 +71,7 @@ usage( const std::string& msg = "" )
         << "            [--db-options]                : db options string to pass to the image writer in quotes (e.g., \"JPEG_QUALITY 60\")\n"
         << "            [--mp]                          ; Use multiprocessing to process the tiles.  Useful for GDAL sources as this avoids the global GDAL lock" << std::endl
         << "            [--mt]                          ; Use multithreading to process the tiles." << std::endl
-        << "            [--concurrency]                 ; The number of threads or proceses to use if --mp or --mt are provided." << std::endl
+        << "            [--concurrency]                 ; The number of threads or processes to use if --mp or --mt are provided." << std::endl
         << "            [--alpha-mask]                  ; Mask out imagery that isn't in the provided extents." << std::endl
         << std::endl
         << "            [--verbose]                     ; Displays progress of the operation" << std::endl;

--- a/src/applications/osgearth_seed/osgearth_seed.cpp
+++ b/src/applications/osgearth_seed/osgearth_seed.cpp
@@ -89,7 +89,7 @@ int
         << "        [--index shapefile]             ; Use the feature extents in a shapefile to set the bounding boxes for seeding" << std::endl
         << "        [--mp]                          ; Use multiprocessing to process the tiles.  Useful for GDAL sources as this avoids the global GDAL lock" << std::endl
         << "        [--mt]                          ; Use multithreading to process the tiles." << std::endl
-        << "        [--concurrency]                 ; The number of threads or proceses to use if --mp or --mt are provided." << std::endl
+        << "        [--concurrency]                 ; The number of threads or processes to use if --mp or --mt are provided." << std::endl
         << "        [--verbose]                     ; Displays progress of the seed operation" << std::endl
         << std::endl
         << "    --purge file.earth                  ; Purges a layer cache in a .earth file (interactive)" << std::endl

--- a/src/osgEarth/GPUClamping.vert.lib.glsl
+++ b/src/osgEarth/GPUClamping.vert.lib.glsl
@@ -27,7 +27,7 @@ void oe_getClampedViewVertex(in vec4 vertView, out vec4 out_clampedVertView, out
     out_clampedVertView = oe_clamp_depthClip2cameraView * clampedVertDepthClip;
 }
 
-// Returns a vector indiciating the "down" direction.
+// Returns a vector indicating the "down" direction.
 void oe_getClampingUpVector(out vec3 up)
 {
     up = normalize(mat3(oe_clamp_depthClip2cameraView) * vec3(0,0,-1));

--- a/src/osgEarthDrivers/osg/OSGTileSource.cpp
+++ b/src/osgEarthDrivers/osg/OSGTileSource.cpp
@@ -88,7 +88,7 @@ public:
 
         if ( !image.valid() )
         {
-            return Status::Error( Status::ResourceUnavailable, Stringify() <<  "Faild to load data from \"" << _options.url()->full() << "\"" );
+            return Status::Error( Status::ResourceUnavailable, Stringify() <<  "Failed to load data from \"" << _options.url()->full() << "\"" );
         }
 
         // calculate and store the maximum LOD for which to return data

--- a/src/osgEarthFeatures/ExtrudeGeometryFilter.cpp
+++ b/src/osgEarthFeatures/ExtrudeGeometryFilter.cpp
@@ -1222,7 +1222,7 @@ ExtrudeGeometryFilter::push( FeatureList& input, FilterContext& context )
     AllocateAndMergeBufferObjectsVisitor allocAndMerge;
     group->accept( allocAndMerge );
 
-    // set a uniform indiciating that clamping attributes are available.
+    // set a uniform indicating that clamping attributes are available.
     Clamping::installHasAttrsUniform( group->getOrCreateStateSet() );
 
     // if we drew outlines, apply a poly offset too.


### PR DESCRIPTION
These spelling errors were reported by the lintian QA tool for the Debian package build:

 * proceses    -> processes
 * Faild       -> Failed
 * indiciating -> indicating