### PR TITLE
Give CQL_FILTER priority over BBOX if both WFS parameters are set

### DIFF
--- a/src/osgEarthDrivers/feature_wfs/FeatureSourceWFS.cpp
+++ b/src/osgEarthDrivers/feature_wfs/FeatureSourceWFS.cpp
@@ -305,7 +305,14 @@ public:
                    "&X=" << tileX <<
                    "&Y=" << tileY;
         }
-        else if (query.bounds().isSet())
+	// BBOX and CQL_FILTER are mutually exclusive. Give CQL_FILTER priority if specified.
+	// NOTE: CQL_FILTER is a non-standard vendor parameter. See:
+	// http://docs.geoserver.org/latest/en/user/services/wfs/vendor.html
+	else if (query.expression().isSet())
+	{
+	    buf << "&CQL_FILTER=" << osgEarth::URI::urlEncode(query.expression().get());
+	}
+	else if (query.bounds().isSet())
         {            
             double buffer = *_options.buffer();            
             buf << "&BBOX=" << std::setprecision(16)
@@ -313,14 +320,6 @@ public:
                             << query.bounds().get().yMin() - buffer << ","
                             << query.bounds().get().xMax() + buffer << ","
                             << query.bounds().get().yMax() + buffer;
-        }
-
-        // BBOX and CQL_FILTER are mutually exclusive
-        // NOTE: CQL_FILTER is a non-standard vendor parameter. See:
-        // http://docs.geoserver.org/latest/en/user/services/wfs/vendor.html
-        else if (query.expression().isSet())
-        {
-            buf << "&CQL_FILTER=" << osgEarth::URI::urlEncode(query.expression().get());
         }
 
         std::string str;


### PR DESCRIPTION
Issue: In a WFS feature model has layout defined it implicitly sets the BBOX WFS parameter, and this would override any explicitly set SQL_FILTER in the query expression property since BBOX and CQL_FILTER are mutually exclusive.

Fix: Test is whether expression (i.e. CQL_FILTER) is available before BBOX to give it priority.