### PR TITLE
osgEarthQt: ModelLayer::getOrCreateNode was changed to ModelLayer::getNode.

### DIFF
--- a/src/osgEarthQt/LayerManagerWidget.cpp
+++ b/src/osgEarthQt/LayerManagerWidget.cpp
@@ -646,7 +646,7 @@ Action* ModelLayerControlWidget::getDoubleClickAction(const ViewVector& views)
 {
   if (!_doubleClick.valid() && _layer.valid() && _map.valid())
   {
-    osg::ref_ptr<osg::Node> temp = _layer->getOrCreateNode();
+    osg::ref_ptr<osg::Node> temp = _layer->getNode();
     if (temp.valid())
     {
       osg::NodePathList nodePaths = temp->getParentalNodePaths();

--- a/src/osgEarthQt/MapCatalogWidget.cpp
+++ b/src/osgEarthQt/MapCatalogWidget.cpp
@@ -116,7 +116,7 @@ namespace
           osgEarth::ModelLayer* model = dynamic_cast<osgEarth::ModelLayer*>(_layer.get());
           if (model && _map.valid())
           {
-            osg::ref_ptr<osg::Node> temp = model->getOrCreateNode();
+            osg::ref_ptr<osg::Node> temp = model->getNode();
             if (temp.valid())
             {
               osg::NodePathList nodePaths = temp->getParentalNodePaths();


### PR DESCRIPTION
The calling sites in osgEarthQt for getOrCreateNode have been updated to getNode.