### PR TITLE
CMake: Respect OSG_DIR when searching for OSG version.

### DIFF
--- a/CMakeModules/OsgEarthMacroUtils.cmake
+++ b/CMakeModules/OsgEarthMacroUtils.cmake
@@ -3,6 +3,11 @@
 #######################################################################################################
 MACRO(DETECT_OSG_VERSION)
 
+    # Fall back to OSG_DIR if OSG_INCLUDE_DIR is not defined
+    if(OSG_DIR AND NOT OSG_INCLUDE_DIR AND EXISTS "${OSG_DIR}/include/osg/Version")
+        set(OSG_INCLUDE_DIR "${OSG_DIR}/include")
+    endif()
+
     OPTION(APPEND_OPENSCENEGRAPH_VERSION "Append the OSG version number to the osgPlugins directory" ON)
 	
     # Try to ascertain the version...


### PR DESCRIPTION
Recent change to OSG version detection broke versioning when OSG_DIR was specified by itself.  This change lets OSG_INCLUDE_DIR fall back to OSG_DIR/include.

We have build scripts that specify OSG_DIR that lets osgEarth figure out the include path etc., as per FindOSG.cmake in line 27 (preferred path for OSG is OSG_DIR).  This change lets those build scripts continue to work.  Without this, the version on first configure is empty-string, leading to bad RPATH on Linux and incorrect install location.