### PR TITLE
Added new access methods in Style and Stylesheet

### DIFF
--- a/src/osgEarthSymbology/Style
+++ b/src/osgEarthSymbology/Style
@@ -144,6 +144,9 @@ namespace osgEarth { namespace Symbology
 
         template<typename T> T* getOrCreate() { return getOrCreateSymbol<T>(); } // alias
 
+	/** Access to list of symbols currently defining the style */
+	SymbolList& symbols() { return _symbols; }
+	const SymbolList& symbols() const { return _symbols; }
 
         /** Serializes this object into a Config. */
         virtual Config getConfig( bool keepOrigType =true ) const;

--- a/src/osgEarthSymbology/StyleSheet
+++ b/src/osgEarthSymbology/StyleSheet
@@ -75,6 +75,10 @@ namespace osgEarth { namespace Symbology
         Style* getDefaultStyle();
         const Style* getDefaultStyle() const;
 
+	/** Get access to styles for manual configuration */
+	StyleMap& styles() { return _styles; }
+	const StyleMap& styles() const { return _styles; }
+
         /** Selectors pick a style from the sheet based on some criteria. */
         StyleSelectorList& selectors() { return _selectors; }
         const StyleSelectorList& selectors() const { return _selectors; }

--- a/src/osgEarthSymbology/Symbol
+++ b/src/osgEarthSymbology/Symbol
@@ -45,6 +45,7 @@ namespace osgEarth { namespace Symbology
         const URIContext& uriContext() const { return _uriContext; }
 
         virtual Config getConfig() const;   
+	virtual void mergeConfig(const Config& conf);
 
     public:
         /* methods required by osg::Object */
@@ -59,8 +60,6 @@ namespace osgEarth { namespace Symbology
         static bool match(const std::string& key, const char* pattern);
 
         Symbol( const Config& conf =Config() );
-
-        void mergeConfig(const Config& conf);
 
         virtual ~Symbol() { }
     };


### PR DESCRIPTION
Access methods needed to UI introspection of current applied StyleSheet and Style. This allows our application to inspect current stylesheet applied to a FeatureModel. The end-user can then make changes and reload the selected FeatureModel based on an updated / edited stylesheet.

    // Start layer update transaction
    map_node_->getMap()->beginUpdate();
    map_node_->getMap()->removeLayer(model_layer_.get());

    // Create new layer with same data options
    osgEarth::Features::FeatureModelSourceOptions fms_opts(model_layer_->options().driver().get());

    // Update styles / stylesheet from user input
    [...snip...]

    osgEarth::ModelLayerOptions ml_opts(model_layer_->getName(), fms_opts);

    model_layer_ = new osgEarth::ModelLayer(ml_opts);
    map_node_->getMap()->addLayer(model_layer_.get());

    // End layer update transaction
    map_node_->getMap()->endUpdate();

Note on "void mergeConfig()": method is defined as a public virtual method in derived classes, but in the base class, it was defined as protected and non-virtual.