### PR TITLE
Windows GLCore/GL3 support and GL3 compile fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,6 +208,11 @@ ENDIF(UNIX)
 
 
 IF(WIN32)
+  FIND_PACKAGE(GLCORE)
+  IF(GLCORE_FOUND)
+      INCLUDE_DIRECTORIES( ${GLCORE_INCLUDE_DIR} )
+  ENDIF()    
+
   IF(MSVC)
         # This option is to enable the /MP switch for Visual Studio 2005 and above compilers
         OPTION(WIN32_USE_MP "Set to ON to build osgEarth with the /MP option (Visual Studio 2005 and above)." OFF)

--- a/CMakeModules/FindGLCORE.cmake
+++ b/CMakeModules/FindGLCORE.cmake
@@ -1,0 +1,36 @@
+# Finds the OpenGL Core Profile (cp) header file.
+# Looks for glcorearb.h
+# 
+# This script defines the following:
+#  GLCORE_FOUND // Set to TRUE if glcorearb.h is found
+#  GLCORE_INCLUDE_DIR // Parent directory of directory (gl, GL3, or OpenGL) containing the CP header.
+#  GLCORE_GLCOREARB_HEADER // advanced
+#
+# GLCORE_ROOT can be set as an environment variable or a CMake variable,
+# to the parent directory of the gl, GL3, or OpenGL directory containing the CP header.
+#
+
+
+FIND_PATH( GLCORE_GLCOREARB_HEADER
+    NAMES GL/glcorearb.h GL3/glcorearb.h OpenGL/glcorearb.h gl/glcorearb.h
+    HINTS ${GLCORE_ROOT}
+    PATHS ENV GLCORE_ROOT
+)
+
+set( GLCORE_INCLUDE_DIR )
+if( GLCORE_GLCOREARB_HEADER )
+    set( GLCORE_INCLUDE_DIR ${GLCORE_GLCOREARB_HEADER} )
+endif()
+
+
+# handle the QUIETLY and REQUIRED arguments and set
+# GLCORE_FOUND to TRUE as appropriate
+INCLUDE( FindPackageHandleStandardArgs )
+FIND_PACKAGE_HANDLE_STANDARD_ARGS( GLCORE
+    "Set GLCORE_ROOT as the parent of the directory containing the OpenGL core profile header."
+    GLCORE_INCLUDE_DIR )
+
+MARK_AS_ADVANCED(
+    GLCORE_INCLUDE_DIR
+    GLCORE_GLCOREARB_HEADER
+)

--- a/src/osgEarth/Capabilities.cpp
+++ b/src/osgEarth/Capabilities.cpp
@@ -206,9 +206,10 @@ _maxTextureBufferSize   ( 0 )
         glGetIntegerv( GL_MAX_VERTEX_ATTRIBS, &_maxGPUAttribs );
         OE_INFO << LC << "  Max GPU attributes = " << _maxGPUAttribs << std::endl;
 
+#if !(defined(OSG_GL3_AVAILABLE))
         glGetIntegerv( GL_DEPTH_BITS, &_depthBits );
         OE_INFO << LC << "  Depth buffer bits = " << _depthBits << std::endl;
-
+#endif
         
         glGetIntegerv( GL_MAX_TEXTURE_SIZE, &_maxTextureSize );
 #if !(defined(OSG_GLES1_AVAILABLE) || defined(OSG_GLES2_AVAILABLE))

--- a/src/osgEarthAnnotation/AnnotationNode.cpp
+++ b/src/osgEarthAnnotation/AnnotationNode.cpp
@@ -228,7 +228,7 @@ AnnotationNode::applyRenderSymbology(const Style& style)
                 (render->backfaceCulling() == true? osg::StateAttribute::ON : osg::StateAttribute::OFF) | osg::StateAttribute::OVERRIDE );
         }
 
-#ifndef OSG_GLES2_AVAILABLE
+#if !(defined(OSG_GLES2_AVAILABLE) || defined(OSG_GL3_AVAILABLE) )
         if ( render->clipPlane().isSet() )
         {
             GLenum mode = GL_CLIP_PLANE0 + render->clipPlane().value();

--- a/src/osgEarthDrivers/engine_mp/MPGeometry.cpp
+++ b/src/osgEarthDrivers/engine_mp/MPGeometry.cpp
@@ -235,7 +235,7 @@ MPGeometry::renderPrimitiveSets(osg::State& state,
         state.setTexCoordPointer( _imageUnit+1, _tileCoords.get() );
     }
 
-#ifndef OSG_GLES2_AVAILABLE
+#if !(defined(OSG_GLES2_AVAILABLE) || defined(OSG_GL3_AVAILABLE) )
     if ( renderColor )
     {
         // emit a default terrain color since we're not binding a color array:

--- a/src/osgEarthFeatures/FeatureModelSource.cpp
+++ b/src/osgEarthFeatures/FeatureModelSource.cpp
@@ -341,7 +341,7 @@ FeatureNodeFactory::getOrCreateStyleGroup(const Style& style,
                 (render->backfaceCulling() == true ? osg::StateAttribute::ON : osg::StateAttribute::OFF) | osg::StateAttribute::OVERRIDE );
         }
 
-#ifndef OSG_GLES2_AVAILABLE
+#if !(defined(OSG_GLES2_AVAILABLE) || defined(OSG_GL3_AVAILABLE) )
         if ( render->clipPlane().isSet() )
         {
             GLenum mode = GL_CLIP_PLANE0 + (render->clipPlane().value());


### PR DESCRIPTION
This support Core GL3 compile on Windows. It is the same as in OSG:

http://forum.openscenegraph.org/viewtopic.php?t=13457
https://github.com/openscenegraph/OpenSceneGraph/blob/5d6322da2b84470fc0675b1c637246acb58802e9/CMakeModules/OsgMacroUtils.cmake#L214

I've testes it on Windows x64 with master branch and OSG 3.5.6 release.

About the GL3 fixes:

GL_DEPTH_BITS and GL_CLIP_PLANE0  is deprecated on GL3. And it doesn't build with core profile without this changes.
