### PR TITLE
LDB: Avoid uninitialized value shader compiler warning.

### DIFF
--- a/src/osgEarthUtil/LogDepthBuffer.vert.glsl
+++ b/src/osgEarthUtil/LogDepthBuffer.vert.glsl
@@ -15,4 +15,9 @@ void oe_logDepth_vert(inout vec4 clip)
         clip.z = (log2(max(1e-6, 1.0 + clip.w)) * oe_logDepth_FC - 1.0) * clip.w;
         oe_logDepth_clipz = 1.0 + clip.w;
     }
+    else
+    {
+        // Set clipz to 2.0 to avoid warnings on value not being initialized
+        oe_logDepth_clipz = 2.0;
+    }
 }


### PR DESCRIPTION
The warning can be seen with apitrace or if you get the log status after linking the shader.  It's a benign warning but this helps reduce clutter in apitrace output in GL Core.