### PR TITLE
Cache wms, wfs, and tms metadata per service

### DIFF
--- a/src/osgEarthUtil/TMS.cpp
+++ b/src/osgEarthUtil/TMS.cpp
@@ -461,11 +461,34 @@ TileMapReaderWriter::read( const std::string& location, const osgDB::Options* op
     ReadResult r = URI(location).readString(options);
     if ( r.failed() )
     {
-        OE_DEBUG << LC << "Failed to read TMS tile map file from " << location
+	OE_DEBUG << LC << "Failed to read TMS tile map file from " << location
             << " ... " << r.errorDetail() << std::endl;
+#if 1  // Read capabilities from cached file
+	OE_WARN << LC << "Failed to read TMS tile map file from " << location
+	    << " ... " << r.errorDetail() << std::endl;
+	std::stringstream cache_filepath;
+	cache_filepath << "/tmp/tms_" << hashToString(location);
+	r = URI(cache_filepath.str()).readString(options);
+	if ( r.failed() )
+	{
+	    OE_WARN << LC << "Failed to read TMS tile map file from cache" << cache_filepath.str()
+		<< " ... " << r.errorDetail() << std::endl;
+	return 0L;
+	}
+#else
         return 0L;
+#endif
     }
-    
+#if 1  // Cache capabilities to file
+    else
+    {
+	std::stringstream cache_filepath;
+	cache_filepath << "/tmp/tms_" << hashToString(location);
+	std::ofstream out(cache_filepath.str().c_str());
+	out << r.getString();
+    }
+#endif
+
     // Read tile map into a Config:
     Config conf;
     std::stringstream buf( r.getString() );

--- a/src/osgEarthUtil/WFS.cpp
+++ b/src/osgEarthUtil/WFS.cpp
@@ -80,9 +80,28 @@ WFSCapabilitiesReader::read( const URI& location, const osgDB::Options* dbOption
     if ( !buffer.empty() )
     {
         std::stringstream buf(buffer);
+
+#if 1  // Cache capabilities to file
+	std::stringstream cache_filepath;
+	cache_filepath << "/tmp/wfs_" << hashToString(location.full());
+	std::ofstream out(cache_filepath.str().c_str());
+	out << buf.str();
+#endif
+
         return read(buf);
     }
+#if 1  // Read capabilities from cached file
+    else
+    {
+	OE_WARN << "Failed to read WFS Capabilities. Attempting to read local cache"<<std::endl;
+	std::stringstream cache_filepath;
+	cache_filepath << "/tmp/wfs_" << hashToString(location.full());
+	std::ifstream in( cache_filepath.str().c_str() );
+	return read( in );
+    }
+#else
     else return 0L;
+#endif
 }
 
 WFSCapabilities*

--- a/src/osgEarthUtil/WMS.cpp
+++ b/src/osgEarthUtil/WMS.cpp
@@ -146,7 +146,23 @@ WMSCapabilitiesReader::read( const std::string &location, const osgDB::ReaderWri
         {
             std::istringstream in( rr.getString() );
             caps = read( in );
+#if 1  // Cache capabilities to file
+	    std::stringstream cache_filepath;
+	    cache_filepath << "/tmp/wms_" << hashToString(location);
+	    std::ofstream out(cache_filepath.str().c_str());
+	    out << in.str();
+#endif
         }
+#if 1  // Read capabilities from cached file
+	else
+	{
+	    OE_WARN << "Failed to read WMS Capabilities. Attempting to read local cache"<<std::endl;
+	    std::stringstream cache_filepath;
+	    cache_filepath << "/tmp/wms_" << hashToString(location);
+	    std::ifstream in( cache_filepath.str().c_str() );
+	    caps = read( in );
+	}
+#endif
     }
     else
     {


### PR DESCRIPTION
If a system has intermittent network issue (e.g. like at an IBC booth), you might not get some layer in an earth file at all if network connection breaks when metadata for layers are read (e.g. WFS Capabilities), event though all tiles are cached locally.

This commit is a hackish solution that caches WFS/WMS/TMS metacast data to disc when read successfully. If then at a later load of an earth file, the network connection is broken at the time when metadata is read, the cached metadata is used.

We would like to see these changes evolve into a propper feature, so that:
* metadata caching can be configured (Enable/disable, age-threshhold, etc.)
* solution is made platform indepedent and consistent with osgEarth data cache config.