### PR TITLE
SilverLining: Support GL Core 3.3 builds.

### DIFF
--- a/src/osgEarthSilverLining/SilverLiningContext.cpp
+++ b/src/osgEarthSilverLining/SilverLiningContext.cpp
@@ -142,8 +142,12 @@ SilverLiningContext::initialize(osg::RenderInfo& renderInfo)
                 resourcePath = osgDB::concatPaths(::getenv("SILVERLINING_PATH"), "Resources");
             }
 
+            int renderer = ::SilverLining::Atmosphere::OPENGL;
+#ifndef OSG_GL_FIXED_FUNCTION_AVAILABLE
+            renderer = ::SilverLining::Atmosphere::OPENGL32CORE;
+#endif
             int result = _atmosphere->Initialize(
-                ::SilverLining::Atmosphere::OPENGL,
+                renderer,
                 resourcePath.c_str(),
                 true,
                 0 );

--- a/src/osgEarthSilverLining/SilverLiningSkyDrawable.cpp
+++ b/src/osgEarthSilverLining/SilverLiningSkyDrawable.cpp
@@ -85,9 +85,12 @@ SkyDrawable::drawImplementation(osg::RenderInfo& renderInfo) const
         osg::GL2Extensions* api = osg::GL2Extensions::Get(renderInfo.getState()->getContextID(), true);
 #endif
         api->glUseProgram((GLuint)0);
-        renderInfo.getState()->setLastAppliedProgramObject(0L);
 #endif
 
+        // Reset the saved program.  SilverLining exits its functionality with a glUseProgram(0). Without this line,
+        // GL Core 3.3 rendering will attempt to load uniforms without an active program, which is an error.  This
+        // tells the state that there is currently no installed program, so if it needs one, to load one.
+        renderInfo.getState()->setLastAppliedProgramObject(0L);
         renderInfo.getState()->apply();
     }
 	}


### PR DESCRIPTION
This was more straightforward than fixing Triton (maybe due to better familiarity with API Trace).  Swaps out the renderer based on FFP availability, and fixes a problem where osg State is confused after Triton draws the sky.