### PR TITLE
Used unused config URI::option_string to configure custom CURL headers

### DIFF
--- a/src/osgEarth/HTTPClient.cpp
+++ b/src/osgEarth/HTTPClient.cpp
@@ -1136,8 +1136,14 @@ HTTPClient::doGet(const HTTPRequest&    request,
         }
     }
 
+    // Interpret osgEarth::URI::optionString as Curl custom header
+    std::string custom_header = options->getPluginStringData("osgEarth::URI::optionString");
+    if (!custom_header.empty())
+	headers = curl_slist_append(headers, custom_header.c_str());
+
     // Disable the default Pragma: no-cache that curl adds by default.
     headers = curl_slist_append(headers, "Pragma: ");
+
     curl_easy_setopt(_curl_handle, CURLOPT_HTTPHEADER, headers);
 
     osg::ref_ptr<HTTPResponse::Part> part = new HTTPResponse::Part();

--- a/src/osgEarthDrivers/feature_tfs/FeatureSourceTFS.cpp
+++ b/src/osgEarthDrivers/feature_tfs/FeatureSourceTFS.cpp
@@ -81,10 +81,21 @@ public:
         // make a local copy of the read options.
         _readOptions = Registry::cloneOrCreateOptions(readOptions);
 
+	const URI tfsURI = _options.url().value();
+	if ( tfsURI.empty() )
+	{
+	    return Status::Error( Status::ConfigurationError, "Fail: driver requires a valid \"url\" property" );
+	}
+
+	// Add URI::option_string as plugin string data to be passed as custom header to CURL
+	// later in HTTPClient::doGet().
+	if (tfsURI.optionString().isSet())
+	    _readOptions->setPluginStringData("osgEarth::URI::optionString", tfsURI.optionString().get());
+
         FeatureProfile* fp = 0L;
 
         // Try to read the TFS metadata:
-        _layerValid = TFSReaderWriter::read(_options.url().get(), _readOptions.get(), _layer);
+	_layerValid = TFSReaderWriter::read(tfsURI, _readOptions.get(), _layer);
 
         if (_layerValid)
         {

--- a/src/osgEarthDrivers/feature_wfs/FeatureSourceWFS.cpp
+++ b/src/osgEarthDrivers/feature_wfs/FeatureSourceWFS.cpp
@@ -92,7 +92,12 @@ public:
                 _options.url()->full() +
                 sep + 
                 "SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities";
-        }        
+
+	    // Add URI::option_string as plugin string data to be passed as custom header to CURL
+	    // later in HTTPClient::doGet().
+	    if (_options.url()->optionString().isSet())
+		_readOptions->setPluginStringData("osgEarth::URI::optionString", _options.url()->optionString().get());
+	}
 
         // read the WFS capabilities:
         _capabilities = WFSCapabilitiesReader::read( capUrl, _readOptions.get() );

--- a/src/osgEarthDrivers/tms/TMSTileSource.cpp
+++ b/src/osgEarthDrivers/tms/TMSTileSource.cpp
@@ -57,6 +57,11 @@ TMSTileSource::initialize(const osgDB::Options* dbOptions)
         return Status::Error( Status::ConfigurationError, "Fail: TMS driver requires a valid \"url\" property" );
     }
 
+    // Add URI::option_string as plugin string data to be passed as custom header to CURL
+    // later in HTTPClient::doGet().
+    if (tmsURI.optionString().isSet())
+	_dbOptions->setPluginStringData("osgEarth::URI::optionString", _options.url()->optionString().get());
+
     // A repo is writable only if it's local.
     if ( tmsURI.isRemote() )
     {

--- a/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
+++ b/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
@@ -113,8 +113,14 @@ public:
                 std::string("&REQUEST=GetCapabilities") );
         }
 
