### PR TITLE
Fix compilation error with Geos 3.7.0.

### DIFF
--- a/src/osgEarthSymbology/GEOS
+++ b/src/osgEarthSymbology/GEOS
@@ -47,7 +47,9 @@ namespace osgEarth { namespace Symbology
         void disposeGeometry(geos::geom::Geometry* input);
 
     protected:
-#if GEOS_VERSION_MAJOR >= 3 && GEOS_VERSION_MINOR >= 6
+#if GEOS_VERSION_MAJOR >= 3 && GEOS_VERSION_MINOR >= 7
+        geos::geom::GeometryFactory::Ptr _factory;
+#elif GEOS_VERSION_MAJOR == 3 && GEOS_VERSION_MINOR == 6
         geos::geom::GeometryFactory::unique_ptr _factory;
 #else
         geos::geom::GeometryFactory* _factory;


### PR DESCRIPTION
According to the 3.7.0 release notes, the C++ API changed, resulting in a compilation error:
osgearth/src/osgEarthSymbology/GEOS:51:38: error: ‘unique_ptr’ in ‘class geos::geom::GeometryFactory’ does not name a type.

Instead, use geos::geom::GeometryFactory::Ptr which should be compatible with Geos 3.6 as well.