### PR TITLE
Capabilities: Detect core profile support added.

### DIFF
--- a/src/osgEarth/Capabilities
+++ b/src/osgEarth/Capabilities
@@ -150,6 +150,9 @@ namespace osgEarth
         /** Maximum size of a texture buffer, when supportsTextureBuffer() is true. */
         int getMaxTextureBufferSize() const { return _maxTextureBufferSize; }
 
+        /** whether OpenGL core profile is active */
+        bool isCoreProfile() const { return _isCoreProfile; }
+
     protected:
         Capabilities();
 
@@ -194,6 +197,7 @@ namespace osgEarth
         bool _isGLES;
         bool _supportsTextureBuffer;
         int  _maxTextureBufferSize;
+        bool _isCoreProfile;
 
     public:
         friend class Registry;

--- a/src/osgEarth/Capabilities.cpp
+++ b/src/osgEarth/Capabilities.cpp
@@ -140,7 +140,8 @@ _supportsARBTC          ( false ),
 _supportsETC            ( false ),
 _supportsRGTC           ( false ),
 _supportsTextureBuffer  ( false ),
-_maxTextureBufferSize   ( 0 )
+_maxTextureBufferSize   ( 0 ),
+_isCoreProfile          ( true )
 {
     // little hack to force the osgViewer library to link so we can create a graphics context
     osgViewerGetVersion();
@@ -191,6 +192,10 @@ _maxTextureBufferSize   ( 0 )
 
         _version = std::string( reinterpret_cast<const char*>(glGetString(GL_VERSION)) );
         OE_INFO << LC << "  Version = " << _version << std::endl;
+
+        // Core profile requires OSG 3.2, and the compatibility extension not being present
+        _isCoreProfile = (GL2->glVersion >= 3.2f && !osg::isGLExtensionSupported(id, "GL_ARB_compatibility"));
+        OE_INFO << LC << "  Core Profile = " << SAYBOOL(_isCoreProfile) << std::endl;
 
 #if !defined(OSG_GLES2_AVAILABLE) && !defined(OSG_GLES3_AVAILABLE)
         glGetIntegerv( GL_MAX_TEXTURE_UNITS, &_maxFFPTextureUnits );

--- a/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
+++ b/src/osgEarthDrivers/sky_simple/SimpleSkyNode.cpp
@@ -779,10 +779,11 @@ SimpleSkyNode::buildStarGeometry(const std::vector<StarData>& stars)
 
     osg::StateSet* sset = geometry->getOrCreateStateSet();
 
-#if !defined(OSG_GL3_AVAILABLE)
-    // In GL3, PointSprite is no longer available, and is always on.
-    sset->setTextureAttributeAndModes( 0, new osg::PointSprite(), osg::StateAttribute::ON );
-#endif
+    const osgEarth::Capabilities& caps = osgEarth::Registry::capabilities();
+    // In GL3 core profile, PointSprite is no longer available, and is always on.  However,
+    // in compatibility profile, PointSprite is available, required, and defaults off.
+    if (!caps.isCoreProfile())
+      sset->setTextureAttributeAndModes(0, new osg::PointSprite(), osg::StateAttribute::ON);
     sset->setMode( GL_VERTEX_PROGRAM_POINT_SIZE, osg::StateAttribute::ON );
 
     Shaders pkg;


### PR DESCRIPTION
Also fixed a problem with star point sprites.  They are required past GL3 if in compatibility mode (i.e. not in core mode)