### PR TITLE
Exposing planar reflections getter/setter to Ocean API

### DIFF
--- a/src/osgEarthTriton/TritonAPIWrapper
+++ b/src/osgEarthTriton/TritonAPIWrapper
@@ -102,6 +102,8 @@ namespace osgEarth { namespace Triton
         void SetGodRaysFade(float fadeAmount);
         float GetGodRaysFade() const;
 
+        void SetPlanarReflectionBlend(float blendPercent);
+        float GetPlanarReflectionBlend() const;
     public:
         Ocean(uintptr_t handle) : _handle(handle) { }
         uintptr_t _handle;

--- a/src/osgEarthTriton/TritonAPIWrapper.cpp
+++ b/src/osgEarthTriton/TritonAPIWrapper.cpp
@@ -108,6 +108,7 @@ SETGET(Ocean, Choppiness, float);
 SETGET_EXPLICIT(Ocean, EnableSpray, SprayEnabled, bool);
 SETGET_EXPLICIT(Ocean, EnableGodRays, GodRaysEnabled, bool);
 SETGET(Ocean, GodRaysFade, float);
+SETGET(Ocean, PlanarReflectionBlend, float);
 
 void Ocean::EnableWireframe(bool wireframe) { HANDLE->EnableWireframe(wireframe); }
 void Ocean::SetQuality(OceanQuality value) { HANDLE->SetQuality((::Triton::OceanQuality)value); }

--- a/src/osgEarthTriton/TritonContext
+++ b/src/osgEarthTriton/TritonContext
@@ -48,6 +48,9 @@ namespace osgEarth { namespace Triton
         /** Sets the spatial reference system of the map */
         void setSRS(const osgEarth::SpatialReference* srs);
 
+        /** */
+        void setPlanarReflectionBlend(float planarReflectionBlend);
+
         /** Sets the user callback */
         void setCallback(Callback* callback);
         Callback* getCallback() const { return _callback.get(); }
@@ -100,6 +103,7 @@ namespace osgEarth { namespace Triton
         Threading::Mutex _initMutex;
 
         osg::ref_ptr<const osgEarth::SpatialReference> _srs;
+        float _planarReflectionBlend;
 
         mutable ::Triton::ResourceLoader* _resourceLoader;
         mutable ::Triton::Environment*    _environment;

--- a/src/osgEarthTriton/TritonContext.cpp
+++ b/src/osgEarthTriton/TritonContext.cpp
@@ -57,6 +57,14 @@ TritonContext::setSRS(const osgEarth::SpatialReference* srs)
 }
 
 void
+TritonContext::setPlanarReflectionBlend(float planarReflectionBlend)
+{
+    _planarReflectionBlend = planarReflectionBlend;
+    if(_ocean)
+        _ocean->SetPlanarReflectionBlend(_planarReflectionBlend);
+}
+
+void
 TritonContext::setCallback(Callback* callback)
 {
     _callback = callback;
@@ -152,6 +160,8 @@ TritonContext::initialize(osg::RenderInfo& renderInfo)
                 _ocean = ::Triton::Ocean::Create(
                     _environment, 
                     ::Triton::JONSWAP );
+
+                _ocean->SetPlanarReflectionBlend(_planarReflectionBlend);
             }
 
             if ( _ocean )

--- a/src/osgEarthTriton/TritonDrawable
+++ b/src/osgEarthTriton/TritonDrawable
@@ -61,7 +61,7 @@ namespace osgEarth { namespace Triton
 
         void setPlanarReflectionMap(osg::Texture2D* map);
 
-        void setPlanarReflectionProjection(osg::RefMatrix* proj);
+        void setPlanarReflectionProjection(osg::ref_ptr<osg::RefMatrix> proj);
 
     protected:
         virtual ~TritonDrawable();

--- a/src/osgEarthTriton/TritonDrawable.cpp
+++ b/src/osgEarthTriton/TritonDrawable.cpp
@@ -72,7 +72,7 @@ TritonDrawable::setPlanarReflectionMap(osg::Texture2D* map)
 }
 
 void
-TritonDrawable::setPlanarReflectionProjection(osg::RefMatrix* proj)
+TritonDrawable::setPlanarReflectionProjection(const osg::ref_ptr<osg::RefMatrix> proj)
 {
     _planarReflectionProjection = proj;
 }

--- a/src/osgEarthTriton/TritonNode
+++ b/src/osgEarthTriton/TritonNode
@@ -60,6 +60,10 @@ namespace osgEarth { namespace Triton
         void onSetSeaLevel();
 
         void onSetAlpha();
+		
+        virtual void onSetPlanarReflectionMap();
+
+        virtual void onSetPlanarReflectionProjection();
 
     public: // osg::Node
 

--- a/src/osgEarthTriton/TritonNode
+++ b/src/osgEarthTriton/TritonNode
@@ -65,6 +65,8 @@ namespace osgEarth { namespace Triton
 
         virtual void onSetPlanarReflectionProjection();
 
+        virtual void onSetPlanarReflectionBlend();
+
     public: // osg::Node
 
         osg::BoundingSphere computeBound() const;

--- a/src/osgEarthTriton/TritonNode.cpp
+++ b/src/osgEarthTriton/TritonNode.cpp
@@ -110,7 +110,7 @@ TritonNode::create()
         _TRITON->setCallback( _callback.get() );
 
     // Set planar reflection value.
-    _TRITON->getOcean()->SetPlanarReflectionBlend(getPlanarReflectionBlend());
+    _TRITON->setPlanarReflectionBlend(getPlanarReflectionBlend());
 
     TritonDrawable* drawable = new TritonDrawable(_TRITON.get());
     _drawable = drawable;
@@ -188,7 +188,7 @@ TritonNode::onSetPlanarReflectionProjection()
 void
 TritonNode::onSetPlanarReflectionBlend()
 {
-    _TRITON->getOcean()->SetPlanarReflectionBlend(getPlanarReflectionBlend());
+    _TRITON->setPlanarReflectionBlend(getPlanarReflectionBlend());
 }
 
 osg::BoundingSphere

--- a/src/osgEarthTriton/TritonNode.cpp
+++ b/src/osgEarthTriton/TritonNode.cpp
@@ -115,6 +115,8 @@ TritonNode::create()
     _alphaUniform->set(getAlpha());
     _drawable->setNodeMask( TRITON_OCEAN_MASK );
     drawable->setMaskLayer(_maskLayer.get());
+    drawable->setPlanarReflectionMap(getPlanarReflectionMap());
+    drawable->setPlanarReflectionProjection(getPlanarReflectionProjection());
     this->addChild(_drawable);
 
     OE_INFO << LC << "TritonNode created" << std::endl;
@@ -166,6 +168,18 @@ void
 TritonNode::onSetAlpha()
 {
     _alphaUniform->set(getAlpha());
+}
+
+void
+TritonNode::onSetPlanarReflectionMap()
+{
+    static_cast<TritonDrawable*>(_drawable)->setPlanarReflectionMap(getPlanarReflectionMap());
+}
+
+void
+TritonNode::onSetPlanarReflectionProjection()
+{
+    static_cast<TritonDrawable*>(_drawable)->setPlanarReflectionProjection(getPlanarReflectionProjection());
 }
 
 osg::BoundingSphere

--- a/src/osgEarthTriton/TritonNode.cpp
+++ b/src/osgEarthTriton/TritonNode.cpp
@@ -109,6 +109,9 @@ TritonNode::create()
     if ( _callback.valid() )
         _TRITON->setCallback( _callback.get() );
 
+    // Set planar reflection value.
+    _TRITON->getOcean()->SetPlanarReflectionBlend(getPlanarReflectionBlend());
+
     TritonDrawable* drawable = new TritonDrawable(_TRITON.get());
     _drawable = drawable;
     _alphaUniform = getOrCreateStateSet()->getOrCreateUniform("oe_ocean_alpha", osg::Uniform::FLOAT);
@@ -180,6 +183,12 @@ void
 TritonNode::onSetPlanarReflectionProjection()
 {
     static_cast<TritonDrawable*>(_drawable)->setPlanarReflectionProjection(getPlanarReflectionProjection());
+}
+
+void
+TritonNode::onSetPlanarReflectionBlend()
+{
+    _TRITON->getOcean()->SetPlanarReflectionBlend(getPlanarReflectionBlend());
 }
 
 osg::BoundingSphere

--- a/src/osgEarthUtil/Ocean
+++ b/src/osgEarthUtil/Ocean
@@ -109,6 +109,10 @@ namespace osgEarth { namespace Util
         void setPlanarReflectionProjection(const osg::ref_ptr<osg::RefMatrix> planarReflectionProjection);
         osg::ref_ptr<osg::RefMatrix> getPlanarReflectionProjection() const { return _planarReflectionProjection; }
 
+        /** Sets the prominence of planar reflections on this ocean surface, if one was set using Ocean::setPlanarReflectionMap */
+        void setPlanarReflectionBlend(float blendPercent);
+        float getPlanarReflectionBlend() const { return _planarReflectionBlend; }
+
     public: // osg::Group
 
         virtual void traverse(osg::NodeVisitor&);
@@ -122,7 +126,8 @@ namespace osgEarth { namespace Util
         virtual void onSetPlanarReflectionMap() { }
 
         virtual void onSetPlanarReflectionProjection() { }
-
+		
+        virtual void onSetPlanarReflectionBlend() { }
     private:
 
         float _seaLevel;
@@ -130,6 +135,7 @@ namespace osgEarth { namespace Util
 
         osg::ref_ptr<osg::Texture2D> _planarReflectionMap;
         osg::ref_ptr<osg::RefMatrix> _planarReflectionProjection;
+        float _planarReflectionBlend;
 
         osg::ref_ptr<const SpatialReference> _srs;
         const OceanOptions _options;

--- a/src/osgEarthUtil/Ocean
+++ b/src/osgEarthUtil/Ocean
@@ -28,6 +28,7 @@
 #include <osgEarth/SpatialReference>
 #include <osgEarth/Profile>
 #include <osg/Group>
+#include <osg/Texture2D>
 #include <osg/View>
 #include <osgDB/ReaderWriter>
 
@@ -99,8 +100,14 @@ namespace osgEarth { namespace Util
         /** Sets the alpha of the ocean */
         void setAlpha(float alpha);
         float getAlpha() const { return _alpha; }
-
-
+		
+        /** Sets the reflection map to use */
+        void setPlanarReflectionMap(const osg::ref_ptr<osg::Texture2D> planarReflectionMap);
+        osg::ref_ptr<osg::Texture2D> getPlanarReflectionMap() const { return _planarReflectionMap; }
+		
+        /** Sets the projection matrix used to render the reflection map on the water */
+        void setPlanarReflectionProjection(const osg::ref_ptr<osg::RefMatrix> planarReflectionProjection);
+        osg::ref_ptr<osg::RefMatrix> getPlanarReflectionProjection() const { return _planarReflectionProjection; }
 
     public: // osg::Group
 
@@ -112,10 +119,17 @@ namespace osgEarth { namespace Util
 
         virtual void onSetAlpha() { }
 
+        virtual void onSetPlanarReflectionMap() { }
+
+        virtual void onSetPlanarReflectionProjection() { }
+
     private:
 
         float _seaLevel;
         float _alpha;
+
+        osg::ref_ptr<osg::Texture2D> _planarReflectionMap;
+        osg::ref_ptr<osg::RefMatrix> _planarReflectionProjection;
 
         osg::ref_ptr<const SpatialReference> _srs;
         const OceanOptions _options;

--- a/src/osgEarthUtil/Ocean.cpp
+++ b/src/osgEarthUtil/Ocean.cpp
@@ -109,6 +109,13 @@ OceanNode::setPlanarReflectionProjection(const osg::ref_ptr<osg::RefMatrix> plan
 }
 
 void
+OceanNode::setPlanarReflectionBlend(float blendPercent)
+{
+    _planarReflectionBlend = blendPercent;
+    onSetPlanarReflectionBlend();
+}
+
+void
 OceanNode::traverse(osg::NodeVisitor& nv)
 {
     if ( nv.getVisitorType() == nv.CULL_VISITOR && _srs.valid() )

--- a/src/osgEarthUtil/Ocean.cpp
+++ b/src/osgEarthUtil/Ocean.cpp
@@ -67,7 +67,9 @@ OceanOptions::getConfig() const
 OceanNode::OceanNode(const OceanOptions& options) :
 _options ( options ),
 _seaLevel( 0.0f ),
-_alpha( 1.0f )
+_alpha( 1.0f ),
+_planarReflectionMap(0),
+_planarReflectionProjection(0)
 {
     //NOP
 }
@@ -89,6 +91,21 @@ OceanNode::setAlpha(float value)
 {
     _alpha = value;
     onSetAlpha();
+}
+
+
+void
+OceanNode::setPlanarReflectionMap(const osg::ref_ptr<osg::Texture2D> planarReflectionMap)
+{
+    _planarReflectionMap = planarReflectionMap;
+    onSetPlanarReflectionMap();
+}
+
+void
+OceanNode::setPlanarReflectionProjection(const osg::ref_ptr<osg::RefMatrix> planarReflectionProjection)
+{
+    _planarReflectionProjection = planarReflectionProjection;
+    onSetPlanarReflectionProjection();
 }
 
 void


### PR DESCRIPTION
Adding functions to get/set planar reflection map on Ocean.
* setPlanarReflectionMap
* getPlanarReflectionMap
* setPlanarReflectionProjection
* getPlanarReflectionProjection
* setPlanarReflectionBlend
* getPlanarReflectionBlend

Functions binded and implemented in osgEarthTriton plugin.