### PR TITLE
Activate viewpoints ui if the earth file was not loaded by the osgearth_viewer

### DIFF
--- a/src/osgEarthDrivers/viewpoints/ViewpointsExtension
+++ b/src/osgEarthDrivers/viewpoints/ViewpointsExtension
@@ -21,6 +21,7 @@
 
 #include <osgEarth/Extension>
 #include <osgEarth/Viewpoint>
+#include <osgEarth/MapNode>
 #include <osgEarthUtil/Controls>
 #include <osgGA/GUIEventAdapter>
 #include <osg/View>
@@ -38,6 +39,7 @@ namespace osgEarth { namespace Viewpoints
     class ViewpointsExtension : public Extension,
                                 public ExtensionInterface<osg::View>,
                                 public ExtensionInterface<Control>,
+                                public ExtensionInterface<MapNode>,
                                 public ConfigOptions
     {
     public:
@@ -71,6 +73,12 @@ namespace osgEarth { namespace Viewpoints
         bool connect(Control* control);
 
         bool disconnect(Control* control);
+
+    public: // ExtensionInterface<MapNode>
+
+        bool connect(MapNode *mapnode);
+
+        bool disconnect(MapNode *mapnode);
 
     private:
         osg::ref_ptr<const osgDB::Options>   _dbOptions;

--- a/src/osgEarthUtil/ExampleResources
+++ b/src/osgEarthUtil/ExampleResources
@@ -172,6 +172,22 @@ namespace osgEarth { namespace Util
         Control* create(MapNode* mapNode) const;
     };
 
+
+    /**
+     * Toggles the main control canvas on and off.
+     */
+    class OSGEARTHUTIL_EXPORT ToggleCanvasEventHandler : public osgGA::GUIEventHandler
+    {
+    public:
+        ToggleCanvasEventHandler(osg::Node* canvas, char key);
+
+        bool handle( const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& aa );
+
+    private:
+        osg::observer_ptr<osg::Node> _canvas;
+        char _key;
+    };
+
 } } // namespace osgEarth::Util
 
 

--- a/src/osgEarthUtil/ExampleResources.cpp
+++ b/src/osgEarthUtil/ExampleResources.cpp
@@ -102,37 +102,6 @@ namespace
         osg::observer_ptr<osg::Node> _node;
     };
 
-    /**
-     * Toggles the main control canvas on and off.
-     */
-    struct ToggleCanvasEventHandler : public osgGA::GUIEventHandler
-    {
-        ToggleCanvasEventHandler(osg::Node* canvas, char key) :
-            _canvas(canvas), _key(key)
-        {
-        }
-
-        bool handle( const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& aa )
-        {
-            if (ea.getEventType() == osgGA::GUIEventAdapter::KEYDOWN)
-            {
-                if (ea.getKey() == _key)
-                {
-                    osg::ref_ptr< osg::Node > safeNode = _canvas.get();
-                    if (safeNode.valid())
-                    {
-                        safeNode->setNodeMask( safeNode->getNodeMask() ? 0 : ~0 );
-                    }
-                    return true;
-                }
-            }
-            return false;
-        }
-
-        osg::observer_ptr<osg::Node> _canvas;
-        char _key;
-    };
-
     // sets a user-specified uniform.
     struct ApplyValueUniform : public ControlEventHandler
     {
@@ -883,4 +852,26 @@ OceanControlFactory::create(SimpleOceanLayer* ocean)
     }
 
     return grid;
+}
+
+ToggleCanvasEventHandler::ToggleCanvasEventHandler(osg::Node* canvas, char key) 
+: _canvas(canvas), _key(key)
+{
+}
+
+bool ToggleCanvasEventHandler::handle( const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapter& aa )
+{
+    if (ea.getEventType() == osgGA::GUIEventAdapter::KEYDOWN)
+    {
+        if (ea.getKey() == _key)
+        {
+            osg::ref_ptr< osg::Node > safeNode = _canvas.get();
+            if (safeNode.valid())
+            {
+                safeNode->setNodeMask( safeNode->getNodeMask() ? 0 : ~0 );
+            }
+            return true;
+        }
+    }
+    return false;
 }


### PR DESCRIPTION
If the Earth file is loaded with another viewer (e.g. osgviewer), the UI must be added so that the viewpoints can be used.