### PR TITLE
Apply the diffuseFront color to the state; same as osg::Material::apply

### DIFF
--- a/src/osgEarth/Lighting.cpp
+++ b/src/osgEarth/Lighting.cpp
@@ -283,6 +283,8 @@ MaterialGL3::apply(osg::State& state) const
 {
 #ifdef OSG_GL_FIXED_FUNCTION_AVAILABLE
     osg::Material::apply(state);
+#else
+    state.Color(_diffuseFront.r(), _diffuseFront.g(), _diffuseFront.b(), _diffuseFront.a());
 #endif
 }
 


### PR DESCRIPTION
This line was missing and caused some weird color issues for models using Material only. The wrong previous color from other models "leaked" into neighboring models. Occurs when building with GLCORE profile.