+	// Add URI::option_string as plugin string data to be passed as custom header to CURL
+	// later in HTTPClient::doGet().
+	osg::ref_ptr<osgDB::Options> localDbOptions = Registry::instance()->cloneOrCreateOptions( dbOptions );
+	if (_options.url()->optionString().isSet())
+	    localDbOptions->setPluginStringData("osgEarth::URI::optionString", _options.url()->optionString().get());
+
         //Try to read the WMS capabilities
-        osg::ref_ptr<WMSCapabilities> capabilities = WMSCapabilitiesReader::read( capUrl.full(), dbOptions );
+	osg::ref_ptr<WMSCapabilities> capabilities = WMSCapabilitiesReader::read( capUrl.full(), localDbOptions );
         if ( !capabilities.valid() )
         {
             return Status::Error( Status::ResourceUnavailable, "Unable to read WMS GetCapabilities." );
@@ -236,7 +242,7 @@ public:
         }
 
         OE_INFO << LC << "Testing for JPL/TileService at " << tsUrl.full() << std::endl;
-        _tileService = TileServiceReader::read(tsUrl.full(), dbOptions);
+	_tileService = TileServiceReader::read(tsUrl.full(), localDbOptions);
         if (_tileService.valid())
         {
             OE_INFO << LC << "Found JPL/TileService spec" << std::endl;
@@ -272,7 +278,7 @@ public:
             OE_INFO << LC << "Profile=" << getProfile()->toString() << std::endl;
 
             // set up the cache options properly for a TileSource.
-            _dbOptions = Registry::instance()->cloneOrCreateOptions( dbOptions );            
+	    _dbOptions = Registry::instance()->cloneOrCreateOptions( localDbOptions );
 
             return Status::OK();
         }

--- a/src/osgEarthDrivers/xyz/ReaderWriterXYZ.cpp
+++ b/src/osgEarthDrivers/xyz/ReaderWriterXYZ.cpp
@@ -60,11 +60,16 @@ public:
       {
           _dbOptions = Registry::instance()->cloneOrCreateOptions(dbOptions);        
 
-          URI xyzURI = _options.url().value();
+	  const URI xyzURI = _options.url().value();
           if ( xyzURI.empty() )
           {
               return Status::Error( Status::ConfigurationError, "Fail: driver requires a valid \"url\" property" );
           }
+
+	  // Add URI::option_string as plugin string data to be passed as custom header to CURL
+	  // later in HTTPClient::doGet().
+	  if (xyzURI.optionString().isSet())
+	      _dbOptions->setPluginStringData("osgEarth::URI::optionString", xyzURI.optionString().get());
 
           // driver requires a profile.
           if ( !getProfile() )


### PR DESCRIPTION
The prime reason for sending custom curl headers through the unused URI::option_string is to enable configuration of oauth2 bearer token for sources protected by oauth2 authentication (Ref. ECMWF data at https://thredds.met.no/thredds/metno.html).

Example imagelayer accessing WMS restricted by oauth2:

```
    <image name="met-no-ecmwf-air-temperature" driver="wms">
        <url>https://thredds.met.no/thredds/wms/ecmwf/atmo/ec_atmo_0_1deg_20180118T120000Z_pl.nc</url>
	<option_string>Authorization: Bearer YOUR-TOKEN-STRING</option_string>
        <format>png</format>
	<version>1.3.0</version>
        <layers>air_temperature_pl</layers>
        <tile_size>256</tile_size>
        <srs>EPSG:4326</srs>
        <transparent>true</transparent>
        <times>2018-01-18T18:00:00.000Z</times>
        <cache_policy usage="no_cache"/>
    </image>
```
Passing URI::option_string as CURL custom header has been enabled for: TFS. WFS, TMS, WMS, and XYZ.

Note 1: Instead of using URI::option_string for passing CURL custom headers, it could be preferable to add URI::curl_header config, or even make it possible to add a list of custom CURL headers.

Note 2: CURLOPT_XOAUTH2_BEARER was not used, since it is not supported by current curl version on CentOS7 (curl-7.29.0)

Note 3: It would be possible to omit using osgDB::Options::pluginStringData if urls were passed as URI classes rather than std::string. However, this would be a much larger code change.