### PR TITLE
Implement Cache::clear()

### DIFF
--- a/src/osgEarth/Cache
+++ b/src/osgEarth/Cache
@@ -207,7 +207,7 @@ namespace osgEarth
          * Removes all records in the cache (if possible). This could take
          * some time to complete.
          */
-        virtual bool clear() { return false; }
+        virtual bool clear();
 
     protected:
         bool                   _ok;

--- a/src/osgEarth/Cache.cpp
+++ b/src/osgEarth/Cache.cpp
@@ -142,6 +142,12 @@ Cache::removeBin( CacheBin* bin )
     _bins.remove( bin );
 }
 
+bool Cache::clear()
+{
+    _bins.clear();
+    return false;
+}
+
 //------------------------------------------------------------------------
 
 #undef  LC

--- a/src/osgEarth/Containers
+++ b/src/osgEarth/Containers
@@ -768,6 +768,12 @@ namespace osgEarth
             }
         }
 
+        void clear()
+        {
+            osgEarth::Threading::ScopedWriteLock exclusive(_mutex);
+            _data.clear();
+        }
+
     private:
         std::map<KEY,osg::ref_ptr<DATA> >    _data;
         osgEarth::Threading::ReadWriteMutex  _mutex;


### PR DESCRIPTION
To this end, PerObjectRefMap::clear needed to be implemented too (simple
call to clear method of std::map<>)