### PR TITLE
Triton: Fix Linux compile error with reinterpret_cast on g++ 4.4

### DIFF
--- a/src/osgEarthTriton/TritonAPIWrapper.cpp
+++ b/src/osgEarthTriton/TritonAPIWrapper.cpp
@@ -81,12 +81,12 @@ void Environment::SetEnvironmentMap(GLuint cubeMap, const osg::Matrixd &textureM
         textureMatrix(0, 0), textureMatrix(0, 1), textureMatrix(0, 2),
         textureMatrix(1, 0), textureMatrix(1, 1), textureMatrix(1, 2),
         textureMatrix(2, 0), textureMatrix(2, 1), textureMatrix(2, 2));
-     ::Triton::TextureHandle tex_handle = reinterpret_cast<::Triton::TextureHandle>(static_cast<size_t>(cubeMap));
+    ::Triton::TextureHandle tex_handle = (::Triton::TextureHandle)(static_cast<size_t>(cubeMap));
     HANDLE->SetEnvironmentMap(tex_handle, triton_tex_mat);
 }
 GLuint Environment::GetEnvironmentMap() const {
     ::Triton::TextureHandle tex_handle = HANDLE->GetEnvironmentMap();
-    return static_cast<GLuint>(reinterpret_cast<size_t>(tex_handle));
+    return static_cast<GLuint>((size_t)tex_handle);
 }
 osg::Matrixd Environment::GetEnvironmentMapMatrix() const {
     ::Triton::Matrix3 m = HANDLE->GetEnvironmentMapMatrix();


### PR DESCRIPTION
On Windows, TextureHandle is a pointer and a reinterpret_cast<> is appropriate.  On Linux, it's an int, and at least on g++ 4.4 it's illegal to reinterpret_cast<> a size_t to an int.  Similarly, it's illegal to reinterpret_cast<> an int to a size_t.

An alternate fix should be to use static_cast<> on Linux (based on `if _WIN32`) and use the preprocessor, but that looked more messy than just having a C-style cast.