### PR TITLE
Fix Config:: _refMap lost when doing Config::merge

### DIFF
--- a/src/osgEarth/Config.cpp
+++ b/src/osgEarth/Config.cpp
@@ -135,6 +135,10 @@ Config::merge( const Config& rhs )
     // add in the new values.
     for( ConfigSet::const_iterator c = rhs._children.begin(); c != rhs._children.end(); ++c )
         add( *c );
+    
+    // merge ref map
+    for( RefMap::const_iterator c = rhs._refMap.begin(); c != rhs._refMap.end(); ++c )
+        _refMap[c->first] = c->second;
 }
 
 const Config*


### PR DESCRIPTION
 `Config:: _refMap` is lost when doing `Config::merge`. I find this issue when running `osgearth_features` demo with `--mem` option. 
