### PR TITLE
update API calls to createVertexArrayState

### DIFF
--- a/src/osgEarthDrivers/engine_mp/MPGeometry
+++ b/src/osgEarthDrivers/engine_mp/MPGeometry
@@ -153,7 +153,9 @@ namespace osgEarth { namespace Drivers { namespace MPTerrainEngine
 #endif
 
     protected:
-#if OSG_MIN_VERSION_REQUIRED(3,5,6)
+#if OSG_MIN_VERSION_REQUIRED(3,5,9)
+        virtual osg::VertexArrayState* createVertexArrayStateImplementation(osg::RenderInfo& renderInfo) const;
+#elif OSG_MIN_VERSION_REQUIRED(3,5,6)
         virtual osg::VertexArrayState* createVertexArrayState(osg::RenderInfo& renderInfo) const;
 #endif
 

--- a/src/osgEarthDrivers/engine_mp/MPGeometry.cpp
+++ b/src/osgEarthDrivers/engine_mp/MPGeometry.cpp
@@ -565,11 +565,17 @@ MPGeometry::compileGLObjects( osg::RenderInfo& renderInfo ) const
 }
 
 #if OSG_MIN_VERSION_REQUIRED(3,5,6)
+
 osg::VertexArrayState*
+#if OSG_MIN_VERSION_REQUIRED(3,5,9)
+MPGeometry::createVertexArrayStateImplementation(osg::RenderInfo& renderInfo) const
+{
+    osg::VertexArrayState* vas = osg::Geometry::createVertexArrayStateImplementation(renderInfo);
+#else
 MPGeometry::createVertexArrayState(osg::RenderInfo& renderInfo) const
 {
     osg::VertexArrayState* vas = osg::Geometry::createVertexArrayState(renderInfo);
-    
+#endif
     // make sure we have array dispatchers for the multipass coords
     vas->assignTexCoordArrayDispatcher(_texCoordList.size() + 2);
 

--- a/src/osgEarthDrivers/engine_rex/GeometryPool
+++ b/src/osgEarthDrivers/engine_rex/GeometryPool
@@ -71,7 +71,11 @@ namespace osgEarth { namespace Drivers { namespace RexTerrainEngine
         const osg::DrawElements* getMaskElements() const { return _maskElements.get(); }
 
 #ifdef SUPPORTS_VAO
+    #if OSG_MIN_VERSION_REQUIRED(3,5,9)
+        osg::VertexArrayState* createVertexArrayStateImplementation(osg::RenderInfo& renderInfo) const;
+    #else
         osg::VertexArrayState* createVertexArrayState(osg::RenderInfo& renderInfo) const;
+    #endif
 #endif
 
         void compileGLObjects(osg::RenderInfo& renderInfo) const;

--- a/src/osgEarthDrivers/engine_rex/GeometryPool.cpp
+++ b/src/osgEarthDrivers/engine_rex/GeometryPool.cpp
@@ -592,7 +592,11 @@ SharedGeometry::empty() const
 
 
 #ifdef SUPPORTS_VAO
+#if OSG_MIN_VERSION_REQUIRED(3,5,9)
+osg::VertexArrayState* SharedGeometry::createVertexArrayStateImplementation(osg::RenderInfo& renderInfo) const
+#else
 osg::VertexArrayState* SharedGeometry::createVertexArrayState(osg::RenderInfo& renderInfo) const
+#endif
 {
     osg::State& state = *renderInfo.getState();
 


### PR DESCRIPTION
This fixes update API calls to createVertexArrayState  that are createVertexArrayStateImplementation from osg 3.5.9 as mentionned by my colleague in #1039 