### PR TITLE
VAO support

### DIFF
--- a/src/applications/osgearth_viewer/osgearth_viewer.cpp
+++ b/src/applications/osgearth_viewer/osgearth_viewer.cpp
@@ -52,6 +52,8 @@ main(int argc, char** argv)
 
     float vfov = -1.0f;
     arguments.read("--vfov", vfov);
+    
+    osg::DisplaySettings::instance()->setVertexBufferHint(osg::DisplaySettings::VertexBufferHint::VERTEX_ARRAY_OBJECT);
 
     // create a viewer:
     osgViewer::Viewer viewer(arguments);

--- a/src/applications/osgearth_viewer/osgearth_viewer.cpp
+++ b/src/applications/osgearth_viewer/osgearth_viewer.cpp
@@ -53,7 +53,10 @@ main(int argc, char** argv)
     float vfov = -1.0f;
     arguments.read("--vfov", vfov);
     
-    osg::DisplaySettings::instance()->setVertexBufferHint(osg::DisplaySettings::VertexBufferHint::VERTEX_ARRAY_OBJECT);
+#if OSG_MIN_VERSION_REQUIRED(3,5,6)
+    //uncomment for VAOs
+    //osg::DisplaySettings::instance()->setVertexBufferHint(osg::DisplaySettings::VertexBufferHint::VERTEX_ARRAY_OBJECT);
+#endif
 
     // create a viewer:
     osgViewer::Viewer viewer(arguments);

--- a/src/osgEarthDrivers/engine_mp/MPGeometry.cpp
+++ b/src/osgEarthDrivers/engine_mp/MPGeometry.cpp
@@ -125,6 +125,10 @@ _supportsGLSL(false)
     // we will set these later (in TileModelCompiler)
     this->setUseDisplayList(false);
     this->setUseVertexBufferObjects(true);
+    
+#if OSG_MIN_VERSION_REQUIRED(3,5,6)
+    if(osg::DisplaySettings::instance()->getVertexBufferHint() == osg::DisplaySettings::VERTEX_ARRAY_OBJECT) this->setUseVertexArrayObject(true);
+#endif
 }
 
 
@@ -692,8 +696,13 @@ MPGeometry::drawImplementation(osg::RenderInfo& renderInfo) const
     renderPrimitiveSets(state, renderColor, true);
 
     // unbind the VBO's if any are used.
-    state.unbindVertexBufferObject();
-    state.unbindElementBufferObject();
+#if OSG_MIN_VERSION_REQUIRED(3,5,6)
+    if (!state.useVertexArrayObject(_useVertexArrayObject) || state.getCurrentVertexArrayState()->getRequiresSetArrays())
+#endif
+    {
+        state.unbindVertexBufferObject();
+        state.unbindElementBufferObject();
+    }
 }
 
 void

--- a/src/osgEarthDrivers/engine_mp/TileModelCompiler.cpp
+++ b/src/osgEarthDrivers/engine_mp/TileModelCompiler.cpp
@@ -425,6 +425,9 @@ namespace
 
 #else // not USE_TEXCOORD_CACHE
         d.renderTileCoords = new osg::Vec2Array();
+#if OSG_MIN_VERSION_REQUIRED(3,5,6)
+        if(osg::DisplaySettings::instance()->getVertexBufferHint() == osg::DisplaySettings::VERTEX_ARRAY_OBJECT) d.renderTileCoords->setVertexBufferObject( new osg::VertexBufferObject() );
+#endif
         d.renderTileCoords->reserve( d.numVerticesInSurface );
         d.ownsTileCoords = true;
 #endif
@@ -470,6 +473,9 @@ namespace
 
 #else // not USE_TEXCOORD_CACHE
                     r._texCoords = new osg::Vec2Array();
+#if OSG_MIN_VERSION_REQUIRED(3,5,6)
+                    if(osg::DisplaySettings::instance()->getVertexBufferHint() == osg::DisplaySettings::VERTEX_ARRAY_OBJECT) r._texCoords->setVertexBufferObject( new osg::VertexBufferObject() );
+#endif
                     r._texCoords->reserve( d.numVerticesInSurface );
                     r._ownsTexCoords = true;
 #endif


### PR DESCRIPTION
Hey Glenn

Here are the changes merged into master. It's actually just adding a vertex buffer object to for the texture coords and switching VAOs on.

Basically you can bind and unbind vbos while a vao is bound your just kind of losing the benefit of vaos. The issues where being caused by the fact the texture coords where sharing their vbos, altering that in vao was the issue.

Previously I did have to override createVertexArrayState in MPGeometry as their weren't enough array dispatchers allocated for the other texture cord channels, but that crash seems to have disappeared.

Anyhow it runs on my mac with a GL3 context.