### PR TITLE
Triton Shaders: Add ocean alpha; add support for older GLSL.

### DIFF
--- a/src/osgEarthTriton/Shaders/user-functions.glsl
+++ b/src/osgEarthTriton/Shaders/user-functions.glsl
@@ -70,11 +70,18 @@ void user_diffuse_color( inout vec3 Cdiffuse, in vec3 CiNoLight, in vec3 Cwash, 
 
 }
 
+#if __VERSION__ > 140
 in float oe_LogDepth_logz;
+#else
+varying float oe_LogDepth_logz;
+#endif
+uniform float oe_ocean_alpha;
 
 // Output to MRT
 void writeFragmentData(in vec4 finalColor, in vec4 Cdiffuse, in vec3 lightColor, in vec3 nNorm )
 {
+    // Modify the final alpha with the value of the oe_ocean_alpha uniform.
+    finalColor.a = finalColor.a * oe_ocean_alpha;
     gl_FragDepth = oe_LogDepth_logz >= 0? oe_LogDepth_logz : gl_FragCoord.z;
     
 #ifdef OPENGL32

--- a/src/osgEarthTriton/Shaders/user-vert-functions.glsl
+++ b/src/osgEarthTriton/Shaders/user-vert-functions.glsl
@@ -27,7 +27,11 @@ void user_intercept(in vec3 worldPosition, in vec3 localPosition, in vec4 eyePos
 
 }
 
+#if __VERSION__ > 140
 out float oe_LogDepth_logz;
+#else
+varying float oe_LogDepth_logz;
+#endif
 uniform mat4 trit_projection;
 
 // Provides a point to override the final value of gl_Position.


### PR DESCRIPTION
Note that this requires https://github.com/gwaldron/osgearth/pull/1185 or the ocean will show up transparent in Triton 4.x, due to default uniform value of 1.0.