### PR TITLE
MGRS: X and Y edge labels can now be styled.  Fixed crash bug in UpdateLabelStyles on label iteration.

### DIFF
--- a/src/osgEarthUtil/GraticuleLabelingEngine
+++ b/src/osgEarthUtil/GraticuleLabelingEngine
@@ -49,6 +49,9 @@ namespace osgEarth { namespace Util
         //! Set the labeling style for all labels
         void setStyle(const Style& style);
 
+        //! Set the labeling style for X and Y labels separately
+        void setStyles(const Style& xStyle, const Style& yStyle);
+
     public: // osg::Node
         void traverse(osg::NodeVisitor& nv);
 
@@ -82,9 +85,10 @@ namespace osgEarth { namespace Util
         };
 
         struct UpdateLabelStyles : public CameraDataMap::Functor {
-            UpdateLabelStyles(const Style& style) : _style(&style) { }
+            UpdateLabelStyles(const Style& xStyle, const Style& yStyle) : _xStyle(&xStyle), _yStyle(&yStyle) { }
             void operator()(CameraData& data);
-            const Style* _style;
+            const Style* _xStyle;
+            const Style* _yStyle;
         };
 
         osg::ref_ptr<const SpatialReference> _srs;

--- a/src/osgEarthUtil/GraticuleLabelingEngine.cpp
+++ b/src/osgEarthUtil/GraticuleLabelingEngine.cpp
@@ -94,24 +94,30 @@ GraticuleLabelingEngine::UpdateLabelStyles::operator()(GraticuleLabelingEngine::
         i != data.xLabels.end();
         ++i)
     {
-        i->get()->setStyle(*_style);
+        i->get()->setStyle(*_xStyle);
     }
 
-    for(GraticuleLabelingEngine::LabelNodeVector::iterator i = data.xLabels.begin();
+    for(GraticuleLabelingEngine::LabelNodeVector::iterator i = data.yLabels.begin();
         i != data.yLabels.end();
         ++i)
     {
-        i->get()->setStyle(*_style);
+        i->get()->setStyle(*_yStyle);
     }
 }
 
 void
 GraticuleLabelingEngine::setStyle(const Style& style)
 {
-    _xLabelStyle = style;
-    _yLabelStyle = style;
+    setStyles(style, style);
+}
 
-    UpdateLabelStyles update(style);
+void
+GraticuleLabelingEngine::setStyles(const Style& xStyle, const Style& yStyle)
+{
+    _xLabelStyle = xStyle;
+    _yLabelStyle = yStyle;
+
+    UpdateLabelStyles update(_xLabelStyle, _yLabelStyle);
     _cameraDataMap.forEach(update);
 }
 

--- a/src/osgEarthUtil/MGRSGraticule.cpp
+++ b/src/osgEarthUtil/MGRSGraticule.cpp
@@ -1115,6 +1115,12 @@ MGRSGraticule::rebuild()
         if (ss->getStyle("1", false)) maxRes = 1.0;
         labeler->setMaxResolution(maxRes);
 
+        // Set labeler styles
+        const Style* xEdgeStyle = ss->getStyle("xedge", false);
+        const Style* yEdgeStyle = ss->getStyle("yedge", false);
+        if (xEdgeStyle && yEdgeStyle)
+            labeler->setStyles(*xEdgeStyle, *yEdgeStyle);
+
         osg::ref_ptr<StateSetCache> sscache = new StateSetCache();
         sscache->optimize(geomTop);
         sscache->optimize(textTop);


### PR DESCRIPTION
The styles are named xedge and yedge.