### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/osgEarth/ElevationPool.cpp
+++ b/src/osgEarth/ElevationPool.cpp
@@ -307,7 +307,7 @@ ElevationPool::getTile(const TileKey& key, MapFrame& frame, osg::ref_ptr<Elevati
     if ( !tile.valid() && OE_GET_TIMER(get) >= timeout )
     {
         // this means we timed out trying to fetch the map tile.
-        OE_TEST << LC << "Timout fetching tile " << key.str() << std::endl;
+        OE_TEST << LC << "Timeout fetching tile " << key.str() << std::endl;
     }
 
     if ( tile.valid() )

--- a/src/osgEarth/catch.hpp
+++ b/src/osgEarth/catch.hpp
@@ -4751,7 +4751,7 @@ namespace Catch {
             ss << seed;
             ss >> config.rngSeed;
             if( ss.fail() )
-                throw std::runtime_error( "Argment to --rng-seed should be the word 'time' or a number" );
+                throw std::runtime_error( "Argument to --rng-seed should be the word 'time' or a number" );
         }
     }
     inline void setVerbosity( ConfigData& config, int level ) {


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for 2.9-rc1:

 * Timout  -> Timeout
 * Argment -> Argument