### PR TITLE
Serialization unit test and extension serialization fix

### DIFF
--- a/src/osgEarth/MapNode.cpp
+++ b/src/osgEarth/MapNode.cpp
@@ -452,16 +452,22 @@ MapNode::getConfig() const
         }
     }
 
+    Config ext = externalConfig();
+
     typedef std::vector< osg::ref_ptr<Extension> > Extensions;
     for(Extensions::const_iterator i = getExtensions().begin(); i != getExtensions().end(); ++i)
     {
         Extension* e = i->get();
-        Config conf = e->getConfigOptions().getConfig();
-        conf.key() = e->getConfigKey();
-        mapConf.add( conf );
+	// Don't write extensions more than once, and don't write extensions
+	// defined in external config.
+	if (!mapConf.hasChild(e->getName()) && !ext.hasChild(e->getName()))
+	{
+	    Config conf = e->getConfigOptions().getConfig();
+	    conf.key() = e->getConfigKey();
+	    mapConf.add( conf );
+	}
     }
 
-    Config ext = externalConfig();
     if ( !ext.empty() )
     {
         ext.key() = "external";

--- a/src/tests/osgEarth_tests/CMakeLists.txt
+++ b/src/tests/osgEarth_tests/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(TARGET_SRC
     GeoExtentTests.cpp
     FeatureTests.cpp
     ImageLayerTests.cpp
+    SerializerTests.cpp
     SpatialReferenceTests.cpp
     ThreadingTests.cpp
     )

--- a/src/tests/osgEarth_tests/SerializerTests.cpp
+++ b/src/tests/osgEarth_tests/SerializerTests.cpp
@@ -1,0 +1,59 @@
+#include <osgEarth/catch.hpp>
+
+#include <osgDB/Registry>
+
+#include <osgEarth/Registry>
+#include <osgEarth/MapNode>
+
+using namespace osgEarth;
+
+void readAndWrite(osgDB::ReaderWriter* readerwriter, std::string filename)
+{
+    SECTION(std::string("Deserialize and re-serialize: ") + filename) {
+
+	std::ifstream file(filename);
+	REQUIRE(file.is_open());
+
+	std::stringstream read_stream;
+	read_stream << file.rdbuf();
+	file.close();
+
+	osgDB::ReaderWriter::ReadResult rr = readerwriter->readNode(read_stream, nullptr);
+	REQUIRE(rr.success());
+
+	osg::ref_ptr<osg::Node> node = rr.getNode();
+	REQUIRE(node.valid());
+
+	osgEarth::MapNode* mapNode = osgEarth::MapNode::findMapNode( node );
+	REQUIRE(mapNode != nullptr);
+
+	std::stringstream write_stream;
+	osg::ref_ptr<osgDB::Options> opts = osgEarth::Registry::instance()->cloneOrCreateOptions(nullptr);
+	osgDB::ReaderWriter::WriteResult wr = readerwriter->writeNode(*mapNode, write_stream, opts.get());
+	REQUIRE(wr.success());
+
+#if 1   // Used to generate comparable input files for this test.
+	std::ofstream dbgfile;
+	dbgfile.open(std::string("/tmp/dbg_")+filename, std::ofstream::out );
+	if (dbgfile.is_open())
+	{
+	    dbgfile << write_stream.str();
+	}
+	dbgfile.close();
+#endif
+
+	// Check that the read input and output earth file from
+	// deserialization/re-serializarion are equal.
+	REQUIRE(read_stream.str() == write_stream.str());
+    }
+}
+
+TEST_CASE( "Serializing and deserializing Earth files" ) {
+
+    osgDB::ReaderWriter* readerwriter = osgDB::Registry::instance()->getReaderWriterForExtension("earth");
+    REQUIRE(readerwriter != nullptr);
+
+    readAndWrite(readerwriter, "../tests/serialized-simple.earth");
+    readAndWrite(readerwriter, "../tests/serialized-extension.earth");
+    readAndWrite(readerwriter, "../tests/serialized-external-extension.earth");
+}

--- a/tests/serialized-extension.earth
+++ b/tests/serialized-extension.earth
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<map>
+  <version>2</version>
+  <options />
+  <image>
+    <driver>gdal</driver>
+    <url>../data/world.tif</url>
+    <name>World GeoTIFF</name>
+  </image>
+  <lod_blending>
+    <duration>1</duration>
+    <blend_imagery>true</blend_imagery>
+    <blend_elevation>true</blend_elevation>
+  </lod_blending>
+</map>

--- a/tests/serialized-external-extension.earth
+++ b/tests/serialized-external-extension.earth
@@ -1,0 +1,17 @@
+<?xml version="1.0" ?>
+<map>
+  <version>2</version>
+  <options />
+  <image>
+    <driver>gdal</driver>
+    <url>../data/world.tif</url>
+    <name>World GeoTIFF</name>
+  </image>
+  <external>
+    <lod_blending>
+      <duration>1.0</duration>
+      <blend_imagery>true</blend_imagery>
+      <blend_elevation>true</blend_elevation>
+    </lod_blending>
+  </external>
+</map>

--- a/tests/serialized-simple.earth
+++ b/tests/serialized-simple.earth
@@ -1,0 +1,10 @@
+<?xml version="1.0" ?>
+<map>
+  <version>2</version>
+  <options />
+  <image>
+    <driver>gdal</driver>
+    <url>../data/world.tif</url>
+    <name>World GeoTIFF</name>
+  </image>
+</map>


### PR DESCRIPTION
Commit f2b811003 adds unit test for deserialization and re-serialization of earth files
    
Unit test demonstrates issue where extensions defined in "<external>" section is saved twice. For each load/save cycles the number of saved extension duplicates will accumulate.

Commit 6abf22297 fixes accumulation of extension duplicates when an extension is created in the '<external>' section of an earth file (as demonstrated in unit test).