### PR TITLE
add description to DataExtent

### DIFF
--- a/src/osgEarth/GeoData
+++ b/src/osgEarth/GeoData
@@ -548,8 +548,11 @@ namespace osgEarth
     {
     public:
         DataExtent(const GeoExtent& extent);
+        DataExtent(const GeoExtent& extent, const std::string &description);
         DataExtent(const GeoExtent& extent, unsigned minLevel );
+        DataExtent(const GeoExtent& extent, unsigned minLevel, const std::string &description);
         DataExtent(const GeoExtent& extent, unsigned minLevel, unsigned maxLevel);
+        DataExtent(const GeoExtent& extent, unsigned minLevel, unsigned maxLevel, const std::string &description);
 
         /** dtor */
         virtual ~DataExtent() { }
@@ -562,9 +565,13 @@ namespace osgEarth
         optional<unsigned>& maxLevel() { return _maxLevel; }
         const optional<unsigned>& maxLevel() const { return _maxLevel; }
 
+        /** description for the data extents */
+        const osgEarth::optional<std::string>& description() const { return _description; }
+
     private:
         optional<unsigned> _minLevel;
         optional<unsigned> _maxLevel;
+        optional<std::string> _description;
     };
 
     typedef std::vector< DataExtent > DataExtentList;

--- a/src/osgEarth/GeoData.cpp
+++ b/src/osgEarth/GeoData.cpp
@@ -1403,6 +1403,22 @@ GeoExtent::createScaleBias(const GeoExtent& rhs, osg::Matrix& output) const
 
 /***************************************************************************/
 
+DataExtent::DataExtent(const GeoExtent& extent, unsigned minLevel, unsigned maxLevel, const std::string &description) :
+GeoExtent(extent)
+{
+    _minLevel = minLevel;
+    _maxLevel = maxLevel;
+    _description = description;
+}
+
+DataExtent::DataExtent(const GeoExtent& extent, const std::string &description) :
+GeoExtent(extent),
+_minLevel( 0 ),
+_maxLevel( 0 )
+{
+    _description = description;
+}
+
 DataExtent::DataExtent(const GeoExtent& extent, unsigned minLevel,  unsigned maxLevel) :
 GeoExtent(extent)
 {
@@ -1415,6 +1431,14 @@ GeoExtent(extent),
 _maxLevel( 25 )
 {
     _minLevel = minLevel;
+}
+
+DataExtent::DataExtent(const GeoExtent& extent, unsigned minLevel, const std::string &description) :
+GeoExtent(extent),
+_maxLevel( 0 )
+{
+    _minLevel = minLevel;
+    _description = description;
 }
 
 DataExtent::DataExtent(const GeoExtent& extent ) :

--- a/src/osgEarthUtil/TMS.cpp
+++ b/src/osgEarthUtil/TMS.cpp
@@ -147,6 +147,8 @@ void TileMap::setExtents( double minX, double minY, double maxX, double maxY)
 #define ATTR_ORDER "order"
 #define ATTR_UNITSPERPIXEL "units-per-pixel"
 
+#define ATTR_DESCRIPTION "description"
+
 bool intersects(const double &minXa, const double &minYa, const double &maxXa, const double &maxYa,
                 const double &minXb, const double &minYb, const double &maxXb, const double &maxYb)
 {
@@ -592,12 +594,24 @@ TileMapReaderWriter::read( const Config& conf )
 
             unsigned int maxLevel = conf.value<unsigned>(ATTR_MAX_LEVEL, 0);
 
+            std::string description = conf.value<std::string>(ATTR_DESCRIPTION, std::string());
+
             //OE_DEBUG << LC << "Read area " << minX << ", " << minY << ", " << maxX << ", " << maxY << ", minlevel=" << minLevel << " maxlevel=" << maxLevel << std::endl;
 
             if ( maxLevel > 0 )
-                tileMap->getDataExtents().push_back( DataExtent(GeoExtent(profile->getSRS(), minX, minY, maxX, maxY), 0, maxLevel));
+            {
+                if(description.empty())
+                    tileMap->getDataExtents().push_back( DataExtent(GeoExtent(profile->getSRS(), minX, minY, maxX, maxY), 0, maxLevel));
+                else
+                    tileMap->getDataExtents().push_back( DataExtent(GeoExtent(profile->getSRS(), minX, minY, maxX, maxY), 0, maxLevel, description));
+            }
             else
-                tileMap->getDataExtents().push_back( DataExtent(GeoExtent(profile->getSRS(), minX, minY, maxX, maxY), 0) );
+            {
+                if(description.empty())
+                    tileMap->getDataExtents().push_back( DataExtent(GeoExtent(profile->getSRS(), minX, minY, maxX, maxY), 0) );
+                else
+                    tileMap->getDataExtents().push_back( DataExtent(GeoExtent(profile->getSRS(), minX, minY, maxX, maxY), 0, description) );
+            }
         }
     }
 
@@ -686,6 +700,8 @@ tileMapToXmlDocument(const TileMap* tileMap)
                 e_data_extent->getAttrs()[ATTR_MIN_LEVEL] = toString<unsigned int>(*itr->minLevel());
             if ( itr->maxLevel().isSet() )
                 e_data_extent->getAttrs()[ATTR_MAX_LEVEL] = toString<unsigned int>(*itr->maxLevel());
+            if ( itr->description().isSet() )
+                e_data_extent->getAttrs()[ATTR_DESCRIPTION] = *itr->description();
             e_data_extents->getChildren().push_back( e_data_extent );
         }
         doc->getChildren().push_back( e_data_extents.get() );


### PR DESCRIPTION
adds an optional string property "description" to DataExtent. This allows to add a human readable description to each data extent in tms.xml, since the coordinates are quite confusion sometimes.