### PR TITLE
Simple Sky: Fix potential NULL access.

### DIFF
--- a/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
@@ -626,7 +626,7 @@ SimpleSkyNode::makeMoon()
 #ifdef OSG_GL3_AVAILABLE
     // Adjust for loss of GL_LUMINANCE in glTexture2D's format parameter.  OSG handles the texture's internal format,
     // but the format parameter comes from the image's pixel format field.
-    if (image->getPixelFormat() == GL_LUMINANCE)
+    if (image.valid() && image->getPixelFormat() == GL_LUMINANCE)
     {
       image->setPixelFormat(GL_RED);
       // Swizzle the RGB all to RED in order to match previous GL_LUMINANCE behavior


### PR DESCRIPTION
Encountered a segfault where image might be NULL if the moon image is not found, leading to a crash in GL3 mode.  Mea culpa.