### PR TITLE
Fixing bug where fill is ignored if no color is set in PolyStyle

### DIFF
--- a/src/osgEarthDrivers/kml/KML_PolyStyle.cpp
+++ b/src/osgEarthDrivers/kml/KML_PolyStyle.cpp
@@ -25,14 +25,13 @@ KML_PolyStyle::scan( xml_node<>* node, Style& style, KMLContext& cx )
 {
 	if (node)
 	{
-        PolygonSymbol* poly = 0L;
+        PolygonSymbol* poly = style.getOrCreate<PolygonSymbol>();
 
 		Color color(Color::White);
 		std::string colorVal = getValue(node, "color");
 		if (!colorVal.empty())
 		{
 			color = Color(Stringify() << "#" << colorVal, Color::ABGR);
-            poly = style.getOrCreate<PolygonSymbol>();
             poly->fill()->color() = color;
 		}
 


### PR DESCRIPTION
[KML_PolyStyle]
- Now getting or creating PolygonSymbol before we apply anything to avoid breaking fill if no color is specified