### PR TITLE
GLSL version fix

### DIFF
--- a/src/osgEarthUtil/LogDepthBuffer.VertOnly.vert.glsl
+++ b/src/osgEarthUtil/LogDepthBuffer.VertOnly.vert.glsl
@@ -1,4 +1,4 @@
-#version 330 compatibility
+#version $GLSL_VERSION_STR
 
 #pragma vp_entryPoint oe_logDepth_vert
 #pragma vp_location   vertex_clip


### PR DESCRIPTION
This is needed for MacOSX Core Profile. It doesn't compile the shader without this.