### PR TITLE
Add GEOS >= 3.6.0 compatibility

### DIFF
--- a/src/osgEarthSymbology/GEOS
+++ b/src/osgEarthSymbology/GEOS
@@ -25,7 +25,9 @@
 #include <osgEarthFeatures/Common>
 #include <osgEarthSymbology/Style>
 #include <osgEarthSymbology/Geometry>
+#include <geos/version.h>
 #include <geos/geom/Geometry.h>
+#include <geos/geom/GeometryFactory.h>
 
 namespace osgEarth { namespace Symbology
 {
@@ -45,7 +47,11 @@ namespace osgEarth { namespace Symbology
         void disposeGeometry(geos::geom::Geometry* input);
 
     protected:
+#if GEOS_VERSION_MAJOR >= 3 && GEOS_VERSION_MINOR >= 6
+        geos::geom::GeometryFactory::unique_ptr _factory;
+#else
         geos::geom::GeometryFactory* _factory;
+#endif
     };
 
 } } // namespace osgEarth::Features

--- a/src/osgEarthSymbology/GEOS.cpp
+++ b/src/osgEarthSymbology/GEOS.cpp
@@ -216,7 +216,11 @@ GEOSContext::GEOSContext()
     geos::geom::PrecisionModel* pm = new geos::geom::PrecisionModel(geom::PrecisionModel::FLOATING);
 
     // Factory will clone the PM
+#if GEOS_VERSION_MAJOR >= 3 && GEOS_VERSION_MINOR >= 6
+    _factory = geos::geom::GeometryFactory::create( pm );
+#else
     _factory = new geos::geom::GeometryFactory( pm );
+#endif
 
     // Delete the template.
     delete pm;
@@ -224,7 +228,9 @@ GEOSContext::GEOSContext()
 
 GEOSContext::~GEOSContext()
 {
+#if !(GEOS_VERSION_MAJOR >= 3 && GEOS_VERSION_MINOR >= 6)
     delete _factory;
+#endif
 }
 
 geom::Geometry*
@@ -233,12 +239,16 @@ GEOSContext::importGeometry(const Symbology::Geometry* input)
     geom::Geometry* output = 0L;
     if ( input && input->isValid() )
     {
+#if GEOS_VERSION_MAJOR >= 3 && GEOS_VERSION_MINOR >= 6
+        output = import( input, _factory.get() );
+#else
         output = import( input, _factory );
 
         // if output is ok, it will have a pointer to f. this is probably a leak.
         // TODO: Check whether this is a leak!! -gw
         //if ( !output )
         //    delete f;
+#endif
     }
     return output;
 }
@@ -335,10 +345,13 @@ GEOSContext::disposeGeometry(geom::Geometry* input)
 {
     if (input)
     {
-        geom::GeometryFactory* f = const_cast<geom::GeometryFactory*>(input->getFactory());
+#if GEOS_VERSION_MAJOR >= 3 && GEOS_VERSION_MINOR >= 6
         _factory->destroyGeometry(input);
+#else
+        geom::GeometryFactory* f = const_cast<geom::GeometryFactory*>(input->getFactory());
         if ( f != _factory )
             delete f;
+#endif
     }
 }
 


### PR DESCRIPTION
Replaces #848, adds support for GEOS >= 3.6.0 while preserving compatibility with older GEOS versions.