### PR TITLE
[WIP] thread safety: use osgDB::readRef*File()

### DIFF
--- a/docs/source/developer/maps.rst
+++ b/docs/source/developer/maps.rst
@@ -10,7 +10,7 @@ Loading a Map from an Earth File
 The easiest way to render a Map is to load it from an *earth file*.
 Since osgEarth uses OpenSceneGraph plugins, you can do this with a single line of code::
 
-    osg::Node* globe = osgDB::readNodeFile("myglobe.earth");
+    osg::Node* globe = osgEarth::readNodeFile("myglobe.earth");
 
 You now have an ``osg::Node`` that you can add to your scene graph and display.
 Seriously, it really is that simple!
@@ -81,7 +81,7 @@ using the API, you will first need to get a reference to the ``MapNode`` to work
 Use the static ``get`` function::
 
     // Load the map
-    osg::Node* loadedModel = osgDB::readNodeFile("mymap.earth");
+    osg::Node* loadedModel = osgEarth::readNodeFile("mymap.earth");
 
     // Find the MapNode
     osgEarth::MapNode* mapNode = MapNode::get( loadedModel );

--- a/docs/source/developer/utilities.rst
+++ b/docs/source/developer/utilities.rst
@@ -55,7 +55,7 @@ across the terrain. This is an old trick that you can use to generate "noise" th
 a low resolution terrain appear more detailed::
 
     DetailTexture* detail = new DetailTexture();
-    detail->setImage( osgDB::readImageFile("mytexture.jpg") );
+    detail->setImage( osgEarth::readImageFile("mytexture.jpg") );
     detail->setIntensity( 0.5f );
     detail->setImageUnit( 4 );
     mapnode->getTerrainEngine()->addEffect( detail );

--- a/src/applications/osgearth_3pv/osgearth_3pv.cpp
+++ b/src/applications/osgearth_3pv/osgearth_3pv.cpp
@@ -31,16 +31,9 @@
 #include <osgEarth/Viewpoint>
 #include <osgEarth/Horizon>
 #include <osgEarth/TraversalData>
+#include <osgEarth/ReadFile>
 
 #include <osgEarthAnnotation/PlaceNode>
-
-#define LC "[viewer] "
-
-using namespace osgEarth;
-using namespace osgEarth::Util;
-using namespace osgEarth::Annotation;
-namespace ui = osgEarth::Util::Controls;
-
 
 #include <osg/Geometry>
 #include <osg/Depth>
@@ -48,10 +41,15 @@ namespace ui = osgEarth::Util::Controls;
 #include <osg/DisplaySettings>
 #include <osg/MatrixTransform>
 #include <osg/LineWidth>
-#include <osgDB/ReadFile>
 #include <osgViewer/CompositeViewer>
 #include <osgGA/TrackballManipulator>
 
