### PR TITLE
Added new optional http_header config to osgEarth::URI

### DIFF
--- a/src/osgEarth/HTTPClient.cpp
+++ b/src/osgEarth/HTTPClient.cpp
@@ -1136,8 +1136,16 @@ HTTPClient::doGet(const HTTPRequest&    request,
         }
     }
 
+    // Interpret osgEarth::URI::optionString as Curl custom header
+    std::string custom_header = options->getPluginStringData("osgEarth::URI::httpHeader");
+    if (!custom_header.empty())
+    {
+	headers = curl_slist_append(headers, custom_header.c_str());
+    }
+
     // Disable the default Pragma: no-cache that curl adds by default.
     headers = curl_slist_append(headers, "Pragma: ");
+
     curl_easy_setopt(_curl_handle, CURLOPT_HTTPHEADER, headers);
 
     osg::ref_ptr<HTTPResponse::Part> part = new HTTPResponse::Part();

--- a/src/osgEarth/URI
+++ b/src/osgEarth/URI
@@ -194,6 +194,10 @@ namespace osgEarth
         optional<std::string>& optionString() { return _optionString; }
         const optional<std::string>& optionString() const { return _optionString; }
 
+	/** Custom Http header string passer to Curl.*/
+	optional<std::string>& httpHeader() { return _httpHeader; }
+	const optional<std::string>& httpHeader() const { return _httpHeader; }
+
     public:
 
         /** Sets a cache key. By default the cache key is the full URI, but you can override that. */
@@ -259,7 +263,8 @@ namespace osgEarth
         {
             Config conf("uri", base());
             conf.addIfSet("option_string", _optionString);
-            conf.setReferrer( context().referrer() );
+	    conf.addIfSet("http_header", _httpHeader);
+	    conf.setReferrer( context().referrer() );
             conf.setIsLocation( true );
             return conf;
         }
@@ -267,7 +272,8 @@ namespace osgEarth
         void mergeConfig(const Config& conf)
         {
             conf.getIfSet("option_string", _optionString);
-        }
+	    conf.getIfSet("http_header", _httpHeader);
+	}
 
     public: // Static convenience methods
 
@@ -280,6 +286,7 @@ namespace osgEarth
         std::string _cacheKey;
         URIContext  _context;
         optional<std::string> _optionString;
+	optional<std::string> _httpHeader;
 
         void ctorCacheKey();
     };

--- a/src/osgEarthDrivers/feature_tfs/FeatureSourceTFS.cpp
+++ b/src/osgEarthDrivers/feature_tfs/FeatureSourceTFS.cpp
@@ -81,10 +81,23 @@ public:
         // make a local copy of the read options.
         _readOptions = Registry::cloneOrCreateOptions(readOptions);
 
+	const URI tfsURI = _options.url().value();
+	if ( tfsURI.empty() )
+	{
+	    return Status::Error( Status::ConfigurationError, "Fail: driver requires a valid \"url\" property" );
+	}
+
+	// Add URI::http_header as plugin string data to be passed as custom header to CURL
+	// later in HTTPClient::doGet().
+	if (tfsURI.httpHeader().isSet())
+	{
+	    _readOptions->setPluginStringData("osgEarth::URI::httpHeader", tfsURI.httpHeader().get());
+	}
+
         FeatureProfile* fp = 0L;
 
         // Try to read the TFS metadata:
-        _layerValid = TFSReaderWriter::read(_options.url().get(), _readOptions.get(), _layer);
+	_layerValid = TFSReaderWriter::read(tfsURI, _readOptions.get(), _layer);
 
         if (_layerValid)
         {

--- a/src/osgEarthDrivers/feature_wfs/FeatureSourceWFS.cpp
+++ b/src/osgEarthDrivers/feature_wfs/FeatureSourceWFS.cpp
@@ -92,7 +92,14 @@ public:
                 _options.url()->full() +
                 sep + 
                 "SERVICE=WFS&VERSION=1.0.0&REQUEST=GetCapabilities";
-        }        
+
+	    // Add URI::http_header as plugin string data to be passed as custom header to CURL
+	    // later in HTTPClient::doGet().
+	    if (_options.url()->httpHeader().isSet())
+	    {
+		_readOptions->setPluginStringData("osgEarth::URI::httpHeader", _options.url()->httpHeader().get());
+	    }
+	}
 
         // read the WFS capabilities:
         _capabilities = WFSCapabilitiesReader::read( capUrl, _readOptions.get() );

--- a/src/osgEarthDrivers/tms/TMSTileSource.cpp
+++ b/src/osgEarthDrivers/tms/TMSTileSource.cpp
@@ -57,6 +57,13 @@ TMSTileSource::initialize(const osgDB::Options* dbOptions)
         return Status::Error( Status::ConfigurationError, "Fail: TMS driver requires a valid \"url\" property" );
     }
 
