### PR TITLE
Update Qt OpenGL context to use the version of OpenGL requested via the Qt graphics context setup.

### DIFF
--- a/src/osgEarthQt/ViewerWidget.cpp
+++ b/src/osgEarthQt/ViewerWidget.cpp
@@ -151,6 +151,15 @@ void ViewerWidget::reconfigure( osgViewer::View* view )
         traits->inheritedWindowData = new osgQt::GraphicsWindowQt::WindowData(this);
 
         _gc = new osgQt::GraphicsWindowQt( traits.get() );
+
+        // Update Qt OpenGL context to use the version of OpenGL requested 
+        // via the Qt graphics context setup.
+        unsigned int major, minor;
+        traits->getContextVersion(major, minor);
+        QGLFormat newFormat(format());
+        newFormat.setVersion(major, minor);
+        setFormat(newFormat);
+        makeCurrent();
     }
 
     // reconfigure this view's camera to use the Qt GC if necessary.


### PR DESCRIPTION
I am using ViewerWidget to display osgEarth content on Linux using an Intel GPU with Core Profile (GPU supports OpenGL 4.5).

I have set the context version using:
osg::DisplaySettings::instance()->setGLContextVersion("4.5");

However this was not being honored when the ViewerWidget was created, thus resulting in a non Core Profile OpenGL context being created by Qt. The result was a bunch of GLSL compile errors.

This update sets the OpenGL version that Qt is to use. This results in the earth being visible.