### PR TITLE
GeometryClamper: g++ 4.4 build error fix.

### DIFF
--- a/src/osgEarth/GeometryClamper
+++ b/src/osgEarth/GeometryClamper
@@ -40,7 +40,7 @@ namespace osgEarth
         class GeometryData {
             osg::ref_ptr<osg::Vec3Array> _verts;
             osg::ref_ptr<osg::FloatArray> _altitudes;
-            friend GeometryClamper;
+            friend class GeometryClamper;
         };
 
         typedef std::map<osg::Array*, GeometryData> LocalData;      


### PR DESCRIPTION
Tested on g++ 4.4, g++ 4.7, and MSVC 2015