### PR TITLE
GL3 fixes for osg::Point spam for point-based Features.

### DIFF
--- a/src/osgEarth/GLUtils.cpp
+++ b/src/osgEarth/GLUtils.cpp
@@ -176,6 +176,7 @@ GL3RealizeOperation::operator()(osg::Object* object)
         state->setModeValidity(GL_RESCALE_NORMAL, false);
         state->setModeValidity(GL_LINE_STIPPLE, false);
         state->setModeValidity(GL_LINE_SMOOTH, false);
+        state->setModeValidity(GL_POINT_SMOOTH, false);
 #endif
     }
 }

--- a/src/osgEarthFeatures/Filter.cpp
+++ b/src/osgEarthFeatures/Filter.cpp
@@ -18,14 +18,11 @@
  */
 #include <osgEarthFeatures/Filter>
 #include <osgEarthFeatures/FilterContext>
-#include <osgEarthSymbology/LineSymbol>
 #include <osgEarthSymbology/PointSymbol>
 #include <osgEarth/ECEF>
+#include <osgEarth/GLUtils>
 #include <osgEarth/Registry>
 #include <osg/MatrixTransform>
-#include <osg/Point>
-#include <osg/LineWidth>
-#include <osg/LineStipple>
 #include <osgEarth/VirtualProgram>
 
 using namespace osgEarth;
@@ -338,6 +335,6 @@ FeaturesToNodeFilter::applyPointSymbology(osg::StateSet*     stateset,
     if ( point )
     {
         float size = std::max( 0.1f, *point->size() );
-        stateset->setAttributeAndModes(new osg::Point(size), 1);
+        GLUtils::setPointSize(stateset, size, 1);
     }
 }


### PR DESCRIPTION
Tested on OSG 3.4 with compatibility profile GL support and everything still works with point features.  Tested on OSG 3.6 with core profile GL support and although point size is still not respected, at least there is no more continuous error spam from unsupported osg::Point or GL_POINT_SMOOTH (a mode that is supported by osg::Point)