### PR TITLE
msys2: fix link error

### DIFF
--- a/src/osgEarth/Profile
+++ b/src/osgEarth/Profile
@@ -75,10 +75,7 @@ namespace osgEarth
         Config getConfig() const;
 
     protected:
-        void mergeConfig( const Config& conf ) {
-            ConfigOptions::mergeConfig( conf );
-            fromConfig( conf );
-        }
+        virtual void mergeConfig( const Config& conf );
 
     private:
         void fromConfig( const Config& conf );

--- a/src/osgEarth/Profile.cpp
+++ b/src/osgEarth/Profile.cpp
@@ -56,6 +56,12 @@ _numTilesHighAtLod0( 1 )
     _namedProfile = namedProfile; // don't set above
 }
 
+ void
+ ProfileOptions::mergeConfig( const Config& conf ) {
+    ConfigOptions::mergeConfig( conf );
+    fromConfig( conf );
+}
+
 void
 ProfileOptions::fromConfig( const Config& conf )
 {


### PR DESCRIPTION
since upgrading to gcc 6.3.0 some plugins fail to link
because of undefined reference to `osgEarth::ProfileOptions::mergeConfig(osgEarth::Config const&)'