### PR TITLE
Disable cancellation from mp

### DIFF
--- a/src/osgEarthDrivers/engine_mp/TilePagedLOD.cpp
+++ b/src/osgEarthDrivers/engine_mp/TilePagedLOD.cpp
@@ -117,12 +117,14 @@ _debug    ( false )
 {
     if ( live )
     {
-        _progress = new MyProgressCallback();
-        _progress->_frameOfLastCull = 0;
-        _progress->_tiles = live;
-        osgDB::Options* options = Registry::instance()->cloneOrCreateOptions();
-        options->setUserData( _progress.get() );
-        setDatabaseOptions( options );
+// Disable cancellation from MP to temporarily prevent elevation dropout
+        
+//        _progress = new MyProgressCallback();
+//        _progress->_frameOfLastCull = 0;
+//        _progress->_tiles = live;
+//        osgDB::Options* options = Registry::instance()->cloneOrCreateOptions();
+//        options->setUserData( _progress.get() );
+//        setDatabaseOptions( options );
     }
 }
 


### PR DESCRIPTION
Disable cancellation from mp to prevent flat elevation tiles.  Perhaps better to limit it to projected maps?