### PR TITLE
Triton: Turn off UBO if Mesa driver detected to prevent GL errors.

### DIFF
--- a/src/osgEarthTriton/TritonContext.cpp
+++ b/src/osgEarthTriton/TritonContext.cpp
@@ -20,6 +20,8 @@
 #include <osg/GLExtensions>
 #include <osg/Math>
 #include <osgDB/FileNameUtils>
+#include <osgEarth/Capabilities>
+#include <osgEarth/Registry>
 #include <osgEarth/SpatialReference>
 #include <cstdlib>
 
@@ -126,6 +128,13 @@ TritonContext::initialize(osg::RenderInfo& renderInfo)
 
             //_environment->SetConfigOption("avoid-opengl-stalls", "yes");
             //_environment->SetConfigOption("fft-texture-update-frame-delayed", "yes");
+
+            // Mesa drivers are unable to index variables in UBO prior to compilation
+            const std::string glRenderer = osgEarth::Registry::instance()->getCapabilities().getRenderer();
+            if (glRenderer.find("Mesa") != std::string::npos)
+            {
+                _environment->SetConfigOption( "use-uniform-buffer-objects", "no" );
+            }
 
             float openGLVersion = osg::getGLVersionNumber();
             enum ::Triton::Renderer tritonOpenGlVersion = ::Triton::OPENGL_2_0;


### PR DESCRIPTION
While testing on Linux, I'm getting a constant stream of errors on console when using Triton.  I traced it down to Unified Buffer Objects (UBO) using apitrace and MESA_DEBUG flag.  The UBO is on by default in latest Triton.config file (not sure about previous values).  Once I turned it off, the osgEarth and SIMDIS SDK Triton demos both worked well.

Note -- It might be advantageous to expose an interface to set individual Configuration settings both for Triton (and SilverLining for that matter) by creating a new field in TritonOptions.  I did not go that far with this approach.  I also did not attempt to fix this in Triton code directly because presumably eventually Mesa drivers might support UBO, and Triton already has a method for configuring this (Triton.config, Environment.SetConfigOption).

Testing was only done on Linux side with latest master of osgEarth and latest Triton.  Testing was done in osgearth_triton, example_ocean in SIMDIS SDK, and in SIMDIS itself.