### PR TITLE
Fix signed integer overflow when computing the threshold.

### DIFF
--- a/src/osgEarth/JsonUtils.cpp
+++ b/src/osgEarth/JsonUtils.cpp
@@ -2480,7 +2480,7 @@ Reader::decodeNumber( Token &token )
    bool isNegative = *current == '-';
    if ( isNegative )
       ++current;
-   Value::UInt threshold = (isNegative ? Value::UInt(-Value::minInt) 
+   Value::UInt threshold = (isNegative ? Value::UInt(Value::maxInt)
                                        : Value::maxUInt) / 10;
    Value::UInt value = 0;
    while ( current < token.end_ )


### PR DESCRIPTION
osgearth/src/osgEarth/JsonUtils.cpp:2483:54: warning: integer overflow in expression of type ‘osgEarth::Json::Value::Int’ {aka ‘int’} results in ‘-2147483648’ [-Woverflow]
    Value::UInt threshold = (isNegative ? Value::UInt(-Value::minInt)

For signed integers, -minInt = maxInt + 1.
This results in an overflow, which is undefined behaviour for signed integers.

Moreover, on most machines, the overflow would wrap around, resulting in the threshold being minInt for negative numbers.
Negative values would always be decoded as double.