### PR TITLE
Added conditional support for exp2 to fix MSVC 2010 and 2012 builds.

### DIFF
--- a/src/osgEarthUtil/CMakeLists.txt
+++ b/src/osgEarthUtil/CMakeLists.txt
@@ -11,7 +11,7 @@ SET(HEADER_PATH ${OSGEARTH_SOURCE_DIR}/include/${LIB_NAME})
 SET(HEADERS_ROOT
     ActivityMonitorTool
     AnnotationEvents
-    AutoClipPlaneHandler    
+    AutoClipPlaneHandler
     ArcGIS
     AtlasBuilder
     Common
@@ -85,7 +85,7 @@ set(TARGET_GLSL
     Graticule.vert.glsl
     Graticule.frag.glsl
     LogDepthBuffer.vert.glsl
-    LogDepthBuffer.VertOnly.vert.glsl    
+    LogDepthBuffer.VertOnly.vert.glsl
     LogDepthBuffer.frag.glsl
     Shadowing.vert.glsl
     Shadowing.frag.glsl
@@ -95,7 +95,7 @@ set(TARGET_GLSL
 set(TARGET_IN
     Shaders.cpp.in)
 
-configure_shaders(            
+configure_shaders(
     Shaders.cpp.in
     ${SHADERS_CPP}
     ${TARGET_GLSL} )
@@ -192,7 +192,7 @@ SET(LIB_PUBLIC_HEADERS
     ${HEADERS_COLORFILTER}
 )
 
-SET(LIB_COMMON_FILES 
+SET(LIB_COMMON_FILES
     ${SOURCES_ROOT} ${SOURCES_COLORFILTER}
 )
 
@@ -206,6 +206,13 @@ ADD_LIBRARY(${LIB_NAME} ${OSGEARTH_USER_DEFINED_DYNAMIC_OR_STATIC}
 # Setting this tells ModuleInstall not to set source groups (since we're doing it here)
 SET(USE_CUSTOM_SOURCE_GROUPS 1)
 
+# Detect presence of exp2() (not available on all platforms)
+INCLUDE(CheckFunctionExists)
+SET(CMAKE_REQUIRED_INCLUDES cmath)
+CHECK_FUNCTION_EXISTS(exp2 HAVE_EXP2)
+IF(HAVE_EXP2)
+  ADD_DEFINITIONS(-DHAVE_EXP2)
+ENDIF()
 
 
 INCLUDE_DIRECTORIES(${OSG_INCLUDE_DIR} ${OSGEARTH_SOURCE_DIR} ${GDAL_INCLUDE_DIR})

--- a/src/osgEarthUtil/FractalElevationLayer.cpp
+++ b/src/osgEarthUtil/FractalElevationLayer.cpp
@@ -86,7 +86,7 @@ namespace
             noise.setPersistence(_options.persistence().get());
             noise.setLacunarity(_options.lacunarity().get());
             noise.setOctaves(std::min(12u, key.getLOD()-_options.baseLOD().get()));
-            
+
             SimplexNoise noise2;
             noise2.setNormalize(true);
             noise2.setRange(-1.0, 1.0);
@@ -118,10 +118,10 @@ namespace
                     n = noise.getTiledValue(uScaled, vScaled);
                     h = n * _options.amplitude().get();
 #endif
-                    
+
                     const double threshold = 0.15;
 #if 0
-                    // Adjust the persistence based on... 
+                    // Adjust the persistence based on...
                     // here it's the first noise value, but later it might be the slope
                     // or the land class classification.
                     double f = 0.5*(n+1.0);
@@ -168,7 +168,11 @@ namespace
         void scaleCoordsToLOD(double& u, double& v, int baseLOD, const TileKey& key)
         {
             double dL = (double)((int)key.getLOD() - baseLOD);
-            double factor = exp2(dL); // pow(2.0, dL); //exp2(dL);
+#ifdef HAVE_EXP2
+            double factor = exp2(dL); // pow(2.0, dL);
+#else
+            double factor = pow(2.0, dL); //exp2(dL);
+#endif
             double invFactor = 1.0/factor;
 
             u *= invFactor;
@@ -184,10 +188,10 @@ namespace
 
                 double ax = floor(tx * invFactor);
                 double ay = floor(ty * invFactor);
-            
+
                 double bx = ax * factor;
                 double by = ay * factor;
-            
+
                 double cx = bx + factor;
                 double cy = by + factor;
 


### PR DESCRIPTION
Added an ifdef around exp2 usage, which is not available on all compilers.  An alternate solution is to replace exp2 with pow(2.0, dL), but there are possibly performance or precision issues with that solution.