### PR TITLE
fix bug:the program crash when _db.size()==0

### DIFF
--- a/src/osgEarth/VirtualProgram.cpp
+++ b/src/osgEarth/VirtualProgram.cpp
@@ -136,7 +136,7 @@ ProgramRepo::use(const ProgramKey& key, unsigned frameNumber, UID user)
 void
 ProgramRepo::release(UID user, osg::State* state)
 {
-    if (!user)
+    if (!user || _db.size()==0)
         return;
 
     for(ProgramMap::iterator i = _db.begin(); i != _db.end(); )


### PR DESCRIPTION
Sometimes, closing the program and releasing resources will crash.


    ucrtbased.dll!00007ffe542797dc()	Unknown
 	ucrtbased.dll!00007ffe54279727()	Unknown
	osgEarthd.dll!std::_Tree_const_iterator<std::_Tree_val<std::_Tree_simple_types<std::pair<std::vector<osgEarth::PolyShader *,std::allocator<osgEarth::PolyShader *> > const ,osg::ref_ptr<osgEarth::ProgramRepo::Entry> > > > >::operator*() Line 221	C++
 	osgEarthd.dll!std::_Tree_iterator<std::_Tree_val<std::_Tree_simple_types<std::pair<std::vector<osgEarth::PolyShader *,std::allocator<osgEarth::PolyShader *> > const ,osg::ref_ptr<osgEarth::ProgramRepo::Entry> > > > >::operator*() Line 333	C++
 	osgEarthd.dll!std::_Tree_iterator<std::_Tree_val<std::_Tree_simple_types<std::pair<std::vector<osgEarth::PolyShader *,std::allocator<osgEarth::PolyShader *> > const ,osg::ref_ptr<osgEarth::ProgramRepo::Entry> > > > >::operator->() Line 337	C++
 	osgEarthd.dll!osgEarth::ProgramRepo::release(int user, osg::State * state) Line 144	C++
 	osgEarthd.dll!osgEarth::VirtualProgram::releaseGLObjects(osg::State * state) Line 1255	C++
 	osgEarthd.dll!osgEarth::StateSetCache::prune() Line 409	C++
 	osgEarthd.dll!osgEarth::StateSetCache::~StateSetCache() Line 214	C++
 	osgEarthd.dll!osgEarth::StateSetCache::`vector deleting destructor'(unsigned int)	C++
 	osg158-osgd.dll!osg::Referenced::signalObserversAndDelete(bool signalDelete, bool doDelete) Line 292	C++
 	osg158-osgd.dll!osg::Referenced::unref() Line 194	C++
 	osgEarthd.dll!osg::ref_ptr<osgEarth::StateSetCache>::~ref_ptr<osgEarth::StateSetCache>() Line 41	C++
 	osgEarthd.dll!osgEarth::Registry::~Registry() Line 174	C++
 	osgEarthd.dll!osgEarth::Registry::`vector deleting destructor'(unsigned int)	C++
 	osg158-osgd.dll!osg::Referenced::signalObserversAndDelete(bool signalDelete, bool doDelete) Line 292	C++
 	osg158-osgd.dll!osg::Referenced::unref() Line 194	C++
 	osgEarthd.dll!osg::ref_ptr<osgEarth::Registry>::~ref_ptr<osgEarth::Registry>() Line 41	C++
 	osgEarthd.dll!`osgEarth::Registry::instance'::`2'::`dynamic atexit destructor for 's_registry''()	C++
 	ucrtbased.dll!00007ffe54282d07()	Unknown
 	ucrtbased.dll!00007ffe542826d5()	Unknown
 	ucrtbased.dll!00007ffe542827da()	Unknown
 	ucrtbased.dll!00007ffe54282f11()	Unknown
 	osgEarthd.dll!__scrt_dllmain_uninitialize_c() Line 400	C++
 	osgEarthd.dll!dllmain_crt_process_detach(const bool is_terminating) Line 108	C++
 	osgEarthd.dll!dllmain_crt_dispatch(HINSTANCE__ * const instance, const unsigned long reason, void * const reserved) Line 139	C++
 	osgEarthd.dll!dllmain_dispatch(HINSTANCE__ * const instance, const unsigned long reason, void * const reserved) Line 212	C++
 	osgEarthd.dll!_DllMainCRTStartup(HINSTANCE__ * const instance, const unsigned long reason, void * const reserved) Line 254	C++
