### PR TITLE
Allow a folder to be referrer

### DIFF
--- a/src/osgEarthDrivers/earth/EarthFileSerializer2.cpp
+++ b/src/osgEarthDrivers/earth/EarthFileSerializer2.cpp
@@ -27,6 +27,7 @@
 #include <osgDB/FileNameUtils>
 #include <stdio.h>
 #include <ctype.h>
+#include <sys/stat.h>
 
 using namespace osgEarth_osgearth;
 using namespace osgEarth;
@@ -181,7 +182,12 @@ namespace
         {
             _rewriteAbsolutePaths = false;
             _newReferrerAbsPath = osgDB::convertFileNameToUnixStyle( osgDB::getRealPath(referrer) );
-            _newReferrerFolder  = osgDB::getFilePath( osgDB::findDataFile(_newReferrerAbsPath) );
+	    // Check whether referrer is file or folder.
+	    struct stat sb;
+	    if (stat(_newReferrerAbsPath.c_str(), &sb) == 0 && S_ISDIR(sb.st_mode))
+		_newReferrerFolder = _newReferrerAbsPath;
+	    else
+		_newReferrerFolder  = osgDB::getFilePath( osgDB::findDataFile(_newReferrerAbsPath) );
         }
 
         /** Whether to make absolute paths into relative paths if possible */


### PR DESCRIPTION
This is very useful when embedding earth files into other files though ReaderWriter::writeNode(const osg::Node&, std::ostream&, const Options*). This allows us to have a fix setup root reference for all resources.