### PR TITLE
Use inline Windows functions in Endian

### DIFF
--- a/src/osgEarth/Endian
+++ b/src/osgEarth/Endian
@@ -81,18 +81,18 @@
 
 #elif defined(__WINDOWS__)
 
-#	include <winsock2.h>
+#	include <windows.h>
 
 #	if BYTE_ORDER == LITTLE_ENDIAN
 
-#		define htobe16(x) htons(x)
+#		define htobe16(x) _byteswap_ushort(x)
 #		define htole16(x) (x)
-#		define be16toh(x) ntohs(x)
+#		define be16toh(x) _byteswap_ushort(x)
 #		define le16toh(x) (x)
  
-#		define htobe32(x) htonl(x)
+#		define htobe32(x) _byteswap_ulong(x)
 #		define htole32(x) (x)
-#		define be32toh(x) ntohl(x)
+#		define be32toh(x) _byteswap_ulong(x)
 #		define le32toh(x) (x)
 
 #		if defined(htonll) && defined(ntohll)


### PR DESCRIPTION
This incorporates the changes to the original code found in
https://gist.github.com/PkmX/63dd23f28ba885be53a5. The advantage is
that the winsock library doesn't need to be linked in.