### PR TITLE
LineDrawable: GCC compile fix

### DIFF
--- a/src/osgEarth/LineDrawable
+++ b/src/osgEarth/LineDrawable
@@ -225,7 +225,7 @@ namespace osgEarth
     template<typename T>
     void LineDrawable::importVertexAttribArray(unsigned location, const T* data)
     {
-        typename T* vaa = osg::cloneType(data);
+        T* vaa = osg::cloneType(data);
         setVertexAttribArray(location, vaa);
         for (unsigned i=0; i < data->getNumElements(); ++i)
             pushVertexAttrib(vaa, (*data)[i]);


### PR DESCRIPTION
Typename isn't required here because it's not ambiguous whether "T" is being used as a type or not (it definitely is).  GCC doesn't like superfluous typename, whereas MSVC is happy to ignore them.