### PR TITLE
Picking with cascaded draping needs 4 frames?

### DIFF
--- a/src/osgEarthUtil/RTTPicker.cpp
+++ b/src/osgEarthUtil/RTTPicker.cpp
@@ -460,7 +460,7 @@ RTTPicker::checkForPickResult(Pick& pick, unsigned frameNumber)
     // register a hit on draped/clamped geometry.
     bool pickExpired =
         hit == true ||
-        frameNumber - pick._frame >= 2u;
+        frameNumber - pick._frame >= 4u;
 
     if ((hit == false) && (pickExpired == true))
     {


### PR DESCRIPTION
Picking with cascaded draping doesn't work on first hit, because the picker hasn't enough frames?
I can't reproduce it after this fix. But is it correct?