+#define LC "[viewer] "
+
+using namespace osgEarth;
+using namespace osgEarth::Util;
+using namespace osgEarth::Annotation;
+namespace ui = osgEarth::Util::Controls;
 
 struct PlacerCallback : public MouseCoordsTool::Callback
 {
@@ -236,7 +234,7 @@ main( int argc, char** argv )
 
     MapNode* mapNode = MapNode::get(node.get());
 
-    osg::ref_ptr<osg::Image> icon = osgDB::readImageFile("../data/placemark32.png");
+    osg::ref_ptr<osg::Image> icon = osgEarth::readImageFile("../data/placemark32.png");
     PlaceNode* place = new PlaceNode(mapNode, GeoPoint::INVALID, icon.get(), "");
     place->getOrCreateStateSet()->setRenderBinDetails(10, "DepthSortedBin");
     place->setDynamic(true);

--- a/src/applications/osgearth_annotation/osgearth_annotation.cpp
+++ b/src/applications/osgearth_annotation/osgearth_annotation.cpp
@@ -21,6 +21,7 @@
 */
 
 #include <osgEarth/MapNode>
+#include <osgEarth/ReadFile>
 
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/ExampleResources>
@@ -348,7 +349,7 @@ main(int argc, char** argv)
     // an image overlay.
     {
         ImageOverlay* imageOverlay = 0L;
-        osg::Image* image = osgDB::readImageFile( "../data/USFLAG.TGA" );
+        osg::ref_ptr<osg::Image> image = osgEarth::readImageFile( "../data/USFLAG.TGA" );
         if ( image )
         {
             imageOverlay = new ImageOverlay(mapNode, image);

--- a/src/applications/osgearth_atlas/osgearth_atlas.cpp
+++ b/src/applications/osgearth_atlas/osgearth_atlas.cpp
@@ -23,16 +23,18 @@
 #include <osgEarth/Notify>
 #include <osgEarth/XmlUtils>
 #include <osgEarth/ImageUtils>
+#include <osgEarth/ReadFile>
+#include <osgEarth/Utils>
+
 #include <osgEarthUtil/AtlasBuilder>
+
 #include <osgEarthSymbology/ResourceLibrary>
 #include <osgEarthSymbology/Skins>
-#include <osgEarth/Utils>
 
 #include <osg/ArgumentParser>
 #include <osgDB/FileUtils>
 #include <osgDB/FileNameUtils>
 #include <osgDB/WriteFile>
-#include <osgDB/ReadFile>
 #include <osg/Geode>
 #include <osg/Geometry>
 #include <osg/Texture2DArray>
@@ -211,7 +213,7 @@ show(osg::ArgumentParser& arguments)
             osgDB::getFileExtension(atlasFile);
     }
 
-    osg::Image* image = osgDB::readImageFile(atlasFile);
+    osg::ref_ptr<osg::Image> image = osgEarth::readImageFile(atlasFile);
     if ( !image )
         return usage("Failed to load atlas image");
 

--- a/src/applications/osgearth_boundarygen/boundarygen.cpp
+++ b/src/applications/osgearth_boundarygen/boundarygen.cpp
@@ -22,22 +22,24 @@
 
 #include "BoundaryUtil"
 
+#include <osgEarth/ReadFile>
+
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+
 #include <osg/Notify>
 #include <osg/LineWidth>
 #include <osg/Point>
 #include <osg/PolygonOffset>
 #include <osg/MatrixTransform>
-#include <osgDB/ReadFile>
+
 #include <osgDB/WriteFile>
 #include <osgGA/StateSetManipulator>
 #include <osgGA/GUIEventHandler>
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
 #include <osgUtil/Optimizer>
-
 
 int usage( char** argv, const std::string& msg )
 {
@@ -80,7 +82,7 @@ int main(int argc, char** argv)
     bool convexOnly = arguments.read("--convex-hull");
     bool view = arguments.read("--view");
 
-    osg::Node* modelNode = osgDB::readNodeFiles( arguments );
+    osg::ref_ptr<osg::Node> modelNode = osgEarth::readNodeFiles( arguments );
     if (!modelNode)
         return usage( argv, "Unable to load model." );
 

--- a/src/applications/osgearth_city/osgearth_city.cpp
+++ b/src/applications/osgearth_city/osgearth_city.cpp
@@ -27,6 +27,7 @@
 #include <osgEarth/MapNode>
 #include <osgEarth/ImageLayer>
 #include <osgEarth/ModelLayer>
+#include <osgEarth/ReadFile>
 
 #include <osgEarthUtil/ExampleResources>
 #include <osgEarthUtil/EarthManipulator>
@@ -279,7 +280,7 @@ void addParks(Map* map)
     model->scale()->setLiteral( 0.2 );
     model->placement() = model->PLACEMENT_RANDOM;
     model->density() = 3000.0f; // instances per sqkm
-    model->setModel(osgDB::readNodeFile(TREE_MODEL_URL));
+    model->setModel(osgEarth::readNodeFile(TREE_MODEL_URL));
     
     // Clamp to the terrain:
     AltitudeSymbol* alt = style.getOrCreate<AltitudeSymbol>();

--- a/src/applications/osgearth_controls/osgearth_controls.cpp
+++ b/src/applications/osgearth_controls/osgearth_controls.cpp
@@ -23,13 +23,16 @@
 #include <typeinfo>
 
 #include <osg/Notify>
-#include <osgDB/ReadFile>
 #include <osgGA/GUIEventHandler>
 #include <osgViewer/Viewer>
+
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
+
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/Controls>
 #include <osgEarthUtil/ExampleResources>
+
 #include <osgEarthSymbology/Color>
 
 using namespace osgEarth::Symbology;
@@ -112,7 +115,7 @@ createControls( ControlCanvas* cs )
         center->setVertAlign( Control::ALIGN_CENTER );
 
         // Add an image:
-        osg::ref_ptr<osg::Image> image = osgDB::readImageFile("../data/osgearth.gif");
+        osg::ref_ptr<osg::Image> image = osgEarth::readImageFile("../data/osgearth.gif");
         if ( image.valid() )
         {
             s_imageControl = new ImageControl( image.get() );

--- a/src/applications/osgearth_createtile/osgearth_createtile.cpp
+++ b/src/applications/osgearth_createtile/osgearth_createtile.cpp
@@ -31,16 +31,21 @@
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
 #include <osgUtil/LineSegmentIntersector>
+
 #include <osgEarth/MapNode>
 #include <osgEarth/TerrainEngineNode>
 #include <osgEarth/StringUtils>
 #include <osgEarth/Terrain>
 #include <osgEarth/GeoTransform>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/Controls>
 #include <osgEarthUtil/ExampleResources>
+
 #include <osg/TriangleFunctor>
 #include <osgDB/WriteFile>
+
 #include <iomanip>
 
 using namespace osgEarth;
@@ -48,7 +53,7 @@ using namespace osgEarth::Util;
 
 static MapNode*       s_mapNode     = 0L;
 static osg::Group*    s_root        = 0L;
-static osg::ref_ptr< osg::Node >  marker = osgDB::readNodeFile("../data/red_flag.osg");
+static osg::ref_ptr< osg::Node >  marker = osgEarth::readNodeFile("../data/red_flag.osg");
 
 struct CollectTriangles
 {

--- a/src/applications/osgearth_elevation/osgearth_elevation.cpp
+++ b/src/applications/osgearth_elevation/osgearth_elevation.cpp
@@ -245,7 +245,7 @@ int main(int argc, char** argv)
     markerStyle.getOrCreate<ModelSymbol>()->autoScale() = true;
     s_marker = new ModelNode(s_mapNode, markerStyle);
     //s_marker->setMapNode( s_mapNode );
-    //s_marker->setIconImage(osgDB::readImageFile("../data/placemark32.png"));
+    //s_marker->setIconImage(osgEarth::readImageFile("../data/placemark32.png"));
     s_marker->setDynamic(true);
     s_mapNode->addChild( s_marker );
 

--- a/src/applications/osgearth_ephemeris/osgearth_ephemeris.cpp
+++ b/src/applications/osgearth_ephemeris/osgearth_ephemeris.cpp
@@ -21,14 +21,18 @@
 */
 
 #include <osgViewer/Viewer>
+
 #include <osgEarth/Notify>
 #include <osgEarth/NodeUtils>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/ExampleResources>
 #include <osgEarthUtil/Ephemeris>
 #include <osgEarthUtil/Sky>
 #include <osgEarthUtil/LatLongFormatter>
 #include <osgEarthUtil/Controls>
+
 #include <osgEarthAnnotation/PlaceNode>
 
 #define LC "[osgearth_ephemeris] "
@@ -77,7 +81,7 @@ main(int argc, char** argv)
 
     viewer.getCamera()->setSmallFeatureCullingPixelSize(-1.0f);
 
-    osg::ref_ptr<osg::Image> mark = osgDB::readImageFile("../data/placemark32.png");
+    osg::ref_ptr<osg::Image> mark = osgEarth::readImageFile("../data/placemark32.png");
     
     App app;
 

--- a/src/applications/osgearth_htm/osgearth_htm.cpp
+++ b/src/applications/osgearth_htm/osgearth_htm.cpp
@@ -21,16 +21,21 @@
 */
 
 #include <osgViewer/Viewer>
+
 #include <osgEarth/Notify>
-#include <osgEarthUtil/EarthManipulator>
-#include <osgEarthUtil/ExampleResources>
 #include <osgEarth/MapNode>
 #include <osgEarth/ThreadingUtils>
 #include <osgEarth/Metrics>
-#include <iostream>
-#include <osgEarthUtil/HTM>
-#include <osgEarthAnnotation/PlaceNode>
 #include <osgEarth/Random>
+#include <osgEarth/ReadFile>
+
+#include <osgEarthUtil/EarthManipulator>
+#include <osgEarthUtil/ExampleResources>
+#include <osgEarthUtil/HTM>
+
+#include <osgEarthAnnotation/PlaceNode>
+
+#include <iostream>
 
 #define LC "[viewer] "
 
@@ -70,7 +75,7 @@ main(int argc, char** argv)
     if (arguments.read("--model", modelPath) == false)
         return usage(argv[0]);
 
-    osg::ref_ptr<osg::Node> model = osgDB::readNodeFile(modelPath);
+    osg::ref_ptr<osg::Node> model = osgEarth::readNodeFile(modelPath);
     if (model.valid() == false)
         return usage(argv[0], "Cannot load model file");
 

--- a/src/applications/osgearth_imageoverlay/osgearth_imageoverlay.cpp
+++ b/src/applications/osgearth_imageoverlay/osgearth_imageoverlay.cpp
@@ -25,12 +25,15 @@
 #include <osgGA/GUIEventHandler>
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
+
 #include <osgEarth/MapNode>
+#include <osgEarth/ReadFile>
+#include <osgEarth/Utils>
+#include <osgEarth/VirtualProgram>
+
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/AutoClipPlaneHandler>
 #include <osgEarthUtil/Controls>
-#include <osgEarth/Utils>
-#include <osgEarth/VirtualProgram>
 
 #include <osg/ImageStream>
 #include <osgDB/FileNameUtils>
@@ -196,7 +199,7 @@ main(int argc, char** argv)
     bool moveVert = arguments.read("--vert");
 
     // load the .earth file from the command line.
-    osg::Node* earthNode = osgDB::readNodeFiles( arguments );
+    osg::ref_ptr<osg::Node> earthNode = osgEarth::readNodeFiles( arguments );
     if (!earthNode)
         return usage( "Unable to load earth model." );
 
@@ -221,10 +224,10 @@ main(int argc, char** argv)
         {
             std::string imageFile = imageFiles[i];
             //Read the image file and play it if it's a movie
-            osg::Image* image = osgDB::readImageFile(imageFile);
+            osg::ref_ptr<osg::Image> image = osgEarth::readImageFile(imageFile);
             if (image)
             {
-                osg::ImageStream* is = dynamic_cast<osg::ImageStream*>(image);
+                osg::ImageStream* is = dynamic_cast<osg::ImageStream*>(image.get());
                 if (is)
                 {
                     is->play();

--- a/src/applications/osgearth_kml/osgearth_kml.cpp
+++ b/src/applications/osgearth_kml/osgearth_kml.cpp
@@ -20,11 +20,16 @@
 #include <osg/Notify>
 #include <osgGA/StateSetManipulator>
 #include <osgGA/GUIEventHandler>
+
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
+
 #include <osgEarth/MapNode>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/AutoClipPlaneHandler>
+
 #include <osgEarthDrivers/kml/KML>
 
 using namespace osgEarth::Util;
@@ -60,7 +65,7 @@ main(int argc, char** argv)
         {
             osg::ref_ptr<osgDB::Options> options = new osgDB::Options();
             options->setPluginData( "osgEarth::MapNode", mapNode );
-            osg::Node* kml = osgDB::readNodeFile( kmlFile, options.get() );
+            osg::ref_ptr<osg::Node> kml = osgEarth::readNodeFile( kmlFile, options.get() );
             if ( kml )
                 root->addChild( kml );
         }

--- a/src/applications/osgearth_los/osgearth_los.cpp
+++ b/src/applications/osgearth_los/osgearth_los.cpp
@@ -21,24 +21,28 @@
 */
 
 #include <osg/Notify>
+#include <osg/io_utils>
+#include <osg/MatrixTransform>
+#include <osg/Depth>
+
 #include <osgGA/StateSetManipulator>
 #include <osgGA/GUIEventHandler>
+
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
+
 #include <osgEarth/MapNode>
 #include <osgEarth/XmlUtils>
+#include <osgEarth/TerrainTileNode>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/AutoClipPlaneHandler>
 #include <osgEarthUtil/LinearLineOfSight>
 #include <osgEarthUtil/RadialLineOfSight>
-#include <osg/io_utils>
-#include <osg/MatrixTransform>
-#include <osg/Depth>
-#include <osgEarth/TerrainTileNode>
 
 using namespace osgEarth;
 using namespace osgEarth::Util;
-
 
 osg::AnimationPath* createAnimationPath(const GeoPoint& pos, const SpatialReference* mapSRS, float radius, double looptime)
 {
@@ -140,7 +144,7 @@ main(int argc, char** argv)
     osgViewer::Viewer viewer(arguments);
 
     // load the .earth file from the command line.
-    osg::Node* earthNode = osgDB::readNodeFiles( arguments );
+    osg::ref_ptr<osg::Node> earthNode = osgEarth::readNodeFiles( arguments );
     if (!earthNode)
     {
         OE_NOTICE << "Unable to load earth model" << std::endl;
@@ -214,7 +218,7 @@ main(int argc, char** argv)
     losGroup->addChild( radialRelEditor );
 
     //Load a plane model.  
-    osg::ref_ptr< osg::Node >  plane = osgDB::readNodeFile("../data/cessna.osgb.5,5,5.scale");
+    osg::ref_ptr< osg::Node > plane = osgEarth::readNodeFile("../data/cessna.osgb.5,5,5.scale");
 
     //Create 2 moving planes
     osg::Node* plane1 = createPlane(plane.get(), GeoPoint(geoSRS, -121.656, 46.0935, 4133.06, ALTMODE_ABSOLUTE), mapSRS, 5000, 20);

--- a/src/applications/osgearth_manip/osgearth_manip.cpp
+++ b/src/applications/osgearth_manip/osgearth_manip.cpp
@@ -28,19 +28,24 @@
 #include <osg/PositionAttitudeTransform>
 #include <osgGA/StateSetManipulator>
 #include <osgGA/GUIEventHandler>
+
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
+
 #include <osgEarth/GeoMath>
 #include <osgEarth/GeoTransform>
 #include <osgEarth/MapNode>
 #include <osgEarth/TerrainEngineNode>
 #include <osgEarth/Viewpoint>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/AutoClipPlaneHandler>
 #include <osgEarthUtil/Controls>
 #include <osgEarthUtil/ExampleResources>
 #include <osgEarthUtil/LogarithmicDepthBuffer>
 #include <osgEarthUtil/ViewFitter>
+
 #include <osgEarthAnnotation/AnnotationUtils>
 #include <osgEarthAnnotation/LabelNode>
 #include <osgEarthSymbology/Style>
@@ -681,10 +686,10 @@ int main(int argc, char** argv)
     osgEarth::MapNode* mapNode = osgEarth::MapNode::findMapNode( earthNode );
 
     // user model?
-    osg::Node* model = 0L;
+    osg::ref_ptr<osg::Node> model;
     std::string modelFile;
     if (arguments.read("--model", modelFile))
-        model = osgDB::readNodeFile(modelFile + ".osgearth_shadergen");
+        model = osgEarth::readNodeFile(modelFile + ".osgearth_shadergen");
 
     osg::Group* sims = new osg::Group();
     root->addChild( sims );

--- a/src/applications/osgearth_map/osgearth_map.cpp
+++ b/src/applications/osgearth_map/osgearth_map.cpp
@@ -23,15 +23,21 @@
 #include <osg/Notify>
 #include <osgGA/GUIEventHandler>
 #include <osgGA/StateSetManipulator>
+
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
+
 #include <osgEarth/MapNode>
 #include <osgEarth/ImageLayer>
 #include <osgEarth/GeoTransform>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/AutoClipPlaneHandler>
 #include <osgEarthUtil/Controls>
+
 #include <osgEarthSymbology/Color>
+
 #include <osgEarthDrivers/tms/TMSOptions>
 #include <osgEarthDrivers/wms/WMSOptions>
 #include <osgEarthDrivers/gdal/GDALOptions>
@@ -82,7 +88,7 @@ main(int argc, char** argv)
     MapNode* node = new MapNode( map );
 
     // put a model on the map atop Pike's Peak, Colorado, USA
-    osg::Node* model = osgDB::readNodeFile("../data/red_flag.osg.10000.scale.osgearth_shadergen");
+    osg::ref_ptr<osg::Node> model = osgEarth::readNodeFile("../data/red_flag.osg.10000.scale.osgearth_shadergen");
     if (model)
     {
         GeoTransform* xform = new GeoTransform();

--- a/src/applications/osgearth_occlusionculling/osgearth_occlusionculling.cpp
+++ b/src/applications/osgearth_occlusionculling/osgearth_occlusionculling.cpp
@@ -23,6 +23,7 @@
 #include <osgEarth/MapNode>
 #include <osgEarth/ScreenSpaceLayout>
 #include <osgEarth/ECEF>
+#include <osgEarth/ReadFile>
 
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/AnnotationEvents>
@@ -107,7 +108,7 @@ main(int argc, char** argv)
 
     //Create a bunch of placemarks around Mt Rainer so we can actually get some elevation
     {
-        osg::Image* pin = osgDB::readImageFile( "../data/placemark32.png" );
+        osg::ref_ptr<osg::Image> pin = osgEarth::readImageFile( "../data/placemark32.png" );
 
         double centerLat =  46.840866;
         double centerLon = -121.769846;

--- a/src/applications/osgearth_package_qt/SceneController.cpp
+++ b/src/applications/osgearth_package_qt/SceneController.cpp
@@ -22,7 +22,10 @@
 #include <osgEarth/Common>
 #include <osgEarth/Map>
 #include <osgEarth/MapNode>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthAnnotation/FeatureNode>
+
 #include <osgEarthUtil/Controls>
 #include <osgEarthUtil/ExampleResources>
 
@@ -166,7 +169,7 @@ osg::Node* SceneController::loadEarthFile(const std::string& url)
     _controlContainer->clearControls();
 
   if (url.length() > 0)
-    _earthNode = osgDB::readNodeFile( url );
+    _earthNode = osgEarth::readNodeFile( url );
 
   //Load a blank globe if needed
   if (!_earthNode.valid())

--- a/src/applications/osgearth_qt_windows/osgearth_qt_windows.cpp
+++ b/src/applications/osgearth_qt_windows/osgearth_qt_windows.cpp
@@ -28,9 +28,14 @@
 
 #include <osg/Notify>
 #include <osgViewer/CompositeViewer>
-#include <osgEarthUtil/EarthManipulator>
-#include <osgEarthQt/ViewWidget>
+
+#include <osgEarth/ReadFile>
 #include <osgEarth/Random>
+
+#include <osgEarthUtil/EarthManipulator>
+
+#include <osgEarthQt/ViewWidget>
+
 #include <QApplication>
 #include <QDialog>
 #include <QMainWindow>
@@ -147,7 +152,7 @@ main(int argc, char** argv)
         return usage("Help", args);
 
     // load something
-    osg::Node* node = osgDB::readNodeFiles( args );
+    osg::ref_ptr<osg::Node> node = osgEarth::readNodeFiles( args );
     if ( !node )
         return usage("Can't load a scene!", args);
 

--- a/src/applications/osgearth_seed/osgearth_seed.cpp
+++ b/src/applications/osgearth_seed/osgearth_seed.cpp
@@ -35,6 +35,7 @@
 #include <osgEarth/ImageLayer>
 #include <osgEarth/ElevationLayer>
 #include <osgEarth/TileVisitor>
+#include <osgEarth/ReadFile>
 
 #include <osgEarthFeatures/FeatureCursor>
 
@@ -160,7 +161,7 @@ seed( osg::ArgumentParser& args )
 
 
     //Read in the earth file.
-    osg::ref_ptr<osg::Node> node = osgDB::readNodeFiles( args );
+    osg::ref_ptr<osg::Node> node = osgEarth::readNodeFiles( args );
     if ( !node.valid() )
         return usage( "Failed to read .earth file." );
 
@@ -398,7 +399,7 @@ seed( osg::ArgumentParser& args )
 
 int list( osg::ArgumentParser& args )
 {
-    osg::ref_ptr<osg::Node> node = osgDB::readNodeFiles( args );
+    osg::ref_ptr<osg::Node> node = osgEarth::readNodeFiles( args );
     if ( !node.valid() )
         return usage( "Failed to read .earth file." );
 
@@ -462,7 +463,7 @@ struct Entry
 int
 purge( osg::ArgumentParser& args )
 {
-    osg::ref_ptr<osg::Node> node = osgDB::readNodeFiles( args );
+    osg::ref_ptr<osg::Node> node = osgEarth::readNodeFiles( args );
     if ( !node.valid() )
         return usage( "Failed to read .earth file." );
 

--- a/src/applications/osgearth_server/osgearth_server.cpp
+++ b/src/applications/osgearth_server/osgearth_server.cpp
@@ -22,12 +22,15 @@
 
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
+
 #include <osgEarth/Notify>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgEarth/TerrainEngineNode>
+
 #include <osgEarthUtil/ExampleResources>
+
 #include <osgDB/ReaderWriter>
-#include <osgDB/ReadFile>
 #include <osgDB/Registry>
 #include <osgDB/FileNameUtils>
 
@@ -608,7 +611,7 @@ main(int argc, char** argv)
 
         // load an earth file, and support all or our example command-line options
     // and earth file <external> tags    
-    osg::ref_ptr< osg::Node> node = osgDB::readNodeFiles( arguments );
+    osg::ref_ptr< osg::Node> node = osgEarth::readNodeFiles( arguments );
     osg::ref_ptr< MapNode > mapNode = MapNode::findMapNode( node );
 
     if (mapNode.valid())

--- a/src/applications/osgearth_shadercomp/osgearth_shadercomp.cpp
+++ b/src/applications/osgearth_shadercomp/osgearth_shadercomp.cpp
@@ -30,22 +30,23 @@
  */
 #include <osg/Notify>
 #include <osg/CullFace>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 #include <osgGA/StateSetManipulator>
+
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
-#include <osgEarthUtil/EarthManipulator>
+
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/Registry>
 #include <osgEarth/Capabilities>
 #include <osgEarth/ShaderUtils>
+#include <osgEarth/ReadFile>
+
+#include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/Controls>
 
 using namespace osgEarth;
 using namespace osgEarth::Util::Controls;
-
-
 
 int usage( const std::string& msg )
 {    
@@ -457,7 +458,7 @@ namespace TEST_8
         OE_NOTICE << "Wrote to out.osgt" << std::endl;
 
         node = 0L;
-        node = osgDB::readNodeFile("out.osgt");
+        node = osgEarth::readNodeFile("out.osgt");
         if (!node) {
             OE_WARN << "Readback failed!!" << std::endl;
             exit(0);
@@ -621,7 +622,7 @@ int main(int argc, char** argv)
 
     if ( test1 || test2 || test3 || test4 || test6 )
     {
-        osg::Node* earthNode = osgDB::readNodeFile( "gdal_tiff.earth" );
+        osg::ref_ptr<osg::Node> earthNode = osgEarth::readNodeFile( "gdal_tiff.earth" );
         if (!earthNode)
         {
             return usage( "Unable to load earth model." );
@@ -663,7 +664,7 @@ int main(int argc, char** argv)
     }
     else if ( test7 )
     {
-        root->addChild( TEST_7::run( osgDB::readNodeFiles(arguments) ) );
+        root->addChild( TEST_7::run( osgEarth::readNodeFiles(arguments) ) );
         if (ui) label->setText("Geometry Shader Injection Test.");
     }
     else if (test8)
@@ -673,7 +674,7 @@ int main(int argc, char** argv)
     }
     else if (test9)
     {
-        osg::Node* earthNode = osgDB::readNodeFile( "readymap.earth" );
+        osg::ref_ptr<osg::Node> earthNode = osgEarth::readNodeFile( "readymap.earth" );
         if (!earthNode)
         {
             return usage( "Unable to load earth model." );

--- a/src/applications/osgearth_shadergen/osgearth_shadergen.cpp
+++ b/src/applications/osgearth_shadergen/osgearth_shadergen.cpp
@@ -20,7 +20,6 @@
 * along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
 
-#include <osgDB/ReadFile>
 #include <osgGA/StateSetManipulator>
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
@@ -30,6 +29,7 @@
 #include <osgEarth/StringUtils>
 #include <osgEarth/Registry>
 #include <osgEarth/StateSetCache>
+#include <osgEarth/ReadFile>
 
 #define LC "[shadergen] "
 
@@ -58,7 +58,7 @@ main(int argc, char** argv)
     cache->setMaxSize(INT_MAX);
 
     // load the file
-    osg::Node* node = osgDB::readNodeFile(
+    osg::ref_ptr<osg::Node> node = osgEarth::readNodeFile(
         Stringify() << argv[1] << ".osgearth_shadergen" );
 
     if ( !node )

--- a/src/applications/osgearth_terrainprofile/osgearth_terrainprofile.cpp
+++ b/src/applications/osgearth_terrainprofile/osgearth_terrainprofile.cpp
@@ -21,22 +21,27 @@
 */
 
 #include <osg/Notify>
+#include <osg/io_utils>
 #include <osgGA/StateSetManipulator>
 #include <osgGA/GUIEventHandler>
+#include <osgText/Text>
+#include <osgText/Font>
+
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
+
 #include <osgEarth/MapNode>
 #include <osgEarth/XmlUtils>
+#include <osgEarth/GeoMath>
+#include <osgEarth/ReadFile>
+#include <osgEarth/Registry>
+
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/AutoClipPlaneHandler>
 #include <osgEarthUtil/TerrainProfile>
-#include <osgEarth/GeoMath>
-#include <osgEarth/Registry>
+
 #include <osgEarthFeatures/Feature>
 #include <osgEarthAnnotation/FeatureNode>
-#include <osgText/Text>
-#include <osgText/Font>
-#include <osg/io_utils>
 
 using namespace osgEarth;
 using namespace osgEarth::Util;
@@ -348,7 +353,7 @@ main(int argc, char** argv)
     osgViewer::Viewer viewer(arguments);
 
     // load the .earth file from the command line.
-    osg::Node* earthNode = osgDB::readNodeFiles( arguments );
+    osg::ref_ptr<osg::Node> earthNode = osgEarth::readNodeFiles( arguments );
     if (!earthNode)
     {
         OE_NOTICE << "Unable to load earth model" << std::endl;

--- a/src/applications/osgearth_tileindex/osgearth_tileindex.cpp
+++ b/src/applications/osgearth_tileindex/osgearth_tileindex.cpp
@@ -31,9 +31,6 @@
 #include <osgEarth/Progress>
 #include <osgEarthUtil/TileIndexBuilder>
 
-
-
-using namespace osgDB;
 using namespace osgEarth;
 using namespace osgEarth::Util;
 

--- a/src/applications/osgearth_toc/osgearth_toc.cpp
+++ b/src/applications/osgearth_toc/osgearth_toc.cpp
@@ -31,7 +31,6 @@
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
 #include <osgGA/StateSetManipulator>
-#include <osgDB/ReadFile>
 
 using namespace osgEarth;
 using namespace osgEarth::Util;

--- a/src/applications/osgearth_tracks/osgearth_tracks.cpp
+++ b/src/applications/osgearth_tracks/osgearth_tracks.cpp
@@ -27,14 +27,18 @@
 #include <osgEarth/Units>
 #include <osgEarth/StringUtils>
 #include <osgEarth/ScreenSpaceLayout>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthUtil/ExampleResources>
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/MGRSFormatter>
 #include <osgEarthUtil/Controls>
 #include <osgEarthUtil/AnnotationEvents>
 #include <osgEarthUtil/HTM>
+
 #include <osgEarthAnnotation/TrackNode>
 #include <osgEarthAnnotation/AnnotationData>
+
 #include <osgEarthSymbology/Color>
 
 #include <osgViewer/Viewer>
@@ -169,7 +173,7 @@ void
 createTrackNodes( MapNode* mapNode, osg::Group* parent, const TrackNodeFieldSchema& schema, TrackSims& sims )
 {
     // load an icon to use:
-    osg::ref_ptr<osg::Image> srcImage = osgDB::readImageFile( ICON_URL );
+    osg::ref_ptr<osg::Image> srcImage = osgEarth::readImageFile( ICON_URL );
     osg::ref_ptr<osg::Image> image;
     ImageUtils::resizeImage( srcImage.get(), ICON_SIZE, ICON_SIZE, image );
 

--- a/src/applications/osgearth_transform/osgearth_transform.cpp
+++ b/src/applications/osgearth_transform/osgearth_transform.cpp
@@ -26,17 +26,19 @@
  */
 
 #include <osg/PositionAttitudeTransform>
-#include <osgDB/ReadFile>
+
 #include <osgViewer/Viewer>
 #include <osgViewer/ViewerEventHandlers>
+
+#include <osgEarth/GeoTransform>
+#include <osgEarth/MapNode>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/ExampleResources>
 #include <osgEarthUtil/Controls>
-#include <osgEarth/GeoTransform>
-#include <osgEarth/MapNode>
 
 #define LC "[osgearth_transform] "
-
 
 using namespace osgEarth;
 using namespace osgEarth::Util;
@@ -159,7 +161,7 @@ main(int argc, char** argv)
 
     // load the model file into the local coordinate frame, which will be
     // +X=east, +Y=north, +Z=up.
-    osg::Node* model = osgDB::readNodeFile("../data/axes.osgt.(1000).scale.osgearth_shadergen");
+    osg::ref_ptr<osg::Node> model = osgEarth::readNodeFile("../data/axes.osgt.(1000).scale.osgearth_shadergen");
     if ( !model )
         return usage(argv[0]);
 

--- a/src/applications/osgearth_viewerIOS/ViewController.mm
+++ b/src/applications/osgearth_viewerIOS/ViewController.mm
@@ -16,13 +16,14 @@
 #include <osgViewer/api/IOS/GraphicsWindowIOS>
 
 #include <osgEarth/Viewpoint>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthUtil/Sky>
 #include <osgEarthUtil/EarthManipulator>
 #include <osgEarthUtil/ExampleResources>
 
 using namespace osgEarth;
 using namespace osgEarth::Util;
-
 
 @interface ViewController () {
 
@@ -56,7 +57,7 @@ using namespace osgEarth::Util;
 
 - (void)loadOsgEarthDemoScene{
     
-    osg::Node* node = osgDB::readNodeFile(osgDB::findDataFile("tests/" + _file));
+    osg::ref_ptr<osg::Node> node = readNodeFile(osgDB::findDataFile("tests/" + _file));
     if ( !node )
     {
         OSG_WARN << "Unable to load an earth file from the command line." << std::endl;

--- a/src/applications/osgearth_viewer_android/jni/OsgMainApp.cpp
+++ b/src/applications/osgearth_viewer_android/jni/OsgMainApp.cpp
@@ -1,11 +1,14 @@
 #include "OsgMainApp.hpp"
 
-#include <osgDB/FileUtils>
 #include <osgEarth/Capabilities>
+#include <osgEarth/ReadFile>
+
 #include <osgEarthUtil/AutoClipPlaneHandler>
 #include <osgEarthUtil/ObjectLocator>
+
 #include <osgEarthDrivers/tms/TMSOptions>
 
+#include <osgDB/FileUtils>
 #include <osgDB/WriteFile>
 
 #include "GLES2ShaderGenVisitor.h"
@@ -144,7 +147,7 @@ void OsgMainApp::initOsgWindow(int x,int y,int width,int height){
     material->setSpecular(osg::Material::FRONT, osg::Vec4(0.4,0.4,0.4,1.0));
 #endif
     
-    osg::Node* node = osgDB::readNodeFile("http://readymap.org/readymap/maps/public/2.earth");
+    osg::ref_ptr<osg::Node> node = osgEarth::readNodeFile("http://readymap.org/readymap/maps/public/2.earth");
     if ( !node )
     {
         OSG_ALWAYS << "Unable to load an earth file from the command line." << std::endl;

--- a/src/applications/osgearth_xfbtest/osgearth_xfbtest.cpp
+++ b/src/applications/osgearth_xfbtest/osgearth_xfbtest.cpp
@@ -33,15 +33,13 @@
 #include <osg/Depth>
 #include <osg/Point>
 #include <osg/VertexAttribDivisor>
-#include <osgDB/ReadFile>
 #include <osgUtil/Optimizer>
 
 #include <osgEarth/Capabilities>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgEarth/ShaderGenerator>
 #include <osgEarth/ShaderLoader>
-
-
 
 #ifndef GL_TRANSFORM_FEEDBACK_BUFFER
     #define GL_TRANSFORM_FEEDBACK_BUFFER      0x8C8E
@@ -50,7 +48,6 @@
 #ifndef TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN
     #define TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN 0x8c88
 #endif
-
 
 using namespace osgEarth;
 
@@ -378,12 +375,12 @@ osg::Node* makeSceneGraph()
     //root->getOrCreateStateSet()->setAttributeAndModes(new osg::Depth(osg::Depth::LESS, 0, 1, false));
     
     // Model to instance:
-    osg::Node* instancedModel = osgDB::readNodeFile("../data/tree.ive.osgearth_shadergen");
+    osg::ref_ptr<osg::Node> instancedModel = osgEarth::readNodeFile("../data/tree.ive.osgearth_shadergen");
     float radius = instancedModel->getBound().radius();
 
     // Reference axis.
     //std::string axis = Stringify() << "../data/axes.osgt.(" << radius << ").scale";
-    //root->addChild( osgDB::readNodeFile(axis) );
+    //root->addChild( osgEarth::readNodeFile(axis) );
 
     const int dim = 256;
     const int maxNumInstances = dim*dim;

--- a/src/osgEarth/CMakeLists.txt
+++ b/src/osgEarth/CMakeLists.txt
@@ -154,6 +154,7 @@ SET(LIB_PUBLIC_HEADERS
     Profiler
     Progress
     Random
+    ReadFile
     Registry
     ResourceReleaser
     Revisioning

--- a/src/osgEarth/Cache.cpp
+++ b/src/osgEarth/Cache.cpp
@@ -151,7 +151,7 @@ Cache::removeBin( CacheBin* bin )
 Cache*
 CacheFactory::create( const CacheOptions& options )
 {
-    osg::ref_ptr<Cache> result =0L;
+    osg::ref_ptr<Cache> result;
     OE_DEBUG << LC << "Initializing cache of type \"" << options.getDriver() << "\"" << std::endl;
 
     if ( options.getDriver().empty() )
@@ -168,8 +168,8 @@ CacheFactory::create( const CacheOptions& options )
         rwopt->setPluginData( CACHE_OPTIONS_TAG, (void*)&options );
 
         std::string driverExt = std::string(".osgearth_cache_") + options.getDriver();
-        osgDB::ReaderWriter::ReadResult rr = osgDB::readObjectFile( driverExt, rwopt.get() );
-        result = dynamic_cast<Cache*>( rr.getObject() );
+        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopt.get() );
+        result = dynamic_cast<Cache*>( object.release() );
         if ( !result.valid() )
         {
             OE_WARN << LC << "Failed to load cache plugin for type \"" << options.getDriver() << "\"" << std::endl;

--- a/src/osgEarth/Cache.cpp
+++ b/src/osgEarth/Cache.cpp
@@ -17,13 +17,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 #include <osgEarth/Cache>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgEarth/ThreadingUtils>
 
 #include <osg/UserDataContainer>
-#include <osgDB/FileNameUtils>
-#include <osgDB/FileUtils>
-#include <osgDB/ReadFile>
 #include <osgDB/Registry>
 #include <osgDB/ReaderWriter>
 
@@ -168,8 +166,7 @@ CacheFactory::create( const CacheOptions& options )
         rwopt->setPluginData( CACHE_OPTIONS_TAG, (void*)&options );
 
         std::string driverExt = std::string(".osgearth_cache_") + options.getDriver();
-        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopt.get() );
-        result = dynamic_cast<Cache*>( object.release() );
+        result = osgEarth::readFile<Cache>( driverExt, rwopt.get() );
         if ( !result.valid() )
         {
             OE_WARN << LC << "Failed to load cache plugin for type \"" << options.getDriver() << "\"" << std::endl;

--- a/src/osgEarth/Extension.cpp
+++ b/src/osgEarth/Extension.cpp
@@ -19,7 +19,6 @@
 #include <osgEarth/Extension>
 #include <osgEarth/Registry>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 
 using namespace osgEarth;
 
@@ -54,7 +53,7 @@ Extension::create(const std::string& name, const ConfigOptions& options)
 
     std::string pluginExtension = std::string( ".osgearth_" ) + name;
 
-    // use this instead of osgDB::readObjectFile b/c the latter prints a warning msg.
+    // use this instead of osgEarth::readObjectFile b/c the latter prints a warning msg.
     osgDB::ReaderWriter::ReadResult rr = osgDB::Registry::instance()->readObject( pluginExtension, dbopt.get() );
     if ( !rr.validObject() || rr.error() )
     {

--- a/src/osgEarth/HTTPClient.cpp
+++ b/src/osgEarth/HTTPClient.cpp
@@ -22,7 +22,6 @@
 #include <osgEarth/Progress>
 #include <osgEarth/StringUtils>
 #include <osgEarth/Metrics>
-#include <osgDB/ReadFile>
 #include <osgDB/Registry>
 #include <osgDB/FileNameUtils>
 #include <osg/Notify>

--- a/src/osgEarth/Layer.cpp
+++ b/src/osgEarth/Layer.cpp
@@ -259,7 +259,7 @@ Layer::create(const std::string& name, const ConfigOptions& options)
     //std::string pluginExtension = std::string( ".osgearth_" ) + name;
     std::string pluginExtension = std::string( "." ) + name;
 
-    // use this instead of osgDB::readObjectFile b/c the latter prints a warning msg.
+    // use this instead of osgEarth::readObjectFile b/c the latter prints a warning msg.
     osgDB::ReaderWriter::ReadResult rr = osgDB::Registry::instance()->readObject( pluginExtension, dbopt.get() );
     if ( !rr.validObject() || rr.error() )
     {

--- a/src/osgEarth/MaskSource.cpp
+++ b/src/osgEarth/MaskSource.cpp
@@ -92,7 +92,7 @@ MaskSourceFactory::~MaskSourceFactory()
 MaskSource*
 MaskSourceFactory::create( const MaskSourceOptions& options )
 {
-    MaskSource* source = 0L;
+    osg::ref_ptr<MaskSource> source;
 
     if ( !options.getDriver().empty() )
     {
@@ -101,7 +101,8 @@ MaskSourceFactory::create( const MaskSourceOptions& options )
         osg::ref_ptr<osgDB::Options> rwopts = Registry::instance()->cloneOrCreateOptions();
         rwopts->setPluginData( MASK_SOURCE_OPTIONS_TAG, (void*)&options );
 
-        source = dynamic_cast<MaskSource*>( osgDB::readObjectFile( driverExt, rwopts.get() ) );
+        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopts.get() );
+        source = dynamic_cast<MaskSource*>( object.release() );
         if ( source )
         {
             OE_INFO << "Loaded MaskSource driver \"" << options.getDriver() << "\" OK" << std::endl;
@@ -116,7 +117,7 @@ MaskSourceFactory::create( const MaskSourceOptions& options )
         OE_WARN << LC << "FAIL, illegal null driver specification" << std::endl;
     }
 
-    return source;
+    return source.release();
 }
 
 //------------------------------------------------------------------------

--- a/src/osgEarth/MaskSource.cpp
+++ b/src/osgEarth/MaskSource.cpp
@@ -17,9 +17,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 #include <osgEarth/MaskSource>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
+
 #include <osg/Notify>
-#include <osgDB/ReadFile>
 
 using namespace osgEarth;
 using namespace OpenThreads;
@@ -101,8 +102,7 @@ MaskSourceFactory::create( const MaskSourceOptions& options )
         osg::ref_ptr<osgDB::Options> rwopts = Registry::instance()->cloneOrCreateOptions();
         rwopts->setPluginData( MASK_SOURCE_OPTIONS_TAG, (void*)&options );
 
-        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopts.get() );
-        source = dynamic_cast<MaskSource*>( object.release() );
+        source = osgEarth::readFile<MaskSource>( driverExt, rwopts.get() );
         if ( source )
         {
             OE_INFO << "Loaded MaskSource driver \"" << options.getDriver() << "\" OK" << std::endl;

--- a/src/osgEarth/ModelSource.cpp
+++ b/src/osgEarth/ModelSource.cpp
@@ -125,7 +125,7 @@ ModelSourceFactory::~ModelSourceFactory()
 ModelSource*
 ModelSourceFactory::create( const ModelSourceOptions& options )
 {
-    ModelSource* modelSource = 0L;
+    osg::ref_ptr<ModelSource> source;
 
     if ( !options.getDriver().empty() )
     {
@@ -134,14 +134,15 @@ ModelSourceFactory::create( const ModelSourceOptions& options )
         osg::ref_ptr<osgDB::Options> rwopts = Registry::instance()->cloneOrCreateOptions();
         rwopts->setPluginData( MODEL_SOURCE_OPTIONS_TAG, (void*)&options );
 
-        modelSource = dynamic_cast<ModelSource*>( osgDB::readObjectFile( driverExt, rwopts.get() ) );
+        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopts.get() );
+        source = dynamic_cast<ModelSource*>( object.release() );
     }
     else
     {
         OE_WARN << LC << "FAIL, illegal null driver specification" << std::endl;
     }
 
-    return modelSource;
+    return source.release();
 }
 
 //------------------------------------------------------------------------

--- a/src/osgEarth/ModelSource.cpp
+++ b/src/osgEarth/ModelSource.cpp
@@ -17,9 +17,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 #include <osgEarth/ModelSource>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
+
 #include <osg/Notify>
-#include <osgDB/ReadFile>
+
 #include <OpenThreads/ScopedLock>
 
 using namespace osgEarth;
@@ -134,8 +136,7 @@ ModelSourceFactory::create( const ModelSourceOptions& options )
         osg::ref_ptr<osgDB::Options> rwopts = Registry::instance()->cloneOrCreateOptions();
         rwopts->setPluginData( MODEL_SOURCE_OPTIONS_TAG, (void*)&options );
 
-        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopts.get() );
-        source = dynamic_cast<ModelSource*>( object.release() );
+        source = osgEarth::readFile<ModelSource>( driverExt, rwopts.get() );
     }
     else
     {

--- a/src/osgEarth/OverlayDecorator.cpp
+++ b/src/osgEarth/OverlayDecorator.cpp
@@ -23,6 +23,7 @@
 #include <osgEarth/DrapingTechnique>
 #include <osgEarth/MapInfo>
 #include <osgEarth/NodeUtils>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgEarth/Capabilities>
 #include <osgEarth/CullingUtils>
@@ -722,17 +723,17 @@ OverlayDecorator::cullTerrainAndCalculateRTTParams(osgUtil::CullVisitor* cv,
             {
                 frustumPH.dumpGeometry(0,0,0,fn);
             }
-            osg::ref_ptr<osg::Node> camNode = osgDB::readRefNodeFile(fn);
+            osg::ref_ptr<osg::Node> camNode = osgEarth::readNodeFile(fn);
             camNode->setName("camera");
 
             // visible overlay BEFORE cutting:
             //uncutVisiblePH.dumpGeometry(0,0,0,fn,osg::Vec4(0,1,1,1),osg::Vec4(0,1,1,.25));
-            //osg::ref_ptr<osg::Node> overlay = osgDB::readRefNodeFile(fn);
+            //osg::ref_ptr<osg::Node> overlay = osgEarth::readNodeFile(fn);
             //overlay->setName("overlay");
 
             // visible overlay Polyherdron AFTER cuting:
             visiblePH.dumpGeometry(0,0,0,fn,osg::Vec4(1,.5,1,1),osg::Vec4(1,.5,0,.25));
-            osg::ref_ptr<osg::Node> intersection = osgDB::readRefNodeFile(fn);
+            osg::ref_ptr<osg::Node> intersection = osgEarth::readNodeFile(fn);
             intersection->setName("intersection");
 
             // RTT frustum:
@@ -745,7 +746,7 @@ OverlayDecorator::cullTerrainAndCalculateRTTParams(osgUtil::CullVisitor* cv,
                 rttPH.transform( inverseMVP, MVP );
                 rttPH.dumpGeometry(0,0,0,fn,osg::Vec4(1,1,0,1),osg::Vec4(1,1,0,0.25));
             }
-            osg::ref_ptr<osg::Node> rttNode = osgDB::readRefNodeFile(fn);
+            osg::ref_ptr<osg::Node> rttNode = osgEarth::readNodeFile(fn);
             rttNode->setName("rtt");
 
             // EyePoint

--- a/src/osgEarth/OverlayDecorator.cpp
+++ b/src/osgEarth/OverlayDecorator.cpp
@@ -722,17 +722,17 @@ OverlayDecorator::cullTerrainAndCalculateRTTParams(osgUtil::CullVisitor* cv,
             {
                 frustumPH.dumpGeometry(0,0,0,fn);
             }
-            osg::Node* camNode = osgDB::readNodeFile(fn);
+            osg::ref_ptr<osg::Node> camNode = osgDB::readRefNodeFile(fn);
             camNode->setName("camera");
 
             // visible overlay BEFORE cutting:
             //uncutVisiblePH.dumpGeometry(0,0,0,fn,osg::Vec4(0,1,1,1),osg::Vec4(0,1,1,.25));
-            //osg::Node* overlay = osgDB::readNodeFile(fn);
+            //osg::ref_ptr<osg::Node> overlay = osgDB::readRefNodeFile(fn);
             //overlay->setName("overlay");
 
             // visible overlay Polyherdron AFTER cuting:
             visiblePH.dumpGeometry(0,0,0,fn,osg::Vec4(1,.5,1,1),osg::Vec4(1,.5,0,.25));
-            osg::Node* intersection = osgDB::readNodeFile(fn);
+            osg::ref_ptr<osg::Node> intersection = osgDB::readRefNodeFile(fn);
             intersection->setName("intersection");
 
             // RTT frustum:
@@ -745,7 +745,7 @@ OverlayDecorator::cullTerrainAndCalculateRTTParams(osgUtil::CullVisitor* cv,
                 rttPH.transform( inverseMVP, MVP );
                 rttPH.dumpGeometry(0,0,0,fn,osg::Vec4(1,1,0,1),osg::Vec4(1,1,0,0.25));
             }
-            osg::Node* rttNode = osgDB::readNodeFile(fn);
+            osg::ref_ptr<osg::Node> rttNode = osgDB::readRefNodeFile(fn);
             rttNode->setName("rtt");
 
             // EyePoint

--- a/src/osgEarth/ReadFile
+++ b/src/osgEarth/ReadFile
@@ -1,0 +1,154 @@
+/* -*-c++-*- */
+/* osgEarth - Dynamic map generation toolkit for OpenSceneGraph
+* Copyright 2016 Pelican Mapping
+* http://osgearth.org
+*
+* osgEarth is free software; you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published by
+* the Free Software Foundation; either version 2 of the License, or
+* (at your option) any later version.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+* FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+* AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+* LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+* FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+* IN THE SOFTWARE.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>
+*/
+#ifndef OSGEARTH_READFILE_H
+#define OSGEARTH_READFILE_H 1
+
+#include <osg/Version>
+
+#if OSG_VERSION_GREATER_OR_EQUAL(3,5,1)
+#undef OSG_PROVIDE_READFILE
+#endif
+
+#include <osg/ArgumentParser>
+#include <osg/Image>
+#include <osg/Node>
+#include <osg/Object>
+
+#include <osgDB/Options>
+#include <osgDB/ReadFile>
+
+#include <osgText/Font>
+
+#include <string>
+#include <list>
+#include <istream>
+
+namespace osgEarth
+{
+
+    inline osg::ref_ptr<osg::Object> readObjectFile(const std::string& filename, const osgDB::Options* options)
+    {
+        return osgDB::readRefObjectFile(filename, options);
+    }
+
+    inline osg::ref_ptr<osg::Object> readObjectFile(const std::string& filename)
+    {
+        return osgDB::readRefObjectFile(filename);
+    }
+
+    template<typename T>
+    inline osg::ref_ptr<T> readFile(const std::string& filename, const osgDB::Options* options)
+    {
+#if OSG_VERSION_GREATER_OR_EQUAL(3,5,1)
+        return osgDB::readRefFile<T>(filename, options);
+#else
+        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile(filename, options);
+        osg::ref_ptr<T> t = dynamic_cast<T*>(object.get());
+        return t;
+#endif
+    }
+
+    template<typename T>
+    inline osg::ref_ptr<T> readFile(const std::string& filename)
+    {
+#if OSG_VERSION_GREATER_OR_EQUAL(3,5,1)
+        return osgDB::readRefFile<T>(filename);
+#else
+        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile(filename);
+        osg::ref_ptr<T> t = dynamic_cast<T*>(object.get());
+        return t;
+#endif
+    }
+    
+    inline osg::ref_ptr<osg::Image> readImageFile(const std::string& filename, const osgDB::Options* options)
+    {
+        return osgDB::readRefImageFile(filename, options);
+    }
+
+    inline osg::ref_ptr<osg::Image> readImageFile(const std::string& filename)
+    {
+        return osgDB::readRefImageFile(filename);
+    }
+
+    inline osg::ref_ptr<osg::Node> readNodeFile(const std::string& filename, const osgDB::Options* options)
+    {
+        return osgDB::readRefNodeFile(filename, options);
+    }
+
+    inline osg::ref_ptr<osg::Node> readNodeFile(const std::string& filename)
+    {
+        return osgDB::readRefNodeFile(filename);
+    }
+
+    inline osg::ref_ptr<osg::Node> readNodeFiles(std::vector<std::string>& fileList, const osgDB::Options* options)
+    {
+#if OSG_VERSION_GREATER_OR_EQUAL(3,5,1)
+        return osgDB::readRefNodeFiles(fileList, options);
+#else
+    // BAD
+    return osgDB::readNodeFiles(fileList, options);
+#endif
+    }
+
+    inline osg::ref_ptr<osg::Node> readNodeFiles(std::vector<std::string>& fileList)
+    {
+#if OSG_VERSION_GREATER_OR_EQUAL(3,5,1)
+        return osgDB::readRefNodeFiles(fileList);
+#else
+    // BAD
+    return osgDB::readNodeFiles(fileList);
+#endif
+    }
+
+    inline osg::ref_ptr<osg::Node> readNodeFiles(osg::ArgumentParser& parser, const osgDB::Options* options)
+    {
+#if OSG_VERSION_GREATER_OR_EQUAL(3,5,1)
+        return osgDB::readRefNodeFiles(parser, options);
+#else
+    // BAD
+    return osgDB::readNodeFiles(parser, options);
+#endif
+    }
+
+    inline osg::ref_ptr<osg::Node> readNodeFiles(osg::ArgumentParser& parser)
+    {
+#if OSG_VERSION_GREATER_OR_EQUAL(3,5,1)
+        return osgDB::readRefNodeFiles(parser);
+#else
+    // BAD
+    return osgDB::readNodeFiles(parser);
+#endif
+    }
+
+    inline osg::ref_ptr<osgText::Font> readFontFile(const std::string& filename, const osgDB::Options* userOptions = 0)
+    {
+        return osgText::readRefFontFile(filename, userOptions);
+    }
+
+    inline osg::ref_ptr<osgText::Font> readRefFontStream(std::istream& stream, const osgDB::Options* userOptions = 0)
+    {
+        return osgText::readRefFontStream(stream, userOptions);
+    }
+
+}
+
+#endif // OSGEARTH_READFILE_H

--- a/src/osgEarth/Registry.cpp
+++ b/src/osgEarth/Registry.cpp
@@ -146,13 +146,13 @@ _devicePixelRatio(1.0f)
     const char* envFont = ::getenv("OSGEARTH_DEFAULT_FONT");
     if ( envFont )
     {
-        _defaultFont = osgText::readFontFile( std::string(envFont) );
+        _defaultFont = osgText::readRefFontFile( std::string(envFont) );
         OE_INFO << LC << "Default font set from environment: " << envFont << std::endl;
     }
     if ( !_defaultFont.valid() )
     {
 #ifdef WIN32
-        _defaultFont = osgText::readFontFile("arial.ttf");
+        _defaultFont = osgText::readRefFontFile("arial.ttf");
 #else
         _defaultFont = osgText::Font::getDefaultFont();
 #endif

--- a/src/osgEarth/Registry.cpp
+++ b/src/osgEarth/Registry.cpp
@@ -30,6 +30,7 @@
 #include <osgEarth/StringUtils>
 #include <osgEarth/TerrainEngineNode>
 #include <osgEarth/ObjectIndex>
+#include <osgEarth/ReadFile>
 
 #include <osgEarth/Units>
 #include <osg/Notify>
@@ -146,13 +147,13 @@ _devicePixelRatio(1.0f)
     const char* envFont = ::getenv("OSGEARTH_DEFAULT_FONT");
     if ( envFont )
     {
-        _defaultFont = osgText::readRefFontFile( std::string(envFont) );
+        _defaultFont = readFontFile( std::string(envFont) );
         OE_INFO << LC << "Default font set from environment: " << envFont << std::endl;
     }
     if ( !_defaultFont.valid() )
     {
 #ifdef WIN32
-        _defaultFont = osgText::readRefFontFile("arial.ttf");
+        _defaultFont = readFontFile("arial.ttf");
 #else
         _defaultFont = osgText::Font::getDefaultFont();
 #endif

--- a/src/osgEarth/ShaderGenerator.cpp
+++ b/src/osgEarth/ShaderGenerator.cpp
@@ -48,7 +48,6 @@
 #include <osg/ValueObject>
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
-#include <osgDB/ReadFile>
 #include <osgText/Text>
 #include <osgSim/LightPointNode>
 

--- a/src/osgEarth/TerrainEngineNode.cpp
+++ b/src/osgEarth/TerrainEngineNode.cpp
@@ -419,7 +419,7 @@ TerrainEngineNode::setComputeRangeCallback(ComputeRangeCallback* computeRangeCal
 TerrainEngineNode*
 TerrainEngineNodeFactory::create(const TerrainOptions& options )
 {
-    TerrainEngineNode* result = 0L;
+    osg::ref_ptr<TerrainEngineNode> node;
 
     std::string driver =
         Registry::instance()->overrideTerrainEngineDriverName().getOrUse(options.getDriver());
@@ -428,12 +428,13 @@ TerrainEngineNodeFactory::create(const TerrainOptions& options )
         driver = Registry::instance()->getDefaultTerrainEngineDriverName();
 
     std::string driverExt = std::string( ".osgearth_engine_" ) + driver;
-    result = dynamic_cast<TerrainEngineNode*>( osgDB::readObjectFile( driverExt ) );
-    if ( !result )
+    osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt );
+    node = dynamic_cast<TerrainEngineNode*>( object.release() );
+    if ( !node )
     {
         OE_WARN << "WARNING: Failed to load terrain engine driver for \"" << driver << "\"" << std::endl;
     }
 
-    return result;
+    return node.release();
 }
 

--- a/src/osgEarth/TerrainEngineNode.cpp
+++ b/src/osgEarth/TerrainEngineNode.cpp
@@ -19,13 +19,14 @@
 #include <osgEarth/TerrainEngineNode>
 #include <osgEarth/Capabilities>
 #include <osgEarth/CullingUtils>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgEarth/TerrainResources>
 #include <osgEarth/NodeUtils>
 #include <osgEarth/MapModelChange>
 #include <osgEarth/TerrainTileModelFactory>
 #include <osgEarth/TraversalData>
-#include <osgDB/ReadFile>
+
 #include <osg/CullFace>
 #include <osg/PolygonOffset>
 #include <osgViewer/View>
@@ -428,8 +429,7 @@ TerrainEngineNodeFactory::create(const TerrainOptions& options )
         driver = Registry::instance()->getDefaultTerrainEngineDriverName();
 
     std::string driverExt = std::string( ".osgearth_engine_" ) + driver;
-    osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt );
-    node = dynamic_cast<TerrainEngineNode*>( object.release() );
+    node = osgEarth::readFile<TerrainEngineNode>( driverExt );
     if ( !node )
     {
         OE_WARN << "WARNING: Failed to load terrain engine driver for \"" << driver << "\"" << std::endl;

--- a/src/osgEarth/TileRasterizer.cpp
+++ b/src/osgEarth/TileRasterizer.cpp
@@ -22,7 +22,6 @@
 #include <osgEarth/Registry>
 #include <osg/MatrixTransform>
 #include <osg/FrameBufferObject>
-#include <osgDB/ReadFile>
 
 #define LC "[TileRasterizer] "
 

--- a/src/osgEarth/TileSource
+++ b/src/osgEarth/TileSource
@@ -41,7 +41,6 @@
 #include <osg/Image>
 #include <osg/Shape>
 #include <osgDB/Options>
-#include <osgDB/ReadFile>
 #include <string>
 
 

--- a/src/osgEarth/TileSource.cpp
+++ b/src/osgEarth/TileSource.cpp
@@ -22,14 +22,15 @@
 #include <osgEarth/ImageToHeightFieldConverter>
 #include <osgEarth/ImageUtils>
 #include <osgEarth/FileUtils>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgEarth/ThreadingUtils>
 #include <osgEarth/MemCache>
 #include <osgEarth/MapFrame>
 #include <osgEarth/Progress>
+
 #include <osgDB/FileUtils>
 #include <osgDB/FileNameUtils>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 
 #define LC "[TileSource] "
@@ -489,8 +490,7 @@ TileSourceFactory::create(const TileSourceOptions& options)
     dbopt->setPluginStringData( TILESOURCE_INTERFACE_TAG, TileSource::INTERFACE_NAME );
 
     std::string driverExt = std::string( ".osgearth_" ) + driver;
-    osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, dbopt.get() );
-    source = dynamic_cast<TileSource*>( object.release() );
+    source = osgEarth::readFile<TileSource>( driverExt, dbopt.get() );
     if ( !source )
     {
         OE_INFO << LC << "Failed to load TileSource driver \"" << driver << "\"" << std::endl;

--- a/src/osgEarth/URI.cpp
+++ b/src/osgEarth/URI.cpp
@@ -300,7 +300,9 @@ namespace
             }
             return HTTPClient::readObject(req, opt, p);
         }
-        ReadResult fromFile( const std::string& uri, const osgDB::Options* opt ) { return ReadResult(osgDB::readObjectFile(uri, opt)); }
+        ReadResult fromFile( const std::string& uri, const osgDB::Options* opt ) {
+            return ReadResult(osgDB::readRefObjectFile(uri, opt).get());
+        }
     };
 
     struct ReadNode
@@ -317,7 +319,9 @@ namespace
             }
             return HTTPClient::readNode(req, opt, p);
         }
-        ReadResult fromFile( const std::string& uri, const osgDB::Options* opt ) { return ReadResult(osgDB::readNodeFile(uri, opt)); }
+        ReadResult fromFile( const std::string& uri, const osgDB::Options* opt ) {
+            return ReadResult(osgDB::readRefNodeFile(uri, opt));
+        }
     };
 
     struct ReadImage
@@ -346,7 +350,7 @@ namespace
             return r;
         }
         ReadResult fromFile( const std::string& uri, const osgDB::Options* opt ) { 
-            ReadResult r = ReadResult(osgDB::readImageFile(uri, opt));
+            ReadResult r = ReadResult(osgDB::readRefImageFile(uri, opt));
             if ( r.getImage() ) r.getImage()->setFileName( uri );
             return r;
         }

--- a/src/osgEarth/URI.cpp
+++ b/src/osgEarth/URI.cpp
@@ -20,13 +20,15 @@
 #include <osgEarth/Cache>
 #include <osgEarth/CacheBin>
 #include <osgEarth/HTTPClient>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgEarth/Progress>
 #include <osgEarth/FileUtils>
+
 #include <osgDB/FileNameUtils>
-#include <osgDB/ReadFile>
 #include <osgDB/ReaderWriter>
 #include <osgDB/Archive>
+
 #include <fstream>
 #include <sstream>
 
@@ -301,7 +303,7 @@ namespace
             return HTTPClient::readObject(req, opt, p);
         }
         ReadResult fromFile( const std::string& uri, const osgDB::Options* opt ) {
-            return ReadResult(osgDB::readRefObjectFile(uri, opt).get());
+            return ReadResult(osgEarth::readObjectFile(uri, opt).get());
         }
     };
 
@@ -320,7 +322,7 @@ namespace
             return HTTPClient::readNode(req, opt, p);
         }
         ReadResult fromFile( const std::string& uri, const osgDB::Options* opt ) {
-            return ReadResult(osgDB::readRefNodeFile(uri, opt));
+            return ReadResult(osgEarth::readNodeFile(uri, opt));
         }
     };
 
@@ -350,7 +352,7 @@ namespace
             return r;
         }
         ReadResult fromFile( const std::string& uri, const osgDB::Options* opt ) { 
-            ReadResult r = ReadResult(osgDB::readRefImageFile(uri, opt));
+            ReadResult r = ReadResult(osgEarth::readImageFile(uri, opt));
             if ( r.getImage() ) r.getImage()->setFileName( uri );
             return r;
         }

--- a/src/osgEarth/Units
+++ b/src/osgEarth/Units
@@ -23,6 +23,14 @@
 #include <osgEarth/Config>
 #include <ostream>
 
+#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+#if GCC_VERSION >= 50300
+#define OPTIMIZE __attribute__((optimize("no-ipa-sra")))
+#else
+#define OPTIMIZE
+#endif
+
 namespace osgEarth
 {
     class Registry;
@@ -105,7 +113,7 @@ namespace osgEarth
             return false;
         }
 
-        static double convert( const Units& from, const Units& to, double input ) {
+        static OPTIMIZE double convert( const Units& from, const Units& to, double input ) {
             double output = input;
             convert( from, to, input, output );
             return output;

--- a/src/osgEarth/Utils
+++ b/src/osgEarth/Utils
@@ -252,6 +252,7 @@ namespace osgEarth
         virtual ~AllocateAndMergeBufferObjectsVisitor() { }
         void apply(osg::Geode& geode);
     };
+    
 }
 
 #endif // OSGEARTH_UTILS_H

--- a/src/osgEarth/VerticalDatum.cpp
+++ b/src/osgEarth/VerticalDatum.cpp
@@ -218,14 +218,15 @@ VerticalDatum::isEquivalentTo( const VerticalDatum* rhs ) const
 VerticalDatum*
 VerticalDatumFactory::create( const std::string& init )
 {
-    VerticalDatum* result = 0L;
+    osg::ref_ptr<VerticalDatum> datum;
 
     std::string driverExt = Stringify() << ".osgearth_vdatum_" << init;
-    result = dynamic_cast<VerticalDatum*>( osgDB::readObjectFile(driverExt) );
-    if ( !result )
+    osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt );
+    datum = dynamic_cast<VerticalDatum*>( object.release() );
+    if ( !datum )
     {
         OE_WARN << "WARNING: Failed to load Vertical Datum driver for \"" << init << "\"" << std::endl;
     }
 
-    return result;
+    return datum.release();
 }

--- a/src/osgEarth/VerticalDatum.cpp
+++ b/src/osgEarth/VerticalDatum.cpp
@@ -21,8 +21,8 @@
 #include <osgEarth/StringUtils>
 #include <osgEarth/ThreadingUtils>
 #include <osgEarth/GeoData>
+#include <osgEarth/ReadFile>
 
-#include <osgDB/ReadFile>
 #include <osgDB/ReaderWriter>
 
 using namespace osgEarth;
@@ -221,8 +221,7 @@ VerticalDatumFactory::create( const std::string& init )
     osg::ref_ptr<VerticalDatum> datum;
 
     std::string driverExt = Stringify() << ".osgearth_vdatum_" << init;
-    osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt );
-    datum = dynamic_cast<VerticalDatum*>( object.release() );
+    datum = osgEarth::readFile<VerticalDatum>( driverExt );
     if ( !datum )
     {
         OE_WARN << "WARNING: Failed to load Vertical Datum driver for \"" << init << "\"" << std::endl;

--- a/src/osgEarthAnnotation/AnnotationUtils.cpp
+++ b/src/osgEarthAnnotation/AnnotationUtils.cpp
@@ -209,10 +209,10 @@ AnnotationUtils::createTextDrawable(const std::string& text,
     t->setCharacterSize( size * Registry::instance()->getDevicePixelRatio() );
     t->setColor( symbol && symbol->fill().isSet() ? symbol->fill()->color() : Color::White );
 
-    osgText::Font* font = 0L;
+    osg::ref_ptr<osgText::Font> font;
     if ( symbol && symbol->font().isSet() )
     {
-        font = osgText::readFontFile( *symbol->font() );
+        font = osgText::readRefFontFile( *symbol->font() );
     }
     if ( !font )
         font = Registry::instance()->getDefaultFont();

--- a/src/osgEarthAnnotation/AnnotationUtils.cpp
+++ b/src/osgEarthAnnotation/AnnotationUtils.cpp
@@ -24,6 +24,7 @@
 #include <osgEarthSymbology/Color>
 #include <osgEarthSymbology/MeshSubdivider>
 #include <osgEarth/ThreadingUtils>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/Capabilities>
@@ -212,7 +213,7 @@ AnnotationUtils::createTextDrawable(const std::string& text,
     osg::ref_ptr<osgText::Font> font;
     if ( symbol && symbol->font().isSet() )
     {
-        font = osgText::readRefFontFile( *symbol->font() );
+        font = readFontFile( *symbol->font() );
     }
     if ( !font )
         font = Registry::instance()->getDefaultFont();

--- a/src/osgEarthDrivers/agglite/AGGLiteRasterizerTileSource.cpp
+++ b/src/osgEarthDrivers/agglite/AGGLiteRasterizerTileSource.cpp
@@ -33,7 +33,6 @@
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 
 #include "AGGLiteOptions"

--- a/src/osgEarthDrivers/arcgis/ReaderWriterArcGIS.cpp
+++ b/src/osgEarthDrivers/arcgis/ReaderWriterArcGIS.cpp
@@ -31,7 +31,6 @@
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 
 #include <sstream>

--- a/src/osgEarthDrivers/bing/BingTileSource.cpp
+++ b/src/osgEarthDrivers/bing/BingTileSource.cpp
@@ -7,6 +7,7 @@
 #include <osgEarth/Random>
 #include <osgEarth/ImageUtils>
 #include <osgEarth/Containers>
+#include <osgEarth/ReadFile>
 
 #include <osgEarthSymbology/Geometry>
 #include <osgEarthSymbology/GeometryRasterizer>
@@ -229,7 +230,7 @@ public:
 
             // request the actual tile
             //OE_INFO << "key = " << key.str() << ", URL = " << location->value() << std::endl;
-            image = osgDB::readRefImageFile( location.full() );
+            image = osgEarth::readImageFile( location.full() );
         }
 
         if ( image &&  _geom.valid() )

--- a/src/osgEarthDrivers/bing/BingTileSource.cpp
+++ b/src/osgEarthDrivers/bing/BingTileSource.cpp
@@ -123,7 +123,7 @@ public:
      */
     osg::Image* createImage( const TileKey& key, ProgressCallback* progress )
     {
-        osg::Image* image = 0L;
+        osg::ref_ptr<osg::Image> image;
 
         if (_debugDirect)
         {
@@ -229,7 +229,7 @@ public:
 
             // request the actual tile
             //OE_INFO << "key = " << key.str() << ", URL = " << location->value() << std::endl;
-            image = osgDB::readImageFile( location.full() );
+            image = osgDB::readRefImageFile( location.full() );
         }
 
         if ( image &&  _geom.valid() )
@@ -241,7 +241,7 @@ public:
             blend.accept( overlay.get(), image );
         }
 
-        return image;
+        return image.release();
     }
 
 private:

--- a/src/osgEarthDrivers/earth/ReaderWriterOsgEarth.cpp
+++ b/src/osgEarthDrivers/earth/ReaderWriterOsgEarth.cpp
@@ -188,7 +188,7 @@ class ReaderWriterEarth : public osgDB::ReaderWriter
             // See if the filename starts with server: and strip it off.  This will trick OSG into
             // passing in the filename to our plugin instead of using the CURL plugin if the filename
             // contains a URL.  So, if you want to read a URL, you can use the following format
-            // osgDB::readNodeFile("server:http://myserver/myearth.earth").  This should only be
+            // osgEarth::readNodeFile("server:http://myserver/myearth.earth").  This should only be
             // necessary for the first level as the other files will have a tilekey prepended to them.
             if ((fileName.length() > 7) && (fileName.substr(0, 7) == "server:"))
                 return readNode(fileName.substr(7), readOptions);            

--- a/src/osgEarthDrivers/engine_mp/MPTerrainEngineDriver.cpp
+++ b/src/osgEarthDrivers/engine_mp/MPTerrainEngineDriver.cpp
@@ -89,7 +89,7 @@ namespace osgEarth { namespace Drivers { namespace MPTerrainEngine
                 // See if the filename starts with server: and strip it off.  This will trick OSG
                 // into passing in the filename to our plugin instead of using the CURL plugin if
                 // the filename contains a URL.  So, if you want to read a URL, you can use the
-                // following format: osgDB::readNodeFile("server:http://myserver/myearth.earth").
+                // following format: osgEarth::readNodeFile("server:http://myserver/myearth.earth").
                 // This should only be necessary for the first level as the other files will have
                 // a tilekey prepended to them.
                 if ((uri.length() > 7) && (uri.substr(0, 7) == "server:"))

--- a/src/osgEarthDrivers/engine_mp/TilePagedLOD.cpp
+++ b/src/osgEarthDrivers/engine_mp/TilePagedLOD.cpp
@@ -489,7 +489,7 @@ void TilePagedLOD::loadChildren()
             std::string filename = getFileName(i);    
             if (!filename.empty() && i >= getNumChildren())
             {
-                osg::ref_ptr< osg::Node > node = osgDB::readNodeFile(filename);                
+                osg::ref_ptr< osg::Node > node = osgDB::readRefNodeFile(filename);
                 if (!node.valid())
                 {
                     break;

--- a/src/osgEarthDrivers/engine_mp/TilePagedLOD.cpp
+++ b/src/osgEarthDrivers/engine_mp/TilePagedLOD.cpp
@@ -23,6 +23,7 @@
 #include "TileNodeRegistry"
 #include "MPTerrainEngineNode"
 #include <osg/Version>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgEarth/CullingUtils>
 #include <cassert>
@@ -489,7 +490,7 @@ void TilePagedLOD::loadChildren()
             std::string filename = getFileName(i);    
             if (!filename.empty() && i >= getNumChildren())
             {
-                osg::ref_ptr< osg::Node > node = osgDB::readRefNodeFile(filename);
+                osg::ref_ptr< osg::Node > node = osgEarth::readNodeFile(filename);
                 if (!node.valid())
                 {
                     break;

--- a/src/osgEarthDrivers/feature_elevation/ReaderWriterFeatureElevation.cpp
+++ b/src/osgEarthDrivers/feature_elevation/ReaderWriterFeatureElevation.cpp
@@ -34,7 +34,6 @@
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 #include <osgDB/ImageOptions>
 

--- a/src/osgEarthDrivers/gdal/ReaderWriterGDAL.cpp
+++ b/src/osgEarthDrivers/gdal/ReaderWriterGDAL.cpp
@@ -30,7 +30,6 @@
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 #include <osgDB/ImageOptions>
 

--- a/src/osgEarthDrivers/osg/OSGTileSource.cpp
+++ b/src/osgEarthDrivers/osg/OSGTileSource.cpp
@@ -23,6 +23,7 @@
 #include <osgEarth/Registry>
 #include <osgEarth/URI>
 #include <osgDB/FileNameUtils>
+#include <osgDB/Registry>
 
 #include <cstring>
 

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
@@ -615,7 +615,7 @@ SimpleSkyNode::makeMoon()
     osg::Geometry* geom = s_makeEllipsoidGeometry( em.get(), em->getRadiusEquator(), true );    
     //TODO:  Embed this texture in code or provide a way to have a default resource directory for osgEarth.
     //       Right now just need to have this file somewhere in your OSG_FILE_PATH
-    osg::Image* image = osgDB::readImageFile( "moon_1024x512.jpg" );
+    osg::ref_ptr<osg::Image> image = osgDB::readRefImageFile( "moon_1024x512.jpg" );
     osg::Texture2D * texture = new osg::Texture2D( image );
     texture->setFilter(osg::Texture::MIN_FILTER,osg::Texture::LINEAR);
     texture->setFilter(osg::Texture::MAG_FILTER,osg::Texture::LINEAR);

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
@@ -30,6 +30,7 @@
 #include <osgEarth/NodeUtils>
 #include <osgEarth/Map>
 #include <osgEarth/Utils>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgEarth/Capabilities>
 #include <osgEarth/CullingUtils>
@@ -615,7 +616,7 @@ SimpleSkyNode::makeMoon()
     osg::Geometry* geom = s_makeEllipsoidGeometry( em.get(), em->getRadiusEquator(), true );    
     //TODO:  Embed this texture in code or provide a way to have a default resource directory for osgEarth.
     //       Right now just need to have this file somewhere in your OSG_FILE_PATH
-    osg::ref_ptr<osg::Image> image = osgDB::readRefImageFile( "moon_1024x512.jpg" );
+    osg::ref_ptr<osg::Image> image = osgEarth::readImageFile( "moon_1024x512.jpg" );
     osg::Texture2D * texture = new osg::Texture2D( image );
     texture->setFilter(osg::Texture::MIN_FILTER,osg::Texture::LINEAR);
     texture->setFilter(osg::Texture::MAG_FILTER,osg::Texture::LINEAR);

--- a/src/osgEarthDrivers/tileindex/ReaderWriterTileIndex.cpp
+++ b/src/osgEarthDrivers/tileindex/ReaderWriterTileIndex.cpp
@@ -31,7 +31,6 @@
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 #include <osgDB/ImageOptions>
 
 #include <sstream>

--- a/src/osgEarthDrivers/vpb/ReaderWriterVPB.cpp
+++ b/src/osgEarthDrivers/vpb/ReaderWriterVPB.cpp
@@ -32,7 +32,6 @@
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 
 #include <sstream>

--- a/src/osgEarthDrivers/wcs/ReaderWriterWCS.cpp
+++ b/src/osgEarthDrivers/wcs/ReaderWriterWCS.cpp
@@ -20,7 +20,6 @@
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 #include "WCS11Source.h"
 #include <sstream>
 #include <stdlib.h>

--- a/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
+++ b/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
@@ -28,7 +28,6 @@
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 #include <osg/ImageSequence>
 #include <sstream>

--- a/src/osgEarthDrivers/xyz/ReaderWriterXYZ.cpp
+++ b/src/osgEarthDrivers/xyz/ReaderWriterXYZ.cpp
@@ -29,7 +29,6 @@
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 
 #include <OpenThreads/Atomic>
 

--- a/src/osgEarthDriversDisabled/engine_droam/Plugin.cpp
+++ b/src/osgEarthDriversDisabled/engine_droam/Plugin.cpp
@@ -20,7 +20,10 @@
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
 #include <osgEarth/MapNode>
+#include <osgEarth/ReadFile>
+
 #include <string>
+
 #include "DRoamNode"
 
 class DRoamEnginePlugin : public osgDB::ReaderWriter
@@ -44,7 +47,7 @@ public:
         {
             std::string earthFile = osgDB::getNameLessExtension( uri );
 
-            osg::ref_ptr<osg::Node> node = osgDB::readNodeFile(earthFile);
+            osg::ref_ptr<osg::Node> node = osgEarth::readNodeFile(earthFile);
             osgEarth::MapNode* mapNode = osgEarth::MapNode::findMapNode(node.get());
             if ( mapNode )
             {

--- a/src/osgEarthDriversDisabled/engine_osgterrain/OSGTileFactory.cpp
+++ b/src/osgEarthDriversDisabled/engine_osgterrain/OSGTileFactory.cpp
@@ -34,7 +34,6 @@
 #include <osg/ClusterCullingCallback>
 #include <osg/CoordinateSystemNode>
 #include <osgFX/MultiTextureControl>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 #include <osgTerrain/Locator>
 #include <osgTerrain/GeometryTechnique>

--- a/src/osgEarthDriversDisabled/engine_osgterrain/Plugin.cpp
+++ b/src/osgEarthDriversDisabled/engine_osgterrain/Plugin.cpp
@@ -80,7 +80,7 @@ public:
             // See if the filename starts with server: and strip it off.  This will trick OSG
             // into passing in the filename to our plugin instead of using the CURL plugin if
             // the filename contains a URL.  So, if you want to read a URL, you can use the
-            // following format: osgDB::readNodeFile("server:http://myserver/myearth.earth").
+            // following format: osgEarth:readNodeFile("server:http://myserver/myearth.earth").
             // This should only be necessary for the first level as the other files will have
             // a tilekey prepended to them.
             if ((uri.length() > 7) && (uri.substr(0, 7) == "server:"))

--- a/src/osgEarthDriversDisabled/engine_quadtree/QuadTreeTerrainEngineDriver.cpp
+++ b/src/osgEarthDriversDisabled/engine_quadtree/QuadTreeTerrainEngineDriver.cpp
@@ -89,7 +89,7 @@ public:
             // See if the filename starts with server: and strip it off.  This will trick OSG
             // into passing in the filename to our plugin instead of using the CURL plugin if
             // the filename contains a URL.  So, if you want to read a URL, you can use the
-            // following format: osgDB::readNodeFile("server:http://myserver/myearth.earth").
+            // following format: osgEarth::readNodeFile("server:http://myserver/myearth.earth").
             // This should only be necessary for the first level as the other files will have
             // a tilekey prepended to them.
             if ((uri.length() > 7) && (uri.substr(0, 7) == "server:"))

--- a/src/osgEarthDriversDisabled/label_overlay/OverlayLabelSource.cpp
+++ b/src/osgEarthDriversDisabled/label_overlay/OverlayLabelSource.cpp
@@ -21,9 +21,12 @@
 #include <osgEarthUtil/Controls>
 #include <osgEarth/Horizon>
 #include <osgEarth/ECEF>
+#include <osgEarth/ReadFile>
+
 #include <osg/ClusterCullingCallback>
 #include <osg/MatrixTransform>
 #include <osgDB/FileNameUtils>
+
 #include <set>
 
 using namespace osgEarth;
@@ -64,7 +67,7 @@ public:
             //    label->setFontSize( *symbol->size() );
             if ( symbol->font().isSet() )
             {
-                osgText::Font* font = osgText::readFontFile(*symbol->font() );
+                osgText::Font* font = readFontFile(*symbol->font() );
                 // mitigates mipmapping issues that cause rendering artifacts for some fonts/placement
                 if ( font )
                     font->setGlyphImageMargin( 2 );
@@ -152,7 +155,7 @@ public:
                 if ( text->font().isSet() )
                 {
                     // mitigates mipmapping issues that cause rendering artifacts for some fonts/placement
-                    osgText::Font* font = osgText::readFontFile(*text->font() );
+                    osgText::Font* font = readFontFile(*text->font() );
                     // mitigates mipmapping issues that cause rendering artifacts for some fonts/placement
                     if ( font )
                         font->setGlyphImageMargin( 2 );

--- a/src/osgEarthDriversDisabled/noise/NoiseDriver.cpp
+++ b/src/osgEarthDriversDisabled/noise/NoiseDriver.cpp
@@ -27,7 +27,6 @@
 #include <osgDB/FileNameUtils>
 #include <osgDB/FileUtils>
 #include <osgDB/Registry>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 #include <sstream>
 #include <cmath>

--- a/src/osgEarthFeatures/FeatureRasterizer.cpp
+++ b/src/osgEarthFeatures/FeatureRasterizer.cpp
@@ -34,6 +34,8 @@ FeatureRasterizerFactory::create(const std::string& driver,
                                  const Config& driverConf,
                                  const osgDB::ReaderWriter::Options* globalOptions )
 {
+    osg::ref_ptr<FeatureRasterizer> rasterizer;
+
     osg::ref_ptr<PluginOptions> pluginOptions = globalOptions?
         new PluginOptions( *globalOptions ) :
         new PluginOptions();
@@ -41,16 +43,18 @@ FeatureRasterizerFactory::create(const std::string& driver,
     // Setup the plugin options for the source
     pluginOptions->config() = driverConf;
 
-	//Load the source from the a plugin.  The "." prefix causes OSG to select the correct plugin.
+    std::string driverExt = std::string(".osgearth_rasterizer_") + driver;
+
+    //Load the source from the a plugin.  The "." prefix causes OSG to select the correct plugin.
     //For instance, the WMS plugin can be loaded by using ".osgearth_wms" as the filename
-    osg::ref_ptr<FeatureRasterizer> rasterizer = dynamic_cast<FeatureRasterizer*>(
-        osgDB::readObjectFile( ".osgearth_rasterizer_" + driver, pluginOptions.get()));
+    osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile(driverExt , pluginOptions.get()));
+    rasterizer = dynamic_cast<FeatureRasterizer*>(object.release());
 
-	if ( !rasterizer.valid() )
-	{
-		osg::notify(osg::NOTICE) << "[osgEarth] Warning: Could not load Rasterizer for driver "  << driver << std::endl;
-	}
+    if ( !rasterizer.valid() )
+    {
+        osg::notify(osg::NOTICE) << "[osgEarth] Warning: Could not load Rasterizer for driver "  << driver << std::endl;
+    }
 
-	return rasterizer.release();
+    return rasterizer.release();
 }
 

--- a/src/osgEarthFeatures/FeatureRasterizer.cpp
+++ b/src/osgEarthFeatures/FeatureRasterizer.cpp
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 #include <osgEarthFeatures/FeatureRasterizer>
-#include <osgDB/ReadFile>
+#include <osgEarth/ReadFile>
 
 using namespace osgEarth;
 using namespace osgEarth::Features;
@@ -47,8 +47,7 @@ FeatureRasterizerFactory::create(const std::string& driver,
 
     //Load the source from the a plugin.  The "." prefix causes OSG to select the correct plugin.
     //For instance, the WMS plugin can be loaded by using ".osgearth_wms" as the filename
-    osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile(driverExt , pluginOptions.get()));
-    rasterizer = dynamic_cast<FeatureRasterizer*>(object.release());
+    rasterizer = osgEarth::readFile<FeatureRasterizer>( driverExt, pluginOptions.get()));
 
     if ( !rasterizer.valid() )
     {

--- a/src/osgEarthFeatures/FeatureSource.cpp
+++ b/src/osgEarthFeatures/FeatureSource.cpp
@@ -214,7 +214,7 @@ FeatureSource::applyFilters(FeatureList& features, const GeoExtent& extent) cons
 FeatureSource*
 FeatureSourceFactory::create( const FeatureSourceOptions& options )
 {
-    FeatureSource* featureSource = 0L;
+    osg::ref_ptr<FeatureSource> source;
 
     if ( !options.getDriver().empty() )
     {
@@ -223,13 +223,14 @@ FeatureSourceFactory::create( const FeatureSourceOptions& options )
         osg::ref_ptr<osgDB::Options> rwopts = Registry::instance()->cloneOrCreateOptions();
         rwopts->setPluginData( FEATURE_SOURCE_OPTIONS_TAG, (void*)&options );
 
-        featureSource = dynamic_cast<FeatureSource*>( osgDB::readObjectFile( driverExt, rwopts.get() ) );
-        if ( featureSource )
+        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopts.get() );
+        source = dynamic_cast<FeatureSource*>( object.release() );
+        if ( source )
         {
             if ( options.name().isSet() )
-                featureSource->setName( *options.name() );
+                source->setName( *options.name() );
             else
-                featureSource->setName( options.getDriver() );
+                source->setName( options.getDriver() );
         }
         else
         {
@@ -241,7 +242,7 @@ FeatureSourceFactory::create( const FeatureSourceOptions& options )
         OE_WARN << LC << "ILLEGAL null feature driver name" << std::endl;
     }
 
-    return featureSource;
+    return source.release();
 }
 
 //------------------------------------------------------------------------

--- a/src/osgEarthFeatures/FeatureSource.cpp
+++ b/src/osgEarthFeatures/FeatureSource.cpp
@@ -21,9 +21,9 @@
 #include <osgEarthFeatures/BufferFilter>
 #include <osgEarthFeatures/ConvertTypeFilter>
 #include <osgEarthFeatures/FilterContext>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osg/Notify>
-#include <osgDB/ReadFile>
 #include <OpenThreads/ScopedLock>
 
 #define LC "[FeatureSource] "
@@ -223,8 +223,7 @@ FeatureSourceFactory::create( const FeatureSourceOptions& options )
         osg::ref_ptr<osgDB::Options> rwopts = Registry::instance()->cloneOrCreateOptions();
         rwopts->setPluginData( FEATURE_SOURCE_OPTIONS_TAG, (void*)&options );
 
-        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopts.get() );
-        source = dynamic_cast<FeatureSource*>( object.release() );
+        source = osgEarth::readFile<FeatureSource>( driverExt, rwopts.get() );
         if ( source )
         {
             if ( options.name().isSet() )

--- a/src/osgEarthFeatures/Filter.cpp
+++ b/src/osgEarthFeatures/Filter.cpp
@@ -104,7 +104,8 @@ FeatureFilterRegistry::create(const Config& conf, const osgDB::Options* dbo)
         dbopt->setPluginData( FEATURE_FILTER_OPTIONS_TAG, (void*)&options );
 
         std::string driverExt = std::string( ".osgearth_featurefilter_" ) + driver;
-        result = dynamic_cast<FeatureFilter*>( osgDB::readObjectFile( driverExt, dbopt.get() ) );
+        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, dbopt.get() );
+        result = dynamic_cast<FeatureFilter*>( object.release() );
     }
 
     if ( !result.valid() )

--- a/src/osgEarthFeatures/LabelSource.cpp
+++ b/src/osgEarthFeatures/LabelSource.cpp
@@ -67,7 +67,7 @@ LabelSource::~LabelSource()
 LabelSource*
 LabelSourceFactory::create( const LabelSourceOptions& options )
 {
-    LabelSource* labelSource = 0L;
+    osg::ref_ptr<LabelSource> source;
 
     if ( !options.getDriver().empty() )
     {
@@ -76,10 +76,11 @@ LabelSourceFactory::create( const LabelSourceOptions& options )
         osg::ref_ptr<osgDB::Options> rwopts = Registry::instance()->cloneOrCreateOptions();
         rwopts->setPluginData( LABEL_SOURCE_OPTIONS_TAG, (void*)&options );
 
-        labelSource = dynamic_cast<LabelSource*>( osgDB::readObjectFile( driverExt, rwopts.get() ) );
-        if ( labelSource )
+        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopts.get() );
+        source = dynamic_cast<LabelSource*>( object.release() );
+        if ( source )
         {
-            //modelSource->setName( options.getName() );
+            //source->setName( options.getName() );
             //OE_INFO << "Loaded LabelSource driver \"" << options.getDriver() << "\" OK" << std::endl;
         }
         else
@@ -92,7 +93,7 @@ LabelSourceFactory::create( const LabelSourceOptions& options )
         OE_WARN << LC << "FAIL, illegal null driver specification" << std::endl;
     }
 
-    return labelSource;
+    return source.release();
 }
 
 //------------------------------------------------------------------------

--- a/src/osgEarthFeatures/LabelSource.cpp
+++ b/src/osgEarthFeatures/LabelSource.cpp
@@ -17,8 +17,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 #include <osgEarthFeatures/LabelSource>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
-#include <osgDB/ReadFile>
 
 using namespace osgEarth;
 using namespace osgEarth::Features;
@@ -76,8 +76,7 @@ LabelSourceFactory::create( const LabelSourceOptions& options )
         osg::ref_ptr<osgDB::Options> rwopts = Registry::instance()->cloneOrCreateOptions();
         rwopts->setPluginData( LABEL_SOURCE_OPTIONS_TAG, (void*)&options );
 
-        osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopts.get() );
-        source = dynamic_cast<LabelSource*>( object.release() );
+        source = osgEarth::readFile<LabelSource>( driverExt, rwopts.get() );
         if ( source )
         {
             //source->setName( options.getName() );

--- a/src/osgEarthFeatures/ScriptEngine.cpp
+++ b/src/osgEarthFeatures/ScriptEngine.cpp
@@ -122,7 +122,7 @@ ScriptEngineFactory::createWithProfile( const Script& script, const std::string&
 ScriptEngine*
 ScriptEngineFactory::create( const ScriptEngineOptions& options, bool quiet)
 {
-    ScriptEngine* scriptEngine = 0L;
+    osg::ref_ptr<ScriptEngine> scriptEngine;
 
     if ( !options.getDriver().empty() )
     {
@@ -133,7 +133,8 @@ ScriptEngineFactory::create( const ScriptEngineOptions& options, bool quiet)
             osg::ref_ptr<osgDB::Options> rwopts = Registry::instance()->cloneOrCreateOptions();
             rwopts->setPluginData( SCRIPT_ENGINE_OPTIONS_TAG, (void*)&options );
 
-            scriptEngine = dynamic_cast<ScriptEngine*>( osgDB::readObjectFile( driverExt, rwopts.get() ) );
+            osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopts.get() );
+            scriptEngine = dynamic_cast<ScriptEngine*>( object.release() );
             if ( scriptEngine )
             {
                 OE_DEBUG << "Loaded ScriptEngine driver \"" << options.getDriver() << "\" OK" << std::endl;
@@ -157,7 +158,7 @@ ScriptEngineFactory::create( const ScriptEngineOptions& options, bool quiet)
             OE_WARN << LC << "FAIL, illegal null driver specification" << std::endl;
     }
 
-    return scriptEngine;
+    return scriptEngine.release();
 }
 
 //------------------------------------------------------------------------

--- a/src/osgEarthFeatures/ScriptEngine.cpp
+++ b/src/osgEarthFeatures/ScriptEngine.cpp
@@ -18,8 +18,8 @@
  */
 #include <osgEarthFeatures/ScriptEngine>
 #include <osgEarth/Notify>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
-#include <osgDB/ReadFile>
 
 using namespace osgEarth;
 using namespace osgEarth::Features;
@@ -133,8 +133,7 @@ ScriptEngineFactory::create( const ScriptEngineOptions& options, bool quiet)
             osg::ref_ptr<osgDB::Options> rwopts = Registry::instance()->cloneOrCreateOptions();
             rwopts->setPluginData( SCRIPT_ENGINE_OPTIONS_TAG, (void*)&options );
 
-            osg::ref_ptr<osg::Object> object = osgDB::readRefObjectFile( driverExt, rwopts.get() );
-            scriptEngine = dynamic_cast<ScriptEngine*>( object.release() );
+            scriptEngine = osgEarth::readFile<ScriptEngine>( driverExt, rwopts.get() );
             if ( scriptEngine )
             {
                 OE_DEBUG << "Loaded ScriptEngine driver \"" << options.getDriver() << "\" OK" << std::endl;

--- a/src/osgEarthFeatures/TextSymbolizer.cpp
+++ b/src/osgEarthFeatures/TextSymbolizer.cpp
@@ -17,6 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 #include <osgEarthFeatures/TextSymbolizer>
+#include <osgEarth/ReadFile>
 #include <osgEarth/Registry>
 #include <osgText/Text>
 
@@ -84,7 +85,7 @@ TextSymbolizer::create(Feature*             feature,
     osg::ref_ptr<osgText::Font> font;
     if ( _symbol.valid() && _symbol->font().isSet() )
     {
-        font = osgText::readRefFontFile( *_symbol->font() );
+        font = readFontFile( *_symbol->font() );
         
 #if OSG_VERSION_LESS_THAN(3,5,8)
         // mitigates mipmapping issues that cause rendering artifacts for some fonts/placement

--- a/src/osgEarthFeatures/TextSymbolizer.cpp
+++ b/src/osgEarthFeatures/TextSymbolizer.cpp
@@ -81,10 +81,10 @@ TextSymbolizer::create(Feature*             feature,
 
     t->setColor( _symbol.valid() && _symbol->fill().isSet() ? _symbol->fill()->color() : Color::White );
 
-    osgText::Font* font = 0L;
+    osg::ref_ptr<osgText::Font> font;
     if ( _symbol.valid() && _symbol->font().isSet() )
     {
-        font = osgText::readFontFile( *_symbol->font() );
+        font = osgText::readRefFontFile( *_symbol->font() );
         
 #if OSG_VERSION_LESS_THAN(3,5,8)
         // mitigates mipmapping issues that cause rendering artifacts for some fonts/placement

--- a/src/osgEarthSymbology/MarkerSymbolizer.cpp
+++ b/src/osgEarthSymbology/MarkerSymbolizer.cpp
@@ -39,8 +39,8 @@ static osg::Node* getNode(const std::string& str)
 #else
     osg::ref_ptr<osgDB::Options> options = new osgDB::Options;
     options->setObjectCacheHint(osgDB::Options::CACHE_ALL);
-    osg::Node* node = osgDB::readNodeFile(str, options.get());
-    return node;
+    ref_ptr<osg::Node> node = osgDB::readRefNodeFile(str, options.get());
+    return node.release();
 #endif
 }
 

--- a/src/osgEarthSymbology/MarkerSymbolizer.cpp
+++ b/src/osgEarthSymbology/MarkerSymbolizer.cpp
@@ -18,7 +18,9 @@
  */
 #include <osgEarthSymbology/MarkerSymbolizer>
 #include <osgEarthSymbology/MarkerSymbol>
-#include <osgDB/ReadFile>
+
+#include <osgEarth/ReadFile>
+
 #include <osgDB/ReaderWriter>
 #include <osg/Geometry>
 #include <osg/MatrixTransform>
@@ -26,22 +28,14 @@
 #include <osg/Geode>
 #include <osg/Version>
 
-
 using namespace osgEarth::Symbology;
 
 static osg::Node* getNode(const std::string& str)
 {
-#if OSG_VERSION_LESS_THAN(2,9,8)
-    osg::ref_ptr<osgDB::ReaderWriter::Options> options = new osgDB::ReaderWriter::Options;
-    options->setObjectCacheHint(osgDB::ReaderWriter::Options::CACHE_ALL);
-    osg::Node* node = osgDB::readNodeFile(str, options.get());
-    return node;
-#else
     osg::ref_ptr<osgDB::Options> options = new osgDB::Options;
     options->setObjectCacheHint(osgDB::Options::CACHE_ALL);
-    ref_ptr<osg::Node> node = osgDB::readRefNodeFile(str, options.get());
+    osg::ref_ptr<osg::Node> node = osgEarth::readNodeFile(str, options.get());
     return node.release();
-#endif
 }
 
 static double getRandomValueInRange(double value)

--- a/src/osgEarthSymbology/ModelSymbolizer.cpp
+++ b/src/osgEarthSymbology/ModelSymbolizer.cpp
@@ -21,7 +21,6 @@
 #include <osgEarth/HTTPClient>
 #include <osg/Geode>
 #include <osg/Version>
-#include <osgDB/ReadFile>
 #include <osgDB/ReaderWriter>
 
 using namespace osgEarth::Symbology;

--- a/src/osgEarthUtil/AtlasBuilder.cpp
+++ b/src/osgEarthUtil/AtlasBuilder.cpp
@@ -19,11 +19,13 @@
 #include <osgEarthUtil/AtlasBuilder>
 #include <osgEarthSymbology/Skins>
 #include <osgEarth/ImageUtils>
+#include <osgEarth/ReadFile>
+
 #include <osgDB/Options>
 #include <osgDB/FileNameUtils>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 #include <osgUtil/Optimizer>
+
 #include <vector>
 #include <string>
 #include <stdlib.h> // for ::getenv
@@ -171,14 +173,14 @@ AtlasBuilder::build(const ResourceLibrary* inputLib,
                 std::string auxFile = base + "_" + pattern + "." + ext;
 
                 // read in the auxiliary image:
-                osg::ref_ptr<osg::Image> auxImage = osgDB::readRefImageFile( auxFile, _options.get() );
+                osg::ref_ptr<osg::Image> auxImage = osgEarth::readImageFile( auxFile, _options.get() );
 
                 // if that didn't work, try alternate extensions:
                 const char* alternateExtensions[3] = {"png", "jpg", "osgb"};
                 for(int b = 0; b < 3 && !auxImage.valid(); ++b)
                 {
                     auxFile = base + "_" + pattern + "." + alternateExtensions[b];
-                    auxImage = osgDB::readRefImageFile( auxFile, _options.get() );
+                    auxImage = osgEarth::readImageFile( auxFile, _options.get() );
                 }
 
                 if ( auxImage.valid() )

--- a/src/osgEarthUtil/AtlasBuilder.cpp
+++ b/src/osgEarthUtil/AtlasBuilder.cpp
@@ -171,15 +171,14 @@ AtlasBuilder::build(const ResourceLibrary* inputLib,
                 std::string auxFile = base + "_" + pattern + "." + ext;
 
                 // read in the auxiliary image:
-                osg::ref_ptr<osg::Image> auxImage;
-                auxImage = osgDB::readImageFile( auxFile, _options.get() );
+                osg::ref_ptr<osg::Image> auxImage = osgDB::readRefImageFile( auxFile, _options.get() );
 
                 // if that didn't work, try alternate extensions:
                 const char* alternateExtensions[3] = {"png", "jpg", "osgb"};
                 for(int b = 0; b < 3 && !auxImage.valid(); ++b)
                 {
                     auxFile = base + "_" + pattern + "." + alternateExtensions[b];
-                    auxImage = osgDB::readImageFile( auxFile, _options.get() );
+                    auxImage = osgDB::readRefImageFile( auxFile, _options.get() );
                 }
 
                 if ( auxImage.valid() )

--- a/src/osgEarthUtil/ExampleResources.cpp
+++ b/src/osgEarthUtil/ExampleResources.cpp
@@ -269,7 +269,7 @@ MapNodeHelper::load(osg::ArgumentParser&  args,
     myReadOptions->setPluginStringData("osgEarth.defaultOptions", defMNO.getConfig().toJSON());
 
     // read in the Earth file:
-    osg::Node* node = osgDB::readNodeFiles(args, myReadOptions.get());
+    osg::ref_ptr<osg::Node> node = osgDB::readNodeFiles(args, myReadOptions.get());
 
     osg::ref_ptr<MapNode> mapNode;
     if ( !node )

--- a/src/osgEarthUtil/ExampleResources.cpp
+++ b/src/osgEarthUtil/ExampleResources.cpp
@@ -45,6 +45,7 @@
 
 #include <osgEarth/XmlUtils>
 #include <osgEarth/StringUtils>
+#include <osgEarth/ReadFile>
 
 #include <osgEarthDrivers/kml/KML>
 
@@ -269,7 +270,7 @@ MapNodeHelper::load(osg::ArgumentParser&  args,
     myReadOptions->setPluginStringData("osgEarth.defaultOptions", defMNO.getConfig().toJSON());
 
     // read in the Earth file:
-    osg::ref_ptr<osg::Node> node = osgDB::readNodeFiles(args, myReadOptions.get());
+    osg::ref_ptr<osg::Node> node = osgEarth::readNodeFiles(args, myReadOptions.get());
 
     osg::ref_ptr<MapNode> mapNode;
     if ( !node )

--- a/src/osgEarthUtil/GARSGraticule.cpp
+++ b/src/osgEarthUtil/GARSGraticule.cpp
@@ -20,6 +20,7 @@
 #include <osgEarthAnnotation/FeatureNode>
 #include <osgEarthFeatures/Feature>
 #include <osgEarth/PagedNode>
+#include <osgEarth/ReadFile>
 
 using namespace osgEarth;
 using namespace osgEarth::Util;
@@ -195,7 +196,7 @@ namespace
         double widthInMeters = west.distanceTo(east);
 
         osgText::Text* text = new osgText::Text;
-        text->setFont(osgText::readRefFontFile("arial.ttf"));
+        text->setFont(readFontFile("arial.ttf"));
         text->setText(label);
 
         text->setCharacterSize(widthInMeters / (double)label.size());

--- a/src/osgEarthUtil/GARSGraticule.cpp
+++ b/src/osgEarthUtil/GARSGraticule.cpp
@@ -195,7 +195,7 @@ namespace
         double widthInMeters = west.distanceTo(east);
 
         osgText::Text* text = new osgText::Text;
-        text->setFont(osgText::readFontFile("arial.ttf"));
+        text->setFont(osgText::readRefFontFile("arial.ttf"));
         text->setText(label);
 
         text->setCharacterSize(widthInMeters / (double)label.size());

--- a/src/osgEarthUtil/Ocean.cpp
+++ b/src/osgEarthUtil/Ocean.cpp
@@ -23,7 +23,7 @@
 #include <osgEarth/Registry>
 #include <osgEarth/CullingUtils>
 #include <osgEarth/MapNode>
-#include <osgDB/ReadFile>
+#include <osgDB/Options>
 
 using namespace osgEarth;
 using namespace osgEarth::Util;

--- a/src/osgEarthUtil/Sky.cpp
+++ b/src/osgEarthUtil/Sky.cpp
@@ -27,7 +27,7 @@
 #include <osgEarth/Extension>
 #include <osgEarth/MapNode>
 #include <osgEarth/Lighting>
-#include <osgDB/ReadFile>
+#include <osgDB/Options>
 
 using namespace osgEarth;
 using namespace osgEarth::Util;

--- a/src/osgEarthUtil/TMSBackFiller.cpp
+++ b/src/osgEarthUtil/TMSBackFiller.cpp
@@ -134,8 +134,9 @@ std::string TMSBackFiller::getFilename( const TileKey& key )
 
 osg::Image* TMSBackFiller::readTile( const TileKey& key )
 {
-    std::string filename = getFilename( key );        
-    return osgDB::readImageFile( filename );        
+    std::string filename = getFilename( key );
+    osg::ref_ptr< osg::Image> image = osgDB::readRefImageFile( filename );
+    return image.release();
 }
 
 void TMSBackFiller::writeTile( const TileKey& key, osg::Image* image )

--- a/src/osgEarthUtil/TMSBackFiller.cpp
+++ b/src/osgEarthUtil/TMSBackFiller.cpp
@@ -23,10 +23,10 @@
 #include <osgEarth/ImageUtils>
 #include <osgEarth/FileUtils>
 #include <osgEarth/ImageMosaic>
+#include <osgEarth/ReadFile>
 
 #include <osgDB/FileUtils>
 #include <osgDB/FileNameUtils>
-#include <osgDB/ReadFile>
 #include <osgDB/WriteFile>
 
 #define LC "[TMSBackFiller] "
@@ -44,32 +44,32 @@ _verbose(false)
 
 
 void TMSBackFiller::process( const std::string& tms, osgDB::Options* options )
-{               
-    std::string fullPath = getFullPath( "", tms );        
+{
+    std::string fullPath = getFullPath( "", tms );
     _options = options;
 
     //Read the tilemap
     _tileMap = TileMapReaderWriter::read( fullPath, 0 );
     if (_tileMap)
-    {                        
+    {
         //The max level is where we are going to read data from, so we need to start one level up.
-        osg::ref_ptr< const Profile> profile = _tileMap->createProfile();           
+        osg::ref_ptr< const Profile> profile = _tileMap->createProfile();
 
         //If the bounds aren't valid just use the full extent of the profile.
         if (!_bounds.valid())
-        {                
+        {
             _bounds = profile->getExtent().bounds();
         }
 
 
-        int firstLevel = _maxLevel-1;            
+        int firstLevel = _maxLevel-1;
 
-        GeoExtent extent( profile->getSRS(), _bounds );           
+        GeoExtent extent( profile->getSRS(), _bounds );
 
         //Process each level in it's entirety
         for (int level = firstLevel; level >= static_cast<int>(_minLevel); level--)
         {
-            if (_verbose) OE_NOTICE << "Processing level " << level << std::endl;                
+            if (_verbose) OE_NOTICE << "Processing level " << level << std::endl;
 
             TileKey ll = profile->createTileKey(extent.xMin(), extent.yMin(), level);
             TileKey ur = profile->createTileKey(extent.xMax(), extent.yMax(), level);
@@ -81,9 +81,9 @@ void TMSBackFiller::process( const std::string& tms, osgDB::Options* options )
                     TileKey key = TileKey(level, x, y, profile.get());
                     processKey( key );
                 }
-            }                
+            }
 
-        }            
+        }
     }
     else
     {
@@ -107,13 +107,13 @@ void TMSBackFiller::processKey( const TileKey& key )
     osg::ref_ptr< osg::Image > lr = readTile( lrKey );
 
     if (ul.valid() && ur.valid() && ll.valid() && lr.valid())
-    {            
+    {
         //Merge them together
         ImageMosaic mosaic;
         mosaic.getImages().push_back( TileImage( ul.get(), ulKey ) );
         mosaic.getImages().push_back( TileImage( ur.get(), urKey ) );
         mosaic.getImages().push_back( TileImage( ll.get(), llKey ) );
-        mosaic.getImages().push_back( TileImage( lr.get(), lrKey ) );            
+        mosaic.getImages().push_back( TileImage( lr.get(), lrKey ) );
 
         osg::ref_ptr< osg::Image> merged = mosaic.createImage();
         if (merged.valid())
@@ -121,21 +121,21 @@ void TMSBackFiller::processKey( const TileKey& key )
             //Resize the image so it's the same size as one of the input files
             osg::ref_ptr<osg::Image> resized;
             ImageUtils::resizeImage( merged.get(), ul->s(), ul->t(), resized );
-            std::string outputFilename = getFilename( key );                
+            std::string outputFilename = getFilename( key );
             writeTile( key, resized.get() );
         }
-    }                
-}    
+    }
+}
 
 std::string TMSBackFiller::getFilename( const TileKey& key )
 {
-    return _tileMap->getURL( key, false );        
+    return _tileMap->getURL( key, false );
 }
 
 osg::Image* TMSBackFiller::readTile( const TileKey& key )
 {
     std::string filename = getFilename( key );
-    osg::ref_ptr< osg::Image> image = osgDB::readRefImageFile( filename );
+    osg::ref_ptr< osg::Image> image = osgEarth::readImageFile( filename );
     return image.release();
 }
 
@@ -144,6 +144,6 @@ void TMSBackFiller::writeTile( const TileKey& key, osg::Image* image )
     std::string filename = getFilename( key );
     if ( !osgDB::fileExists( osgDB::getFilePath(filename) ) )
         osgEarth::makeDirectoryForFile( filename );
-    osgDB::writeImageFile( *image, filename, _options.get() );        
+    osgDB::writeImageFile( *image, filename, _options.get() );
 }
-     
+

--- a/src/osgEarthUtil/TileIndexBuilder.cpp
+++ b/src/osgEarthUtil/TileIndexBuilder.cpp
@@ -26,10 +26,10 @@
 #include <osgEarth/Progress>
 #include <osgEarth/ImageLayer>
 #include <osgEarthDrivers/gdal/GDALOptions>
+
 #include <osgDB/FileUtils>
 #include <osgDB/FileNameUtils>
 
-using namespace osgDB;
 using namespace osgEarth;
 using namespace osgEarth::Util;
 using namespace osgEarth::Drivers;
@@ -57,35 +57,35 @@ void TileIndexBuilder::build(const std::string& indexFilename, const osgEarth::S
     osg::ref_ptr< osgEarth::Util::TileIndex > index = osgEarth::Util::TileIndex::create( indexFilename, srs );
 
     _indexFilename = indexFilename;
-    std::string indexDir = getFilePath( _indexFilename );    
-    
+    std::string indexDir = osgDB::getFilePath( _indexFilename );
+
     unsigned int total = _expandedFilenames.size();
 
     for (unsigned int i = 0; i < _expandedFilenames.size(); i++)
-    {   
-        std::string filename = _expandedFilenames[ i ];        
+    {
+        std::string filename = _expandedFilenames[ i ];
 
         GDALOptions opt;
         opt.url() = filename;
-        
-        osg::ref_ptr< ImageLayer > layer = new ImageLayer( ImageLayerOptions("", opt) );        
+
+        osg::ref_ptr< ImageLayer > layer = new ImageLayer( ImageLayerOptions("", opt) );
 
         bool ok = false;
-                
-        if ( layer.valid() )        
-        {            
+
+        if ( layer.valid() )
+        {
             osg::ref_ptr< TileSource > source = layer->getTileSource();
             if (source.valid())
             {
                 for (DataExtentList::iterator itr = source->getDataExtents().begin(); itr != source->getDataExtents().end(); ++itr)
                 {
-                    // We want the filename as it is relative to the index file                
-                    std::string relative = getPathRelative( indexDir, filename );                
-                    index->add( relative, *itr);    
+                    // We want the filename as it is relative to the index file
+                    std::string relative = osgDB::getPathRelative( indexDir, filename );
+                    index->add( relative, *itr);
                     ok = true;
-                }                
+                }
             }
-        }        
+        }
 
         if (_progress.valid())
         {
@@ -104,24 +104,24 @@ void TileIndexBuilder::build(const std::string& indexFilename, const osgEarth::S
         }
     }
 
-    osg::Timer_t end = osg::Timer::instance()->tick();    
+    osg::Timer_t end = osg::Timer::instance()->tick();
 }
 
 void TileIndexBuilder::expandFilenames()
 {
-    // Expand the filenames since they might contain directories    
+    // Expand the filenames since they might contain directories
     for (unsigned int i = 0; i < _filenames.size(); i++)
     {
         std::string filename = _filenames[i];
         if (osgDB::fileType(filename) == osgDB::DIRECTORY)
-        {            
+        {
             CollectFilesVisitor v;
             v.traverse( filename );
             for (unsigned int j = 0; j < v.filenames.size(); j++)
             {
                 _expandedFilenames.push_back( v.filenames[ j ] );
             }
-        }   
+        }
         else
         {
             _expandedFilenames.push_back( filename );


### PR DESCRIPTION
New read*File() methods are in osgEarth/Utils

The read*File() methods could stay in Utils or be moved to a new osgEarth/FileRead.

