### PR TITLE
OverlayDecorator: Check engine for validity before dereferencing

### DIFF
--- a/src/osgEarth/OverlayDecorator.cpp
+++ b/src/osgEarth/OverlayDecorator.cpp
@@ -358,7 +358,8 @@ OverlayDecorator::initializePerViewData( PerViewData& pvd, osg::Camera* cam )
         params._group = _overlayGroups[i].get();
         params._terrainStateSet = pvd._sharedTerrainStateSet.get(); // share it.
         params._horizonDistance = &pvd._sharedHorizonDistance;      // share it.
-        params._terrainResources = _engine->getResources();
+        if (_engine.valid())
+            params._terrainResources = _engine->getResources();
         params._mainCamera = cam;
     }
 }
@@ -420,7 +421,7 @@ OverlayDecorator::cullTerrainAndCalculateRTTParams(osgUtil::CullVisitor* cv,
 
     OE_TEST << LC << "------- OD CULL ------------------------" << std::endl;
 
-    if ( _isGeocentric )
+    if ( _isGeocentric && _engine.valid() )
     {
         eyeLen = eye.length();
 


### PR DESCRIPTION
We were getting a crash in a headless startup that had an incomplete setup.  The setup didn't have LD_LIBRARY_PATH set up to find REX engine.  This fixes minor crashes related to the engine not existing.