### PR TITLE
nullptr test added for the drawable parameter on entry to PrimitiveItersector::intersect

### DIFF
--- a/src/osgEarth/PrimitiveIntersector.cpp
+++ b/src/osgEarth/PrimitiveIntersector.cpp
@@ -441,7 +441,7 @@ void PrimitiveIntersector::leave()
 
 void PrimitiveIntersector::intersect(osgUtil::IntersectionVisitor& iv, osg::Drawable* drawable)
 {
-    if (reachedLimit() && !drawable) return;
+    if (reachedLimit() || !drawable) return;
 
     osg::BoundingBox bb = Utils::getBoundingBox(drawable);
 

--- a/src/osgEarth/PrimitiveIntersector.cpp
+++ b/src/osgEarth/PrimitiveIntersector.cpp
@@ -441,7 +441,7 @@ void PrimitiveIntersector::leave()
 
 void PrimitiveIntersector::intersect(osgUtil::IntersectionVisitor& iv, osg::Drawable* drawable)
 {
-    if (reachedLimit()) return;
+    if (reachedLimit() && !drawable) return;
 
     osg::BoundingBox bb = Utils::getBoundingBox(drawable);
 


### PR DESCRIPTION
This was discovered when using old style picking. Occasionally drawable would be null.