### PR TITLE
Fixed an issue where setting color for the first vertex in a LineDraw…

### DIFF
--- a/src/osgEarth/LineDrawable.cpp
+++ b/src/osgEarth/LineDrawable.cpp
@@ -524,8 +524,12 @@ LineDrawable::setColor(unsigned vi, const osg::Vec4& color)
         if (_mode == GL_LINE_STRIP || _mode == GL_LINE_LOOP)
         {
             if (vi == 0)
+            {
                 for (unsigned i=0; i<2; ++i)
                     (*_colors)[i] = color;
+                for (unsigned i=_colors->size()-2; i<_colors->size(); ++i)
+                    (*_colors)[i] = color;
+            }
             else
                 for (unsigned i=vi*4-2; i<vi*4+2; ++i)
                     (*_colors)[i] = color;


### PR DESCRIPTION
…able in GL_LINE_LOOP mode would not set the color for use in both directions.