### PR TITLE
Reduced pragma length in two more shader files, for old Intel drivers.

### DIFF
--- a/src/osgEarthDrivers/engine_mp/MPEngine.frag.glsl
+++ b/src/osgEarthDrivers/engine_mp/MPEngine.frag.glsl
@@ -6,7 +6,8 @@ $GLSL_DEFAULT_PRECISION_FLOAT
 #pragma vp_order      0.5
 #pragma vp_define     MP_USE_BLENDING
 
-#pragma import_defines(OE_IS_PICK_CAMERA, OE_IS_DEPTH_CAMERA, OE_IS_SHADOW_CAMERA, OE_TERRAIN_CAST_SHADOWS)
+#pragma import_defines(OE_IS_PICK_CAMERA, OE_IS_DEPTH_CAMERA, OE_IS_SHADOW_CAMERA)
+#pragma import_defines(OE_TERRAIN_CAST_SHADOWS)
 
 uniform vec4 oe_terrain_color;
 uniform sampler2D oe_layer_tex;

--- a/src/osgEarthDrivers/engine_rex/RexEngine.frag.glsl
+++ b/src/osgEarthDrivers/engine_rex/RexEngine.frag.glsl
@@ -6,7 +6,8 @@ $GLSL_DEFAULT_PRECISION_FLOAT
 #pragma vp_location   fragment_coloring
 #pragma vp_order      0.5
 
-#pragma import_defines(OE_TERRAIN_RENDER_IMAGERY,OE_TERRAIN_MORPH_IMAGERY,OE_TERRAIN_BLEND_IMAGERY,OE_TERRAIN_CAST_SHADOWS)
+#pragma import_defines(OE_TERRAIN_RENDER_IMAGERY,OE_TERRAIN_MORPH_IMAGERY,OE_TERRAIN_BLEND_IMAGERY)
+#pragma import_defines(OE_TERRAIN_CAST_SHADOWS)
 #pragma import_defines(OE_IS_PICK_CAMERA,OE_IS_SHADOW_CAMERA,OE_IS_DEPTH_CAMERA)
 
 uniform sampler2D oe_layer_tex;


### PR DESCRIPTION
Another customer had another old Intel driver (this time the 20.15.xx family), which could only handle 3 pragma parameters at a time