### PR TITLE
Handle *_BATCH_UPDATE in MapCallback::onMapModelChanged

### DIFF
--- a/src/osgEarth/MapCallback.cpp
+++ b/src/osgEarth/MapCallback.cpp
@@ -53,6 +53,14 @@ MapCallback::onMapModelChanged( const MapModelChange& change )
         onLayerDisabled(change.getLayer());
         break;
 
+    case MapModelChange::BEGIN_BATCH_UPDATE:
+	onBeginUpdate();
+	break;
+
+    case MapModelChange::END_BATCH_UPDATE:
+	onEndUpdate();
+	break;
+
     default: 
         break;
     }

--- a/src/osgEarthUtil/WMS
+++ b/src/osgEarthUtil/WMS
@@ -53,7 +53,7 @@ namespace osgEarth { namespace Util
         /**
         *Gets the name of the style
         */
-        const std::string& getName() {return _name;}
+	const std::string& getName() const {return _name;}
 
         /**
         *Sets the name of the style
@@ -63,7 +63,7 @@ namespace osgEarth { namespace Util
         /**
         *Gets the title of the style
         */
-        const std::string& getTitle() {return _title;}
+	const std::string& getTitle() const {return _title;}
 
         /**
         *Sets the title of the style


### PR DESCRIPTION
MapCallback::onBeginUpdate() and MapCallback::onEndUpdate() and were not invoked as expected when my_mapnode->map()->beginUpdate() and my_mapnode->map()->endUpdate() were called.

Also WMSStyle::getName() and ::getTitle() methods should be const since operation and return references are const.

Conflicts:
	src/osgEarth/MapCallback.cpp