### PR TITLE
ObjectIndex now stores observer_ptr instead of ref_ptr.

### DIFF
--- a/src/osgEarth/ObjectIndex
+++ b/src/osgEarth/ObjectIndex
@@ -214,7 +214,7 @@ namespace osgEarth
     protected:
         virtual ~ObjectIndex() { }
         
-        typedef std::map<ObjectID, osg::ref_ptr<osg::Referenced> > IndexMap;
+        typedef std::map<ObjectID, osg::observer_ptr<osg::Referenced> > IndexMap;
 
         IndexMap                 _index;
         int                      _attribLocation;


### PR DESCRIPTION
This allows objects to reliably use tagNode(this,this), then call remove() in their own destructor.  Without this, their destructor is never called, and it's much more awkward to remove references.