### PR TITLE
Fix broken download link for AlphaPixel

### DIFF
--- a/docs/source/startup.rst
+++ b/docs/source/startup.rst
@@ -95,7 +95,7 @@ Here are a few tips.
 .. _GDAL:           http://www.gdal.org/
 .. _GDAL binaries:  http://www.gisinternals.com/
 .. _FWTools:        http://fwtools.maptools.org/
-.. _AlphaPixel:     http://openscenegraph.alphapixel.com/osg/downloads/openscenegraph-third-party-library-downloads
+.. _AlphaPixel:     http://downloads.alphapixel.org/
 .. _Mike Weiblen:   http://mew.cx/osg/
 .. _the forum:      http://forum.osgearth.org
 .. _LevelDB:        https://github.com/pelicanmapping/leveldb


### PR DESCRIPTION
Previous link was now a 404. Went to alphapixel.com and found current link to their downloads of prebuilt OSG and 3rd party dependencies