### PR TITLE
Namespace tinyxml

### DIFF
--- a/CMakeModules/FindGDAL.cmake
+++ b/CMakeModules/FindGDAL.cmake
@@ -22,7 +22,7 @@
 FIND_PATH(GDAL_INCLUDE_DIR gdal.h
   $ENV{GDAL_DIR}
   NO_DEFAULT_PATH
-    PATH_SUFFIXES include
+    PATH_SUFFIXES include include/gdal
 )
 
 FIND_PATH(GDAL_INCLUDE_DIR gdal.h

--- a/src/osgEarth/tinyxml.cpp
+++ b/src/osgEarth/tinyxml.cpp
@@ -34,6 +34,8 @@ distribution.
 
 FILE* TiXmlFOpen( const char* filename, const char* mode );
 
+using namespace osgEarth;
+
 bool TiXmlBase::condenseWhiteSpace = true;
 
 // Microsoft compiler security

--- a/src/osgEarth/tinyxml.h
+++ b/src/osgEarth/tinyxml.h
@@ -80,6 +80,8 @@ distribution.
 	#endif
 #endif	
 
+namespace osgEarth
+{
 class TiXmlDocument;
 class TiXmlElement;
 class TiXmlComment;
@@ -87,6 +89,8 @@ class TiXmlUnknown;
 class TiXmlAttribute;
 class TiXmlText;
 class TiXmlDeclaration;
+}
+
 class TiXmlParsingData;
 
 const int TIXML_MAJOR_VERSION = 2;
@@ -125,6 +129,8 @@ struct TiXmlCursor
 
 	@sa TiXmlNode::Accept()
 */
+namespace osgEarth
+{
 class TiXmlVisitor
 {
 public:
@@ -149,6 +155,7 @@ public:
 	/// Visit an unknow node
 	virtual bool Visit( const TiXmlUnknown& /*unknown*/ )			{ return true; }
 };
+} // namespace osgEarth
 
 // Only used by Attribute::Query functions
 enum 
@@ -191,6 +198,8 @@ const TiXmlEncoding TIXML_DEFAULT_ENCODING = TIXML_ENCODING_UNKNOWN;
 	A Decleration contains: Attributes (not on tree)
 	@endverbatim
 */
+namespace osgEarth
+{
 class TiXmlBase
 {
 	friend class TiXmlNode;
@@ -737,17 +746,17 @@ public:
 	*/
 	virtual bool Accept( TiXmlVisitor* visitor ) const = 0;
 
+#ifdef TIXML_USE_STL
+    // The real work of the input operator.
+    virtual void StreamIn( std::istream* in, TIXML_STRING* tag ) = 0;
+#endif
+
 protected:
 	TiXmlNode( NodeType _type );
 
 	// Copy to the allocated object. Shared functionality between Clone, Copy constructor,
 	// and the assignment operator.
 	void CopyTo( TiXmlNode* target ) const;
-
-	#ifdef TIXML_USE_STL
-	    // The real work of the input operator.
-	virtual void StreamIn( std::istream* in, TIXML_STRING* tag ) = 0;
-	#endif
 
 	// Figure out what is at *p, and parse it. Returns null if it is not an xml node.
 	TiXmlNode* Identify( const char* start, TiXmlEncoding encoding );
@@ -1546,7 +1555,7 @@ private:
 	TiXmlCursor errorLocation;
 	bool useMicrosoftBOM;		// the UTF-8 BOM were found when read. Note this, and try to write.
 };
-
+} // namespace osgEarth
 
 /**
 	A TiXmlHandle is a class that wraps a node pointer with null checks; this is
@@ -1628,6 +1637,9 @@ private:
 	}
 	@endverbatim
 */
+
+using namespace osgEarth;
+
 class TiXmlHandle
 {
 public:

--- a/src/osgEarth/tinyxml.h
+++ b/src/osgEarth/tinyxml.h
@@ -100,6 +100,8 @@ const int TIXML_PATCH_VERSION = 1;
 /*	Internal structure for tracking location of items 
 	in the XML file.
 */
+namespace osgEarth
+{
 struct TiXmlCursor
 {
 	TiXmlCursor()		{ Clear(); }
@@ -108,7 +110,7 @@ struct TiXmlCursor
 	int row;	// 0 based.
 	int col;	// 0 based.
 };
-
+} // namespace osgEarth
 
 /**
 	Implements the interface to the "Visitor pattern" (see the Accept() method.)
@@ -1638,13 +1640,11 @@ private:
 	@endverbatim
 */
 
-using namespace osgEarth;
-
 class TiXmlHandle
 {
 public:
 	/// Create a handle from any node (at any depth of the tree.) This can be a null pointer.
-	TiXmlHandle( TiXmlNode* _node )					{ this->node = _node; }
+    TiXmlHandle( osgEarth::TiXmlNode* _node )					{ this->node = _node; }
 	/// Copy constructor
 	TiXmlHandle( const TiXmlHandle& ref )			{ this->node = ref.node; }
 	TiXmlHandle operator=( const TiXmlHandle& ref ) { this->node = ref.node; return *this; }
@@ -1687,36 +1687,36 @@ public:
 
 	/** Return the handle as a TiXmlNode. This may return null.
 	*/
-	TiXmlNode* ToNode() const			{ return node; } 
+    osgEarth::TiXmlNode* ToNode() const			{ return node; }
 	/** Return the handle as a TiXmlElement. This may return null.
 	*/
-	TiXmlElement* ToElement() const		{ return ( ( node && node->ToElement() ) ? node->ToElement() : 0 ); }
+    osgEarth::TiXmlElement* ToElement() const		{ return ( ( node && node->ToElement() ) ? node->ToElement() : 0 ); }
 	/**	Return the handle as a TiXmlText. This may return null.
 	*/
-	TiXmlText* ToText() const			{ return ( ( node && node->ToText() ) ? node->ToText() : 0 ); }
+    osgEarth::TiXmlText* ToText() const			{ return ( ( node && node->ToText() ) ? node->ToText() : 0 ); }
 	/** Return the handle as a TiXmlUnknown. This may return null.
 	*/
-	TiXmlUnknown* ToUnknown() const		{ return ( ( node && node->ToUnknown() ) ? node->ToUnknown() : 0 ); }
+    osgEarth::TiXmlUnknown* ToUnknown() const		{ return ( ( node && node->ToUnknown() ) ? node->ToUnknown() : 0 ); }
 
 	/** @deprecated use ToNode. 
 		Return the handle as a TiXmlNode. This may return null.
 	*/
-	TiXmlNode* Node() const			{ return ToNode(); } 
+    osgEarth::TiXmlNode* Node() const			{ return ToNode(); }
 	/** @deprecated use ToElement. 
 		Return the handle as a TiXmlElement. This may return null.
 	*/
-	TiXmlElement* Element() const	{ return ToElement(); }
+    osgEarth::TiXmlElement* Element() const	{ return ToElement(); }
 	/**	@deprecated use ToText()
 		Return the handle as a TiXmlText. This may return null.
 	*/
-	TiXmlText* Text() const			{ return ToText(); }
+    osgEarth::TiXmlText* Text() const			{ return ToText(); }
 	/** @deprecated use ToUnknown()
 		Return the handle as a TiXmlUnknown. This may return null.
 	*/
-	TiXmlUnknown* Unknown() const	{ return ToUnknown(); }
+    osgEarth::TiXmlUnknown* Unknown() const	{ return ToUnknown(); }
 
 private:
-	TiXmlNode* node;
+    osgEarth::TiXmlNode* node;
 };
 
 
@@ -1739,22 +1739,22 @@ private:
 	fprintf( stdout, "%s", printer.CStr() );
 	@endverbatim
 */
-class TiXmlPrinter : public TiXmlVisitor
+class TiXmlPrinter : public osgEarth::TiXmlVisitor
 {
 public:
 	TiXmlPrinter() : depth( 0 ), simpleTextPrint( false ),
 					 buffer(), indent( "    " ), lineBreak( "\n" ) {}
 
-	virtual bool VisitEnter( const TiXmlDocument& doc );
-	virtual bool VisitExit( const TiXmlDocument& doc );
+    virtual bool VisitEnter( const osgEarth::TiXmlDocument& doc );
+    virtual bool VisitExit( const osgEarth::TiXmlDocument& doc );
 
-	virtual bool VisitEnter( const TiXmlElement& element, const TiXmlAttribute* firstAttribute );
-	virtual bool VisitExit( const TiXmlElement& element );
+    virtual bool VisitEnter( const osgEarth::TiXmlElement& element, const osgEarth::TiXmlAttribute* firstAttribute );
+    virtual bool VisitExit( const osgEarth::TiXmlElement& element );
 
-	virtual bool Visit( const TiXmlDeclaration& declaration );
-	virtual bool Visit( const TiXmlText& text );
-	virtual bool Visit( const TiXmlComment& comment );
-	virtual bool Visit( const TiXmlUnknown& unknown );
+    virtual bool Visit( const osgEarth::TiXmlDeclaration& declaration );
+    virtual bool Visit( const osgEarth::TiXmlText& text );
+    virtual bool Visit( const osgEarth::TiXmlComment& comment );
+    virtual bool Visit( const osgEarth::TiXmlUnknown& unknown );
 
 	/** Set the indent characters for printing. By default 4 spaces
 		but tab (\t) is also useful, or null/empty string for no indentation.

--- a/src/osgEarth/tinyxmlerror.cpp
+++ b/src/osgEarth/tinyxmlerror.cpp
@@ -30,6 +30,7 @@ distribution.
 //
 // It also cleans up the code a bit.
 //
+using namespace osgEarth;
 
 const char* TiXmlBase::errorString[ TIXML_ERROR_STRING_COUNT ] =
 {

--- a/src/osgEarth/tinyxmlparser.cpp
+++ b/src/osgEarth/tinyxmlparser.cpp
@@ -37,6 +37,8 @@ distribution.
 #	endif
 #endif
 
+using namespace osgEarth;
+
 // Note tha "PutString" hardcodes the same list. This
 // is less flexible than it appears. Changing the entries
 // or order will break putstring.	
@@ -168,15 +170,14 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 }
 
 
-class TiXmlParsingData
+struct TiXmlParsingData
 {
 	friend class TiXmlDocument;
-  public:
-	void Stamp( const char* now, TiXmlEncoding encoding );
+
+    void Stamp( const char* now, TiXmlEncoding encoding );
 
 	const TiXmlCursor& Cursor()	{ return cursor; }
 
-  private:
 	// Only used by the document!
 	TiXmlParsingData( const char* start, int _tabsize, int row, int col )
 	{
@@ -187,8 +188,8 @@ class TiXmlParsingData
 		cursor.col = col;
 	}
 
-	TiXmlCursor		cursor;
-	const char*		stamp;
+    TiXmlCursor		cursor;
+    const char*		stamp;
 	int				tabsize;
 };
 


### PR DESCRIPTION
Attempt to prevent conflicts with applications that use their own tinyxml. Also added a search path in the FindGDAL.make module.