### PR TITLE
Horizon: Avoid constantly constructing new std::string for UDC key.

### DIFF
--- a/src/osgEarth/Horizon.cpp
+++ b/src/osgEarth/Horizon.cpp
@@ -26,7 +26,10 @@
 
 #define LC "[Horizon] "
 
-#define OSGEARTH_HORIZON_UDC_NAME "osgEarth.Horizon"
+namespace
+{
+    const std::string OSGEARTH_HORIZON_UDC_NAME = "osgEarth.Horizon";
+}
 
 using namespace osgEarth;
 


### PR DESCRIPTION
Profiler pointed to a define-string to std::string conversion for UDC key taking up 5% of overall CPU time in a particular massive data example.  This is a minor performance improvement with no apparent downside.