### PR TITLE
ReaderWriterWMS: Locale independent bounds serialization

### DIFF
--- a/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
+++ b/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
@@ -480,8 +480,15 @@ public:
         double minx, miny, maxx, maxy;
         key.getExtent().getBounds( minx, miny, maxx, maxy);
         
+        // Convert numbers only in "C" locale (decimal point is dot)
+        // Store current numeric locale
+        char *cur_lc_numeric = setlocale(LC_NUMERIC, "C");
+
         char buf[2048];
         sprintf(buf, _prototype.c_str(), minx, miny, maxx, maxy);
+
+        // Restore current numeric locale
+        setlocale(LC_NUMERIC, cur_lc_numeric);
         
         std::string uri(buf);
 


### PR DESCRIPTION
BBOX of eight numbers? It's true for locale with desimal point is the `,`.

Use the `sprintf` function is not safe here. The result depends on the locale.

The result is an improper URL request which can not be recognized cartographic server.

This request is a patch for a quick solution to the problem. Probably it is necessary to improve the implementation, but I have no time to do it. I just want to draw attention to the problem.