### PR TITLE
LGN: Render symbology now applies correctly on setStyle().  Fixed GL …

### DIFF
--- a/src/osgEarthAnnotation/LocalGeometryNode.cpp
+++ b/src/osgEarthAnnotation/LocalGeometryNode.cpp
@@ -111,6 +111,10 @@ LocalGeometryNode::compileGeometry()
 
             // re-assess support for per vertex clamping
             togglePerVertexClamping();
+
+            // apply current style
+            setDefaultLighting( getStyle().has<ExtrusionSymbol>() );
+            applyRenderSymbology( getStyle() );
         }
     }
 }

--- a/src/osgEarthFeatures/ExtrudeGeometryFilter.cpp
+++ b/src/osgEarthFeatures/ExtrudeGeometryFilter.cpp
@@ -1268,8 +1268,10 @@ ExtrudeGeometryFilter::push( FeatureList& input, FilterContext& context )
     {
         osg::StateSet* groupStateSet = group->getOrCreateStateSet();
         groupStateSet->setAttributeAndModes( new osg::PolygonOffset(1,1), 1 );
+#ifdef OSG_GL_FIXED_FUNCTION_AVAILABLE
         if ( _outlineSymbol->stroke()->width().isSet() )
             groupStateSet->setAttributeAndModes( new osg::LineWidth(*_outlineSymbol->stroke()->width()), 1 );
+#endif
     }
 
     return group;


### PR DESCRIPTION
…Core Profile line width spam for extruded symbols.