### PR TITLE
static QString use tr()  will failed.

### DIFF
--- a/src/osgEarthQt/LayerManagerWidget.cpp
+++ b/src/osgEarthQt/LayerManagerWidget.cpp
@@ -197,7 +197,7 @@ namespace osgEarth { namespace QtGui
 
 
 //---------------------------------------------------------------------------
-const QString LayerWidgetMimeData::MIME_TYPE = tr("application/LayerWidgetMimeData");
+const QString LayerWidgetMimeData::MIME_TYPE = QT_TR_NOOP("application/LayerWidgetMimeData");
 
 
 //---------------------------------------------------------------------------

--- a/src/osgEarthQt/LayerManagerWidget.cpp
+++ b/src/osgEarthQt/LayerManagerWidget.cpp
@@ -197,7 +197,7 @@ namespace osgEarth { namespace QtGui
 
 
 //---------------------------------------------------------------------------
-const QString LayerWidgetMimeData::MIME_TYPE = QT_TR_NOOP("application/LayerWidgetMimeData");
+const QString LayerWidgetMimeData::MIME_TYPE = QT_TRANSLATE_NOOP("LayerWidgetMimeData","application/LayerWidgetMimeData");
 
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
BTW, it will crash , when i run applications/osgearth_qt_windows on Windows 10 with Qt 5.12.3 and debug version.
https://stackoverflow.com/questions/1486492/qt-tr-does-not-seem-to-work-on-static-constant-members