### PR TITLE
Geodetic Graticule: Grid line visibility from Options is now respected.

### DIFF
--- a/src/osgEarthUtil/GeodeticGraticule.cpp
+++ b/src/osgEarthUtil/GeodeticGraticule.cpp
@@ -341,6 +341,7 @@ GeodeticGraticule::setMapNode(MapNode* mapNode)
 
         stateset->addUniform(new osg::Uniform(COLOR_UNIFORM, options().color().get()));
         stateset->addUniform(new osg::Uniform(WIDTH_UNIFORM, options().lineWidth().get()));
+        updateGridLineVisibility();
 
         _callback = new GraticuleTerrainCallback(this);
         mapNode->getTerrainEngine()->addCullCallback(_callback.get());


### PR DESCRIPTION
Without this, the define OE_DISABLE_GRATICULE is not configured properly.