+    // Add URI::http_header as plugin string data to be passed as custom header to CURL
+    // later in HTTPClient::doGet().
+    if (tmsURI.httpHeader().isSet())
+    {
+	_dbOptions->setPluginStringData("osgEarth::URI::httpHeader", _options.url()->httpHeader().get());
+    }
+
     // A repo is writable only if it's local.
     if ( tmsURI.isRemote() )
     {

--- a/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
+++ b/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
@@ -113,8 +113,16 @@ public:
                 std::string("&REQUEST=GetCapabilities") );
         }
 
+	// Add URI::http_header as plugin string data to be passed as custom header to CURL
+	// later in HTTPClient::doGet().
+	osg::ref_ptr<osgDB::Options> localDbOptions = Registry::instance()->cloneOrCreateOptions( dbOptions );
+	if (_options.url()->httpHeader().isSet())
+	{
+	    localDbOptions->setPluginStringData("osgEarth::URI::httpHeader", _options.url()->httpHeader().get());
+	}
+
         //Try to read the WMS capabilities
-        osg::ref_ptr<WMSCapabilities> capabilities = WMSCapabilitiesReader::read( capUrl.full(), dbOptions );
+	osg::ref_ptr<WMSCapabilities> capabilities = WMSCapabilitiesReader::read( capUrl.full(), localDbOptions );
         if ( !capabilities.valid() )
         {
             return Status::Error( Status::ResourceUnavailable, "Unable to read WMS GetCapabilities." );
@@ -236,7 +244,7 @@ public:
         }
 
         OE_INFO << LC << "Testing for JPL/TileService at " << tsUrl.full() << std::endl;
-        _tileService = TileServiceReader::read(tsUrl.full(), dbOptions);
+	_tileService = TileServiceReader::read(tsUrl.full(), localDbOptions);
         if (_tileService.valid())
         {
             OE_INFO << LC << "Found JPL/TileService spec" << std::endl;
@@ -272,7 +280,7 @@ public:
             OE_INFO << LC << "Profile=" << getProfile()->toString() << std::endl;
 
             // set up the cache options properly for a TileSource.
-            _dbOptions = Registry::instance()->cloneOrCreateOptions( dbOptions );            
+	    _dbOptions = Registry::instance()->cloneOrCreateOptions( localDbOptions );
 
             return Status::OK();
         }

--- a/src/osgEarthDrivers/xyz/ReaderWriterXYZ.cpp
+++ b/src/osgEarthDrivers/xyz/ReaderWriterXYZ.cpp
@@ -60,11 +60,18 @@ public:
       {
           _dbOptions = Registry::instance()->cloneOrCreateOptions(dbOptions);        
 
-          URI xyzURI = _options.url().value();
+	  const URI xyzURI = _options.url().value();
           if ( xyzURI.empty() )
           {
               return Status::Error( Status::ConfigurationError, "Fail: driver requires a valid \"url\" property" );
           }
+
+	  // Add URI::http_header as plugin string data to be passed as custom header to CURL
+	  // later in HTTPClient::doGet().
+	  if (xyzURI.httpHeader().isSet())
+	  {
+	      _dbOptions->setPluginStringData("osgEarth::URI::httpHeader", xyzURI.httpHeader().get());
+	  }
 
           // driver requires a profile.
           if ( !getProfile() )


### PR DESCRIPTION
The new URL::http_header config is used to pass custom http header to Curl in osgEarth::HTTPClient. 

The prime reason for adding the URI::http_header is to enable configuration of oauth2 bearer token for sources protected by oauth2 authentication (Ref. ECMWF data at https://thredds.met.no/thredds/metno.html).

Example imagelayer accessing WMS restricted by oauth2:
```
   <image name="met-no-ecmwf-air-temperature" driver="wms">
      <url>https://thredds.met.no/thredds/wms/ecmwf/atmo/ec_atmo_0_1deg_20180118T120000Z_pl.nc</url>
      <http_header>Authorization: Bearer YOUR-TOKEN-STRING</http_header>
      <format>png</format>
      <version>1.3.0</version>
      <layers>air_temperature_pl</layers>
      <tile_size>256</tile_size>
      <srs>EPSG:4326</srs>
      <transparent>true</transparent>
      <times>2018-01-18T18:00:00.000Z</times>
      <cache_policy usage="no_cache"/>
   </image>
```

Passing URI::http_header to CURL has been enabled for: TFS. WFS, TMS, WMS, and XYZ.

Note 1: CURLOPT_XOAUTH2_BEARER was not used, since it is not supported by current curl version on CentOS7 (curl-7.29.0)

Note 2: It would be possible to omit using osgDB::Options::pluginStringData if urls were passed as URI classes rather than std::string. However, this would be a much larger code change.