### PR TITLE
Windows compile fix

### DIFF
--- a/src/osgEarth/LayerShader
+++ b/src/osgEarth/LayerShader
@@ -36,7 +36,7 @@ namespace osgEarth
 
     //! Serializable shader that supports samplers and uniforms
     //! in an earth file.
-    class ShaderOptions : public ConfigOptions
+    class OSGEARTH_EXPORT ShaderOptions : public ConfigOptions
     {
     public:
         META_ConfigOptions(osgEarth, ShaderOptions, ConfigOptions);


### PR DESCRIPTION
This patch is required to compile osgearth on Windows.