### PR TITLE
documentation typo fix in link to forum.osgearth.osg; 

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -129,7 +129,7 @@ Maintainers
 .. _@pelicanmapping:  https://twitter.com/pelicanmapping
 .. _Google+ Page:     https://plus.google.com/b/104014917856468748129/104014917856468748129/posts
 
-.. _support forum:    http://forum.osgearth.osg
+.. _support forum:    http://forum.osgearth.org
 .. _OSG Mailing List: http://lists.openscenegraph.org/listinfo.cgi/osg-users-openscenegraph.org
 .. _OSG Forum:        http://forum.openscenegraph.org
 .. _Contact us:       http://pelicanmapping.com/?page_id=2


### PR DESCRIPTION
there's not top level domain .osg (yet)

ps. The google+ page link under social media (pelicanmapping?) seems dead to me. As I can't find pelicanmapping on google+ I think it should be removed.
Regards, Laurens.