### PR TITLE
Units: revert gcc optimizer bug fix

### DIFF
--- a/src/osgEarth/Units
+++ b/src/osgEarth/Units
@@ -23,14 +23,6 @@
 #include <osgEarth/Config>
 #include <ostream>
 
-#define GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
-
-#if GCC_VERSION >= 50300
-#define OPTIMIZE __attribute__((optimize("no-ipa-sra")))
-#else
-#define OPTIMIZE
-#endif
-
 namespace osgEarth
 {
     class Registry;
@@ -113,7 +105,7 @@ namespace osgEarth
             return false;
         }
 
-        static OPTIMIZE double convert( const Units& from, const Units& to, double input ) {
+        static double convert( const Units& from, const Units& to, double input ) {
             double output = input;
             convert( from, to, input, output );
             return output;


### PR DESCRIPTION
was erroneously commited as part of https://github.com/gwaldron/osgearth/issues/1012