### PR TITLE
Re added createVertexArrayStates fix

### DIFF
--- a/src/osgEarth/HTTPClient.cpp
+++ b/src/osgEarth/HTTPClient.cpp
@@ -1311,7 +1311,7 @@ HTTPClient::doGet(const HTTPRequest&    request,
 
     METRIC_END("HTTPClient::doGet", 2,
                "response_code", toString<int>(response.getCode()).c_str(),
-               "canceled", toString<bool>(response.isCancelled()));
+               "canceled", toString<bool>(response.isCancelled()).c_str());
 
     return response;
 }

--- a/src/osgEarthDrivers/engine_mp/MPGeometry
+++ b/src/osgEarthDrivers/engine_mp/MPGeometry
@@ -153,7 +153,9 @@ namespace osgEarth { namespace Drivers { namespace MPTerrainEngine
 #endif
 
     protected:
+#if OSG_MIN_VERSION_REQUIRED(3,5,6)
         virtual osg::VertexArrayState* createVertexArrayState(osg::RenderInfo& renderInfo) const;
+#endif
 
     public:
         META_Object(osgEarth, MPGeometry);

--- a/src/osgEarthDrivers/engine_mp/MPGeometry
+++ b/src/osgEarthDrivers/engine_mp/MPGeometry
@@ -152,6 +152,9 @@ namespace osgEarth { namespace Drivers { namespace MPTerrainEngine
         osg::BoundingBox computeBound() const;
 #endif
 
+    protected:
+        virtual osg::VertexArrayState* createVertexArrayState(osg::RenderInfo& renderInfo) const;
+
     public:
         META_Object(osgEarth, MPGeometry);
         MPGeometry();

--- a/src/osgEarthDrivers/engine_mp/MPGeometry.cpp
+++ b/src/osgEarthDrivers/engine_mp/MPGeometry.cpp
@@ -587,6 +587,19 @@ MPGeometry::compileGLObjects( osg::RenderInfo& renderInfo ) const
 }
 
 
+osg::VertexArrayState*
+MPGeometry::createVertexArrayState(osg::RenderInfo& renderInfo) const
+{
+    osg::VertexArrayState* vas = osg::Geometry::createVertexArrayState(renderInfo);
+    
+    // make sure we have array dispatchers for the multipass coords
+    if(osg::DisplaySettings::instance()->getVertexBufferHint() == osg::DisplaySettings::VERTEX_ARRAY_OBJECT)
+        vas->assignTexCoordArrayDispatcher(_texCoordList.size() + 2);
+
+    return vas;
+}
+
+
 void 
 MPGeometry::drawImplementation(osg::RenderInfo& renderInfo) const
 {

--- a/src/osgEarthDrivers/engine_mp/MPGeometry.cpp
+++ b/src/osgEarthDrivers/engine_mp/MPGeometry.cpp
@@ -586,7 +586,7 @@ MPGeometry::compileGLObjects( osg::RenderInfo& renderInfo ) const
     osg::Geometry::compileGLObjects( renderInfo );
 }
 
-
+#if OSG_MIN_VERSION_REQUIRED(3,5,6)
 osg::VertexArrayState*
 MPGeometry::createVertexArrayState(osg::RenderInfo& renderInfo) const
 {
@@ -598,6 +598,7 @@ MPGeometry::createVertexArrayState(osg::RenderInfo& renderInfo) const
 
     return vas;
 }
+#endif
 
 
 void 


### PR DESCRIPTION
Hi Glenn

Remo ran into an issue I was previously having with VAO on OSX but I thought it had been fixed within osg. Turns out it hadn't

So the change to MPGeometry is required because on line 239 of MPGeometry.cpp a texture coord unit is used that wasn't part of the geometry texture arrays. This means no vertex array dispatcher was created for it so it crashes.

I feel like it should nearly always crash, but it seems fine in some cases and like I said it stopped crashing on me, but a .earth file with no layers causes it to happen still.

The fix is pretty ugly I think, but it works and I've made it only apply when VOAs are in use as no one else seems to have the issue.

I also fixed a small compiler error in HTTPClient.cpp

My topic-vao-osx branch was merged with latest master before I did these changes