### PR TITLE
Config: Moved global into local scope to avoid global initialization …

### DIFF
--- a/src/osgEarth/Config.cpp
+++ b/src/osgEarth/Config.cpp
@@ -34,11 +34,6 @@ using namespace osgEarth;
 
 #define LC "[Config] "
 
-namespace
-{
-    Config s_emptyConf;
-}
-
 Config::~Config()
 {
 }
@@ -94,6 +89,7 @@ Config::child( const std::string& childName ) const
         if ( i->key() == childName )
             return *i;
     }
+    static Config s_emptyConf;
     return s_emptyConf;
     //Config emptyConf;
     //emptyConf.setReferrer( _referrer );


### PR DESCRIPTION
…order issue on g++ 4.4.

Fixes crash bug on Linux running against g++ 4.4 of osgEarth.