### PR TITLE
Fixed compilations errors on clang

### DIFF
--- a/src/osgEarthDrivers/engine_rex/SurfaceNode.cpp
+++ b/src/osgEarthDrivers/engine_rex/SurfaceNode.cpp
@@ -187,7 +187,7 @@ HorizonTileCuller::set(const SpatialReference* srs,
         // necessary because a tile that's below the ellipsoid (ocean floor, e.g.)
         // may be visible even if it doesn't pass the horizon-cone test. In such
         // cases we need a more conservative ellipsoid.
-        double zMin = (double)std::min( bbox.corner(0).z(), 0.0f );
+        double zMin = static_cast<double>(std::min( bbox.corner(0).z(), static_cast<osg::BoundingBox::value_type>(0.)));
         zMin = std::max(zMin, -25000.0); // approx the lowest point on earth * 2
         _horizon->setEllipsoid( osg::EllipsoidModel(
             srs->getEllipsoid()->getRadiusEquator() + zMin, 

--- a/src/osgEarthDrivers/model_simple/SimpleModelSource.cpp
+++ b/src/osgEarthDrivers/model_simple/SimpleModelSource.cpp
@@ -231,7 +231,9 @@ public:
                     osg::Vec3d center = result->getBound().center();
                     OE_DEBUG << "Radius=" << result->getBound().radius() << " center=" << center.x() << "," << center.y() << "," << center.z() << std::endl;                    
                     plod->setCenter(result->getBound().center());
-                    plod->setRadius(std::max(result->getBound().radius(), maxRange));
+                    plod->setRadius(std::max(result->getBound().radius(), 
+                                             static_cast<osg::BoundingSphere::value_type>(maxRange)));
+
                 }
                 lod = plod;
             }   

--- a/src/osgEarthSplat/Zone.cpp
+++ b/src/osgEarthSplat/Zone.cpp
@@ -52,10 +52,10 @@ Zone::configure(const Map* map, const osgDB::Options* readOptions)
         
         GeoExtent extent(
             SpatialReference::get("wgs84"),
-            osg::clampBetween(box.xMin(), -180.0f, 180.0f),
-            osg::clampBetween(box.yMin(),  -90.0f,  90.0f),
-            osg::clampBetween(box.xMax(), -180.0f, 180.0f),
-            osg::clampBetween(box.yMax(),  -90.0f,  90.0f));
+            osg::clampBetween(static_cast<float>(box.xMin()), -180.0f, 180.0f),
+            osg::clampBetween(static_cast<float>(box.yMin()),  -90.0f,  90.0f),
+            osg::clampBetween(static_cast<float>(box.xMax()), -180.0f, 180.0f),
+            osg::clampBetween(static_cast<float>(box.yMax()),  -90.0f,  90.0f));
 
         extent.createPolytope( b.tope );
         b.zmin2 = box.zMin() > -FLT_MAX ? box.zMin()*box.zMin() : box.zMin();

--- a/src/osgEarthUtil/SimplePager.cpp
+++ b/src/osgEarthUtil/SimplePager.cpp
@@ -260,7 +260,7 @@ osg::Node* SimplePager::createPagedNode(const TileKey& key, ProgressCallback* pr
     // notify any callbacks.
     fire_onCreateNode(key, node.get());
 
-    tileRadius = std::max(tileBounds.radius(), tileRadius);
+    tileRadius = std::max(tileBounds.radius(), static_cast<osg::BoundingSphere::value_type>(tileRadius));
 
     //osg::PagedLOD* plod = new osg::PagedLOD;
     osg::PagedLOD* plod = 


### PR DESCRIPTION
Hi @gwaldron,

I was trying to compile osgEarth on macOS and had issues because clang disallows mixing double an floats in std::min and std::max.

Hopefully these corrections will work even if BoundingSphere and BoundingBox are using floats