### PR TITLE
fix glCompileShader error with placenode

### DIFF
--- a/src/osgEarthAnnotation/PlaceNode.cpp
+++ b/src/osgEarthAnnotation/PlaceNode.cpp
@@ -47,7 +47,7 @@ using namespace osgEarth::Symbology;
 namespace
 {
     const char* iconVS =
-        "#version 330\n"
+        "#version " GLSL_VERSION_STR "\n"
         "out vec2 oe_PlaceNode_texcoord; \n"
         "void oe_PlaceNode_icon_VS(inout vec4 vertex) { \n"
         "    oe_PlaceNode_texcoord = gl_MultiTexCoord0.st; \n"


### PR DESCRIPTION
Cleanup glCompileShader error:

VERTEX glCompileShader "oe_PlaceNode_icon_VS" FAILED
VERTEX Shader "oe_PlaceNode_icon_VS" infolog:
0(5) : error C7616: global variable gl_MultiTexCoord0 is removed after version 140