### PR TITLE
Earth Rewriter: Folder now based on absolute path instead of findData…

### DIFF
--- a/src/osgEarthDrivers/earth/EarthFileSerializer2.cpp
+++ b/src/osgEarthDrivers/earth/EarthFileSerializer2.cpp
@@ -180,7 +180,7 @@ namespace
         {
             _rewriteAbsolutePaths = false;
             _newReferrerAbsPath = osgDB::convertFileNameToUnixStyle( osgDB::getRealPath(referrer) );
-            _newReferrerFolder  = osgDB::getFilePath( osgDB::findDataFile(_newReferrerAbsPath) );
+            _newReferrerFolder  = osgDB::getFilePath( _newReferrerAbsPath );
         }
 
         /** Whether to make absolute paths into relative paths if possible */


### PR DESCRIPTION
…File(), which can return empty string if file not found.  Supports stream-based loading and saving of Earth files instead of file-based.