### PR TITLE
Minor linux warning fixes on g++ 4.8.4

### DIFF
--- a/src/osgEarth/TraversalData
+++ b/src/osgEarth/TraversalData
@@ -83,7 +83,7 @@ namespace osgEarth
             std::string _key;
 
             Install(const std::string& key) : _key(key) { }
-            Install(const std::string& key, osg::Referenced* data) : _key(key), _data(data) { }
+            Install(const std::string& key, osg::Referenced* data) : _data(data), _key(key) { }
 
             void operator()(osg::Node* node, osg::NodeVisitor* nv)
             {

--- a/src/osgEarthUtil/Controls
+++ b/src/osgEarthUtil/Controls
@@ -55,7 +55,7 @@ namespace osgEarth { namespace Util { namespace Controls
     // internal state class
     struct ControlContext
     {
-        ControlContext() : _viewContextID(~0), _frameStamp(0L), _view(0L) { }
+        ControlContext() : _view(0L), _viewContextID(~0), _frameStamp(0L) { }
         osg::View* _view;
         osg::ref_ptr<const osg::Viewport> _vp;
         unsigned int _viewContextID;


### PR DESCRIPTION
Reordered parameters to match declaration order as per Linux warning finding.  No functionality change.