### PR TITLE
Fix build with deprecated build flag

### DIFF
--- a/src/osgEarth/GeometryClamper.cpp
+++ b/src/osgEarth/GeometryClamper.cpp
@@ -172,7 +172,7 @@ GeometryClamper::apply(osg::Drawable& drawable)
         }
         else
         {
-#if ((OPENSCENEGRAPH_MAJOR_VERSION <= 3) && (OPENSCENEGRAPH_MINOR_VERSION < 6))
+#if OSG_VERSION_LESS_THAN(3,6,0)
             geom->dirtyDisplayList();
 #else
             geom->dirtyGLObjects();

--- a/src/osgEarth/GeometryClamper.cpp
+++ b/src/osgEarth/GeometryClamper.cpp
@@ -172,7 +172,11 @@ GeometryClamper::apply(osg::Drawable& drawable)
         }
         else
         {
+#if ((OPENSCENEGRAPH_MAJOR_VERSION <= 3) && (OPENSCENEGRAPH_MINOR_VERSION < 6))
             geom->dirtyDisplayList();
+#else
+            geom->dirtyGLObjects();
+#endif
         }
 
         OE_DEBUG << LC << "clamped " << count << " verts." << std::endl;

--- a/src/osgEarthUtil/ClampCallback.cpp
+++ b/src/osgEarthUtil/ClampCallback.cpp
@@ -101,7 +101,11 @@ bool ClampCallback::clampGeometry(osg::Geometry* geom, const osg::Matrixd& local
         }
     }
     geom->dirtyBound();
+#if ((OPENSCENEGRAPH_MAJOR_VERSION <= 3) && (OPENSCENEGRAPH_MINOR_VERSION < 6))
     geom->dirtyDisplayList();
+#else
+    geom->dirtyGLObjects();
+#endif
 
     return true;
 }

--- a/src/osgEarthUtil/ClampCallback.cpp
+++ b/src/osgEarthUtil/ClampCallback.cpp
@@ -101,7 +101,7 @@ bool ClampCallback::clampGeometry(osg::Geometry* geom, const osg::Matrixd& local
         }
     }
     geom->dirtyBound();
-#if ((OPENSCENEGRAPH_MAJOR_VERSION <= 3) && (OPENSCENEGRAPH_MINOR_VERSION < 6))
+#if OSG_VERSION_LESS_THAN(3,6,0)
     geom->dirtyDisplayList();
 #else
     geom->dirtyGLObjects();


### PR DESCRIPTION
Allow building with the OSG cmake flag, OSG_USE_DEPRECATED_API since osg::Geometry::dirtyDisplayLists is removed with this option enabled starting with OSG 3.6.0.