### PR TITLE
Adds optional name property in osgEarth::Symbology::StyleSheet

### DIFF
--- a/src/osgEarthSymbology/StyleSheet
+++ b/src/osgEarthSymbology/StyleSheet
@@ -56,6 +56,10 @@ namespace osgEarth { namespace Symbology
         /** Constructs a new style sheet */
         StyleSheet( const Config& conf );
 
+	/** Optional name of the style sheet */
+	optional<std::string>& name() { return _name; }
+	const optional<std::string>& name() const { return _name; }
+
         /** Gets the context for relative path resolution */
         const URIContext& uriContext() const { return _uriContext; }
 
@@ -103,6 +107,7 @@ namespace osgEarth { namespace Symbology
         virtual void mergeConfig( const Config& conf );
 
     protected:
+        optional<std::string>        _name;
         URIContext                   _uriContext;
         osg::ref_ptr<ScriptDef>      _script;
         StyleSelectorList            _selectors;

--- a/src/osgEarthSymbology/StyleSheet.cpp
+++ b/src/osgEarthSymbology/StyleSheet.cpp
@@ -178,6 +178,7 @@ Config
 StyleSheet::getConfig() const
 {
     Config conf;
+    conf.set("name", _name);
 
     for( StyleSelectorList::const_iterator i = _selectors.begin(); i != _selectors.end(); ++i )
     {
@@ -226,6 +227,8 @@ StyleSheet::getConfig() const
 void
 StyleSheet::mergeConfig( const Config& conf )
 {
+    conf.getIfSet("name", _name);
+
     _uriContext = URIContext( conf.referrer() );
 
     // read in any resource library references


### PR DESCRIPTION
Enables applications to keep track of what style sheet was applied to which feature model layers.