### PR TITLE
RTT: setCullMask and getCullMask added.

### DIFF
--- a/src/osgEarthUtil/RTTPicker
+++ b/src/osgEarthUtil/RTTPicker
@@ -88,6 +88,13 @@ namespace osgEarth { namespace Util
         virtual bool removeChild(osg::Node* child);
         virtual bool replaceChild(osg::Node* oldChild, osg::Node* newChild);
 
+    public: // simulate osg::Camera cull mask methods
+
+        /** Specifies the cull mask for the RTT camera */
+        void setCullMask(osg::Node::NodeMask nm);
+        osg::Node::NodeMask getCullMask() const { return _cullMask; }
+
+
     public: // for debugging
 
         /** For debugging only - creates (if nec.) and returns a texture that captures
@@ -104,6 +111,7 @@ namespace osgEarth { namespace Util
         
         int                    _rttSize;     // size of the RTT image (pixels per side)
         int                    _buffer;      // buffer around pick point to check (pixels)
+        osg::Node::NodeMask    _cullMask;    // cull mask applied to the camera
         osg::ref_ptr<Callback> _defaultCallback;
 
         // Associates a view and a pick camera for that view.

--- a/src/osgEarthUtil/RTTPicker.cpp
+++ b/src/osgEarthUtil/RTTPicker.cpp
@@ -110,6 +110,9 @@ RTTPicker::RTTPicker(int cameraSize)
 
     // pixels around the click to test
     _buffer = 2;
+    
+    // Cull mask for RTT cameras
+    _cullMask = ~0;
 }
 
 RTTPicker::~RTTPicker()
@@ -139,6 +142,18 @@ RTTPicker::getOrCreateTexture(osg::View* view)
         pc._tex->setMaxAnisotropy(1.0f); // no filtering
     }
     return pc._tex.get();
+}
+
+void
+RTTPicker::setCullMask(osg::Node::NodeMask nm)
+{
+    if ( _cullMask == nm )
+        return;
+    _cullMask = nm;
+    for(PickContexts::const_iterator i = _pickContexts.begin(); i != _pickContexts.end(); ++i)
+    {
+        i->_pickCamera->setCullMask( _cullMask );
+    }
 }
 
 RTTPicker::PickContext&
@@ -173,6 +188,7 @@ RTTPicker::getOrCreatePickContext(osg::View* view)
     c._pickCamera->setRenderTargetImplementation( osg::Camera::FRAME_BUFFER_OBJECT );
     c._pickCamera->attach( osg::Camera::COLOR_BUFFER0, c._image.get() );
     c._pickCamera->setSmallFeatureCullingPixelSize( -1.0f );
+    c._pickCamera->setCullMask( _cullMask );
 
     c._pickCamera->setGraphicsContext(view->getCamera()->getGraphicsContext());
     


### PR DESCRIPTION
This is useful in the SIMDIS SDK for preventing the drawing of labels, which improves both performance (no need to traverse) and accuracy (no dead zones).