### PR TITLE
Simple Sky: Sun alpha is now correct and no longer obscures stars.

### DIFF
--- a/src/osgEarthDrivers/sky_simple/SimpleSky.Sun.frag.glsl
+++ b/src/osgEarthDrivers/sky_simple/SimpleSky.Sun.frag.glsl
@@ -15,5 +15,7 @@ void main( void )
 { 
    float fCos = -atmos_v3Direction[2];          
    float fMiePhase = 0.050387596899224826 * (1.0 + fCos*fCos) / atmos_fastpow(1.9024999999999999 - -1.8999999999999999*fCos, 1.5); 
-   out_FragColor = vec4(fMiePhase*vec3(.3,.3,.2), atmos_sunAlpha); //*gl_FragColor.r);
+   out_FragColor.rgb = fMiePhase*vec3(.3,.3,.2);
+   // Alpha needs to scale from full at the center (where red == 1) to 0 on the edges of sun disc
+   out_FragColor.a = atmos_sunAlpha * out_FragColor.r;
 }


### PR DESCRIPTION
Broken by a combination of bfdc92a9b and 9347baed4d.