### PR TITLE
Add PLACEMENT_FIRSTVERTEX option for ModelSymbol on line geometries

### DIFF
--- a/docs/source/references/symbology.rst
+++ b/docs/source/references/symbology.rst
@@ -305,6 +305,8 @@ Like icons, models are typically used for:
 |                         |    :random:   Place models randomly within the geometry, according |
 |                         |               to the ``model-density`` property.                   |
 |                         |    :centroid: Place a single model at the centroid of the geometry.|
+|                         |    :first:    Place a single model at the first vertex of the      |
+|                         |               geometry.                                            |
 +-------------------------+--------------------------------------------------------------------+
 | model-density           | For ``model-placement`` settings of ``interval`` or ``random``,    |
 |                         | this property is hint as to how many instances osgEarth should     |

--- a/src/osgEarthFeatures/CMakeLists.txt
+++ b/src/osgEarthFeatures/CMakeLists.txt
@@ -35,6 +35,7 @@ SET(LIB_PUBLIC_HEADERS
     FeatureTileSource
     Filter
     FilterContext
+    FirstVertexFilter
     GeometryCompiler
     GeometryUtils
     LabelSource
@@ -77,6 +78,7 @@ SET(TARGET_SRC
     FeatureTileSource.cpp
     Filter.cpp
     FilterContext.cpp
+    FirstVertexFilter.cpp
     GeometryCompiler.cpp
     GeometryUtils.cpp
     LabelSource.cpp

--- a/src/osgEarthFeatures/FirstVertexFilter
+++ b/src/osgEarthFeatures/FirstVertexFilter
@@ -1,0 +1,46 @@
+/* -*-c++-*- */
+/* osgEarth - Dynamic map generation toolkit for OpenSceneGraph
+ * Copyright 2016 Pelican Mapping
+ * http://osgearth.org
+ *
+ * osgEarth is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#ifndef OSGEARTHFEATURES_FIRSTVERTEX_FILTER_H
+#define OSGEARTHFEATURES_FIRSTVERTEX_FILTER_H 1
+
+#include <osgEarthFeatures/Common>
+#include <osgEarthFeatures/Filter>
+
+namespace osgEarth { namespace Features
+{
+    using namespace osgEarth;
+    using namespace osgEarth::Symbology;
+
+    /**
+     * Replaces each feature's geometry with first vertex to be found
+     */
+    class OSGEARTHFEATURES_EXPORT FirstVertexFilter : public FeatureFilter
+    {
+    public:
+        FirstVertexFilter();
+        virtual ~FirstVertexFilter() { }
+
+    public:
+        virtual FilterContext push( FeatureList& input, FilterContext& context );
+    };
+
+} } // namespace osgEarth::Features
+
+#endif // OSGEARTHFEATURES_FIRSTVERTEX_FILTER_H

--- a/src/osgEarthFeatures/FirstVertexFilter.cpp
+++ b/src/osgEarthFeatures/FirstVertexFilter.cpp
@@ -1,0 +1,63 @@
+/* -*-c++-*- */
+/* osgEarth - Dynamic map generation toolkit for OpenSceneGraph
+ * Copyright 2016 Pelican Mapping
+ * http://osgearth.org
+ *
+ * osgEarth is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include <osgEarthFeatures/FirstVertexFilter>
+
+#define LC "[FirstVertexFilter] "
+
+using namespace osgEarth;
+using namespace osgEarth::Features;
+
+//------------------------------------------------------------------------
+
+FirstVertexFilter::FirstVertexFilter()
+{
+    //NOP
+}
+
+FilterContext
+FirstVertexFilter::push(FeatureList& features, FilterContext& context )
+{
+    for( FeatureList::iterator i = features.begin(); i != features.end(); ++i )
+    {
+        Feature* f = i->get();
+
+        Geometry* geom = f->getGeometry();
+        if ( !geom )
+            continue;
+
+        if ( geom )
+        {
+            switch( geom->getComponentType() )
+            {
+            case Geometry::TYPE_LINESTRING:
+                osgEarth::Symbology::LineString* line = (LineString*) geom;
+
+                PointSet* newGeom = new PointSet();
+                osg::Vec3dArray* arr = line->createVec3dArray();
+
+                newGeom->push_back(arr->at(1));
+                f->setGeometry( newGeom );
+                break;
+              }
+        }
+    }
+
+    return context;
+}

--- a/src/osgEarthFeatures/GeometryCompiler.cpp
+++ b/src/osgEarthFeatures/GeometryCompiler.cpp
@@ -21,6 +21,7 @@
 #include <osgEarthFeatures/BuildTextFilter>
 #include <osgEarthFeatures/AltitudeFilter>
 #include <osgEarthFeatures/CentroidFilter>
+#include <osgEarthFeatures/FirstVertexFilter>
 #include <osgEarthFeatures/ExtrudeGeometryFilter>
 #include <osgEarthFeatures/ScatterFilter>
 #include <osgEarthFeatures/SubstituteModelFilter>
@@ -407,6 +408,12 @@ GeometryCompiler::compile(FeatureList&          workingSet,
             CentroidFilter centroid;
             localCX = centroid.push( workingSet, localCX );
             if ( trackHistory ) history.push_back( "centroid" );
+        }
+        else if ( instance->placement() == InstanceSymbol::PLACEMENT_FIRSTVERTEX )
+        {
+            FirstVertexFilter fvfilter;
+            localCX = fvfilter.push( workingSet, localCX );
+            if ( trackHistory ) history.push_back( "first" );
         }
 
         if ( altRequired )

--- a/src/osgEarthSymbology/InstanceSymbol
+++ b/src/osgEarthSymbology/InstanceSymbol
@@ -52,6 +52,9 @@ namespace osgEarth { namespace Symbology
             /** Places one instance at the centroid of the feature. */
             PLACEMENT_CENTROID,
 
