### PR TITLE
Add resample key to ResampleFilterOptions configuration

### DIFF
--- a/src/osgEarthFeatures/ResampleFilter
+++ b/src/osgEarthFeatures/ResampleFilter
@@ -65,6 +65,7 @@ namespace osgEarth { namespace Features
 
         Config getConfig() const {
             Config conf = ConfigOptions::getConfig();
+            conf.key() = "resample";
             conf.addIfSet("min_length", _minLen);
             conf.addIfSet("max_length", _maxLen);
             conf.addIfSet("mode", "linear",       _mode, RESAMPLE_LINEAR);


### PR DESCRIPTION
Without "resample" as the value of the Config key, the proper driver
won't be found.

This fixes the osgearth_city demo.