### PR TITLE
DrapeableNode is now a MapNodeObserver.

### DIFF
--- a/src/osgEarth/DrapeableNode
+++ b/src/osgEarth/DrapeableNode
@@ -23,6 +23,7 @@
 #include <osgEarth/Common>
 #include <osgEarth/optional>
 #include <osgEarth/MapNode>
+#include <osgEarth/MapNodeObserver>
 #include <osg/Group>
 
 namespace osgEarth
@@ -34,7 +35,7 @@ namespace osgEarth
      * Usage: Create this node and put it anywhere in the scene graph. The
      * subgraph of this node will be draped on the MapNode's terrain.
      */
-    class OSGEARTH_EXPORT DrapeableNode : public osg::Group
+    class OSGEARTH_EXPORT DrapeableNode : public osg::Group, public MapNodeObserver
     {
     public:
         META_Object(osgEarth, DrapeableNode);
@@ -57,6 +58,10 @@ namespace osgEarth
 
         virtual void traverse(osg::NodeVisitor& nv);
 
+    public: // osgEarth::MapNodeObserver
+
+        virtual void setMapNode(MapNode* mapNode) { _mapNode = mapNode; }
+        virtual MapNode* getMapNode() { return _mapNode.get(); }
 
     protected:
         /** dtor */


### PR DESCRIPTION
This fixes two problems:
- DrapeableNode may not be in the NodePath of a MapNode, so its update traversal never finds an initial MapNode.  setMapNode() gives users a way to configure it properly externally.
- The Map Node may change at runtime and DrapeableNode would not catch the change.