+            /** Places one instance at the first vertex of the feature. */
+            PLACEMENT_FIRSTVERTEX,
+
             /** Places instances at regular intervals within/along the feature geometry,
                 according to density. */
             PLACEMENT_INTERVAL,

--- a/src/osgEarthSymbology/InstanceSymbol.cpp
+++ b/src/osgEarthSymbology/InstanceSymbol.cpp
@@ -58,6 +58,7 @@ InstanceSymbol::getConfig() const
     conf.addIfSet   ( "placement", "interval",  _placement, PLACEMENT_INTERVAL );
     conf.addIfSet   ( "placement", "random",    _placement, PLACEMENT_RANDOM );
     conf.addIfSet   ( "placement", "centroid",  _placement, PLACEMENT_CENTROID );
+    conf.addIfSet   ( "placement", "first",     _placement, PLACEMENT_FIRSTVERTEX );
     conf.addIfSet   ( "density", _density );
     conf.addIfSet   ( "random_seed", _randomSeed );
 
@@ -79,6 +80,7 @@ InstanceSymbol::mergeConfig( const Config& conf )
     conf.getIfSet   ( "placement", "interval", _placement, PLACEMENT_INTERVAL );
     conf.getIfSet   ( "placement", "random",   _placement, PLACEMENT_RANDOM );
     conf.getIfSet   ( "placement", "centroid", _placement, PLACEMENT_CENTROID );
+    conf.getIfSet   ( "placement", "first",    _placement, PLACEMENT_FIRSTVERTEX );
     conf.getIfSet   ( "density", _density );
     conf.getIfSet   ( "random_seed", _randomSeed );
     

--- a/src/osgEarthSymbology/MarkerSymbol
+++ b/src/osgEarthSymbology/MarkerSymbol
@@ -46,6 +46,9 @@ namespace osgEarth { namespace Symbology
             /** Places one model instance at the centroid of the feature. */
             PLACEMENT_CENTROID,
 
+            /** Places one model instance at the centroid of the feature. */
+            PLACEMENT_FIRSTVERTEX,
+
             /** Places a model instance at each feature point. */
             PLACEMENT_VERTEX,
 

--- a/src/osgEarthSymbology/MarkerSymbol.cpp
+++ b/src/osgEarthSymbology/MarkerSymbol.cpp
@@ -263,6 +263,8 @@ MarkerSymbol::parseSLD(const Config& c, Style& style)
             style.getOrCreate<MarkerSymbol>()->placement() = MarkerSymbol::PLACEMENT_RANDOM;
         else if ( match(c.value(), "centroid") ) 
             style.getOrCreate<MarkerSymbol>()->placement() = MarkerSymbol::PLACEMENT_CENTROID;
+        else if ( match(c.value(), "first") )
+            style.getOrCreate<MarkerSymbol>()->placement() = MarkerSymbol::PLACEMENT_FIRSTVERTEX;
     }
     else if ( match(c.key(), "marker-density") ) {
         style.getOrCreate<MarkerSymbol>()->density() = as<float>(c.value(), 1.0f);

--- a/src/osgEarthSymbology/ModelSymbol.cpp
+++ b/src/osgEarthSymbology/ModelSymbol.cpp
@@ -135,6 +135,8 @@ ModelSymbol::parseSLD(const Config& c, Style& style)
             style.getOrCreate<ModelSymbol>()->placement() = ModelSymbol::PLACEMENT_RANDOM;
         else if ( match(c.value(), "centroid") ) 
             style.getOrCreate<ModelSymbol>()->placement() = ModelSymbol::PLACEMENT_CENTROID;
+        else if ( match(c.value(), "first") )
+            style.getOrCreate<ModelSymbol>()->placement() = ModelSymbol::PLACEMENT_FIRSTVERTEX;
     }
     else if ( match(c.key(), "model-density") ) {
         style.getOrCreate<ModelSymbol>()->density() = as<float>(c.value(), 1.0f);


### PR DESCRIPTION
Documentation added by Ralf Habacker.

We needed this for a project and want to share this. 
We are using the 2.8 branch, because the last stable branch 2.10 has issues with virtual box clients (GLES 3.3 required)