### PR TITLE
Debug Layer: Fix glyph display for GL_RED and GL_LUMINANCE fonts.

### DIFF
--- a/src/osgEarthDrivers/debug/DebugTileSource.cpp
+++ b/src/osgEarthDrivers/debug/DebugTileSource.cpp
@@ -55,8 +55,21 @@ namespace
             for( int src_s=0, dst_s=dx; src_s < src->s(); src_s++, dst_s++ )
             {           
                 osg::Vec4 color = read(src_s, src_t);
-                if ( color.a() > 0.5f )
-                    color = newColor;
+
+                // GL_RED images through read() will be (c,c,c,1.0), with alpha never set
+                if ( src->getInternalTextureFormat() == GL_RED || src->getInternalTextureFormat() == GL_LUMINANCE )
+                {
+                    if ( color.r() <= 0.5f )
+                        continue;
+                }
+                else
+                {
+                    if ( color.a() <= 0.5f )
+                        continue;
+                }
+
+                // Only write non-transparent colors
+                color = newColor;
                 write( color, dst_s, dst_t );
             }
         }


### PR DESCRIPTION
Using the default global "default font", the debug layer works good.  But if you replace the global font with one that returns glyphs that are `GL_RED`, the debug layer driver will break.

This change detects `GL_RED` and `GL_LUMINANCE` images (since `ImageUtils` treats them the same), and treats the red value as the image's transparency value.  Instead of writing a supposed-to-be-transparent pixel to the output image, nothing is written if alpha is under 0.5.  That prevents black backgrounds from showing up on the `GL_RED` case.

I investigated `ImageUtils` changes but it looks correct.  For general purpose, its reader seems correct, setting the rgb components to r and setting the alpha to 1.0.  I think debug layer driver ought to be accounting for the difference instead.

Another option, not pursued here, is to detect `GL_RED`, then create a new color (i.e. `color = Vec4f(1.0, 1.0, 1.0, color.r())`).  That would forgo the `continue` calls.