### PR TITLE
Fixes gdal-mutex crash-on-exit.

### DIFF
--- a/src/osgEarth/Registry
+++ b/src/osgEarth/Registry
@@ -34,7 +34,7 @@
 #include <set>
 
 #define GDAL_SCOPED_LOCK \
-    OpenThreads::ScopedLock<OpenThreads::ReentrantMutex> _slock( osgEarth::getGDALMutex() )\
+    OpenThreads::ScopedLock<OpenThreads::ReentrantMutex> _slock( osgEarth::Registry::_gdal_mutex )\
 
 namespace osgText {
     class Font;
@@ -55,8 +55,6 @@ namespace osgEarth
 
     typedef SharedSARepo<osg::Program> ProgramSharedRepo;
 
-
-    extern OSGEARTH_EXPORT OpenThreads::ReentrantMutex& getGDALMutex();
 
     /**
      * Application-wide global repository.
@@ -276,6 +274,9 @@ namespace osgEarth
 
         //! Access to the general-purpose async operations queue
         osg::OperationQueue* getAsyncOperationQueue() const { return _opQueue.get(); }
+
+        /** Global mutex for accessing GDAL */
+        static OpenThreads::ReentrantMutex _gdal_mutex;
 
     protected:
         virtual ~Registry();

--- a/src/osgEarth/Registry.cpp
+++ b/src/osgEarth/Registry.cpp
@@ -55,6 +55,9 @@ using namespace OpenThreads;
 #define LC "[Registry] "
 
 
+OpenThreads::ReentrantMutex Registry::_gdal_mutex;
+
+
 Registry::Registry() :
 osg::Referenced     ( true ),
 _gdal_registered    ( false ),
@@ -198,12 +201,6 @@ void
 Registry::destruct()
 {
     //nop
-}
-
-OpenThreads::ReentrantMutex& osgEarth::getGDALMutex()
-{
-    static OpenThreads::ReentrantMutex _gdal_mutex;
-    return _gdal_mutex;
 }
 
 const Profile*


### PR DESCRIPTION
On gcc global cleanup local static variables are deleted before global static variables. To ensure that gdal_mutex is alive when registry destructs it has been moved into the class Registry.