### PR TITLE
Some clang-tidy fixies

### DIFF
--- a/src/applications/osgearth_featureinfo/osgearth_featureinfo.cpp
+++ b/src/applications/osgearth_featureinfo/osgearth_featureinfo.cpp
@@ -50,7 +50,7 @@ void printStats(FeatureSource* features)
     std::cout << "Geometry Type:  " << osgEarth::Symbology::Geometry::toString( features->getGeometryType() ) << std::endl;
 
     //Print the schema
-    const FeatureSchema schema = features->getSchema();
+    const FeatureSchema& schema = features->getSchema();
     std::cout << "Schema:" << std::endl;
     for (FeatureSchema::const_iterator itr = schema.begin(); itr != schema.end(); ++itr)
     {

--- a/src/applications/osgearth_toc/osgearth_toc.cpp
+++ b/src/applications/osgearth_toc/osgearth_toc.cpp
@@ -419,7 +419,7 @@ addLayerItem( Grid* grid, int layerIndex, int numLayers, Layer* layer, bool isAc
 
     // layer type
     std::string typeName = typeid(*layer).name();
-    typeName = typeName.substr(typeName.find_last_of(":")+1);
+    typeName = typeName.substr(typeName.find_last_of(':')+1);
     LabelControl* typeLabel = new LabelControl(typeName, osg::Vec4(.5,.7,.5,1));
     grid->setControl( gridCol, gridRow, typeLabel );
     gridCol++;

--- a/src/osgEarth/HTTPClient.cpp
+++ b/src/osgEarth/HTTPClient.cpp
@@ -253,7 +253,7 @@ HTTPRequest::getURL() const
         buf << _url;
         for( Parameters::const_iterator i = _parameters.begin(); i != _parameters.end(); i++ )
         {
-            buf << ( i == _parameters.begin() && _url.find( "?" ) == std::string::npos? "?" : "&" );
+            buf << ( i == _parameters.begin() && _url.find( '?' ) == std::string::npos? "?" : "&" );
             buf << i->first << "=" << i->second;
         }
          std::string bufStr;
@@ -575,7 +575,7 @@ HTTPClient::readOptions(const osgDB::Options* options, std::string& proxy_host, 
         std::string opt;
         while( iss >> opt )
         {
-            int index = opt.find( "=" );
+            int index = opt.find( '=' );
             if( opt.substr( 0, index ) == "OSG_CURL_PROXY" )
             {
                 proxy_host = opt.substr( index+1 );
@@ -1412,7 +1412,7 @@ namespace
         if ( !reader )
         {
             // try to look up a reader by mime-type first:
-            std::string mimeType = response.getMimeType();
+            const std::string& mimeType = response.getMimeType();
             if ( !mimeType.empty() )
             {
                 reader = osgDB::Registry::instance()->getReaderWriterForMimeType(mimeType);

--- a/src/osgEarth/SpatialReference.cpp
+++ b/src/osgEarth/SpatialReference.cpp
@@ -240,7 +240,7 @@ SpatialReference::create(const Key& key)
         srs = createCube();
     }
 
-    else if (key.horizLower.find( "+" ) == 0 )
+    else if (key.horizLower.find( '+' ) == 0 )
     {
         srs = createFromPROJ4( key.horiz, key.horiz );
     }

--- a/src/osgEarth/XmlUtils.cpp
+++ b/src/osgEarth/XmlUtils.cpp
@@ -241,7 +241,7 @@ XmlElement::getConfig(const std::string& referrer) const
 
         URIContext uriContext(referrer);
         URI uri(href, uriContext);
-        std::string fullURI = uri.full();
+        const std::string& fullURI = uri.full();
         OE_INFO << "Loading href from " << fullURI << std::endl;
 
         osg::ref_ptr< XmlDocument > doc = XmlDocument::load(fullURI);

--- a/src/osgEarthDrivers/arcgis/MapService.cpp
+++ b/src/osgEarthDrivers/arcgis/MapService.cpp
@@ -140,7 +140,7 @@ bool
 MapService::init( const URI& _uri, const osgDB::ReaderWriter::Options* options )
 {
     uri = _uri;
-    std::string sep = uri.full().find( "?" ) == std::string::npos ? "?" : "&";
+    std::string sep = uri.full().find( '?' ) == std::string::npos ? "?" : "&";
     std::string json_url = uri.full() + sep + std::string("f=pjson");  // request the data in JSON format
 
     ReadResult r = URI(json_url).readString( options );

--- a/src/osgEarthDrivers/arcgis/ReaderWriterArcGIS.cpp
+++ b/src/osgEarthDrivers/arcgis/ReaderWriterArcGIS.cpp
@@ -104,7 +104,7 @@ public:
             std::string token = _options.token().value();
             if (!token.empty())
             {
-                std::string sep = url.full().find( "?" ) == std::string::npos ? "?" : "&";
+                std::string sep = url.full().find( '?' ) == std::string::npos ? "?" : "&";
                 url = url.append( sep + std::string("token=") + token );
             }
         }
@@ -120,7 +120,7 @@ public:
 			OE_DEBUG << LC << "_Layers: " << layers << std::endl;
 			if (!layers.empty())
 			{
-				std::string sep = url.full().find( "?" ) == std::string::npos ? "?" : "&";
+				std::string sep = url.full().find( '?' ) == std::string::npos ? "?" : "&";
 				url = url.append( sep + std::string("layers=show:") + layers );
 			}
 		}
@@ -215,7 +215,7 @@ public:
             {
                 std::string str;
                 str = buf.str();
-                std::string sep = str.find( "?" ) == std::string::npos ? "?" : "&";
+                std::string sep = str.find( '?' ) == std::string::npos ? "?" : "&";
                 buf << sep << "token=" << token;
             }
         }
@@ -228,7 +228,7 @@ public:
             {
                 std::string str;
                 str = buf.str();
-                std::string sep = str.find( "?" ) == std::string::npos ? "?" : "&";
+                std::string sep = str.find( '?' ) == std::string::npos ? "?" : "&";
 				buf << sep << "layers=show:" << layers;
             }
         }

--- a/src/osgEarthDrivers/bing/BingTileSource.cpp
+++ b/src/osgEarthDrivers/bing/BingTileSource.cpp
@@ -193,7 +193,7 @@ public:
                         OE_WARN << LC << "REST API request error!" << std::endl;
 
                         Config metadata;
-                        std::string content = metadataResult.getString();
+                        const std::string& content = metadataResult.getString();
                         metadata.fromJSON( content );
                         ConfigSet errors = metadata.child("errorDetails").children();
                         for(ConfigSet::const_iterator i = errors.begin(); i != errors.end(); ++i )
@@ -307,7 +307,7 @@ public:
                     OE_WARN << LC << "REST API request error!" << std::endl;
 
                     Config metadata;
-                    std::string content = result.getString();
+                    const std::string& content = result.getString();
                     OE_WARN << content << std::endl;
                     metadata.fromJSON(content);
                     ConfigSet errors = metadata.child("errorDetails").children();

--- a/src/osgEarthDrivers/earth/ReaderWriterOsgEarth.cpp
+++ b/src/osgEarthDrivers/earth/ReaderWriterOsgEarth.cpp
@@ -241,7 +241,7 @@ class ReaderWriterEarth : public osgDB::ReaderWriter
             if ( !conf.empty() )
             {
                 // see if we were given a reference URI to use:
-                std::string refURI = uriContext.referrer();
+                const std::string& refURI = uriContext.referrer();
 
                 if ( conf.value("version") == "1" )
                 {

--- a/src/osgEarthDrivers/engine_rex/SelectionInfo.cpp
+++ b/src/osgEarthDrivers/engine_rex/SelectionInfo.cpp
@@ -68,7 +68,7 @@ SelectionInfo::initialize(unsigned firstLod, unsigned maxLod, const Profile* pro
         unsigned tx, ty;
         profile->getNumTiles(lod, tx, ty);
         TileKey key(lod, tx/2, ty/2, profile);
-        GeoExtent e = key.getExtent();
+        const GeoExtent& e = key.getExtent();
         GeoCircle c = e.computeBoundingGeoCircle();
         double range = c.getRadius() * mtrf * 2.0 * (1.0/1.405);
         _lods[lod]._visibilityRange = range;

--- a/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp
+++ b/src/osgEarthDrivers/feature_ogr/FeatureCursorOGR.cpp
@@ -101,7 +101,7 @@ _filters          ( filters )
         // Quote the layer name if it is a shapefile, so we can handle any weird filenames like those with spaces or hyphens.
         // Or quote any layers containing spaces for PostgreSQL
         if (driverName == "ESRI Shapefile" || driverName == "VRT" ||
-            from.find(" ") != std::string::npos)
+            from.find(' ') != std::string::npos)
         {
             std::string delim = "\"";
             from = delim + from + delim;

--- a/src/osgEarthDrivers/feature_xyz/FeatureSourceXYZ.cpp
+++ b/src/osgEarthDrivers/feature_xyz/FeatureSourceXYZ.cpp
@@ -93,8 +93,8 @@ public:
 
           _template = _options.url()->full();
 
-          _rotateStart = _template.find("[");
-          _rotateEnd   = _template.find("]");
+          _rotateStart = _template.find('[');
+          _rotateEnd   = _template.find(']');
           if ( _rotateStart != std::string::npos && _rotateEnd != std::string::npos && _rotateEnd-_rotateStart > 1 )
           {
               _rotateString  = _template.substr(_rotateStart, _rotateEnd-_rotateStart+1);

--- a/src/osgEarthDrivers/gltf/tiny_gltf.h
+++ b/src/osgEarthDrivers/gltf/tiny_gltf.h
@@ -1381,8 +1381,8 @@ static std::string FindFile(const std::vector<std::string> &paths,
 }
 
 static std::string GetFilePathExtension(const std::string &FileName) {
-  if (FileName.find_last_of(".") != std::string::npos)
-    return FileName.substr(FileName.find_last_of(".") + 1);
+  if (FileName.find_last_of('.') != std::string::npos)
+    return FileName.substr(FileName.find_last_of('.') + 1);
   return "";
 }
 
@@ -4316,7 +4316,7 @@ static bool ValueToJson(const Value &value, json *ret) {
       break;
     case ARRAY_TYPE: {
       for (unsigned int i = 0; i < value.ArrayLen(); ++i) {
-        Value elementValue = value.Get(int(i));
+        const Value& elementValue = value.Get(int(i));
         json elementJson;
         if (ValueToJson(value.Get(int(i)), &elementJson))
           obj.push_back(elementJson);

--- a/src/osgEarthDrivers/template/ReaderWriterTemplate.cpp
+++ b/src/osgEarthDrivers/template/ReaderWriterTemplate.cpp
@@ -76,7 +76,7 @@ class TemplateReaderWriter: public osgDB::ReaderWriter
                 std::string opt;
                 while (iss >> opt) {
                     std::string optLower = osgDB::convertToLowerCase(opt);
-                    std::size_t eqInd = opt.find("=");
+                    std::size_t eqInd = opt.find('=');
                     std::string key = optLower.substr(0, eqInd);
                     std::string value = opt.substr(eqInd + 1);
                     t.set(key, value);

--- a/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
+++ b/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
@@ -300,7 +300,7 @@ public:
         std::string uri = createURI(key);
         if ( !extraAttrs.empty() )
         {
-            std::string delim = uri.find("?") == std::string::npos ? "?" : "&";
+            std::string delim = uri.find('?') == std::string::npos ? "?" : "&";
             uri = uri + delim + extraAttrs;
         }
 

--- a/src/osgEarthDrivers/xyz/ReaderWriterXYZ.cpp
+++ b/src/osgEarthDrivers/xyz/ReaderWriterXYZ.cpp
@@ -74,8 +74,8 @@ public:
 
           _template = xyzURI.full();
 
-          _rotateStart = _template.find("[");
-          _rotateEnd   = _template.find("]");
+          _rotateStart = _template.find('[');
+          _rotateEnd   = _template.find(']');
           if ( _rotateStart != std::string::npos && _rotateEnd != std::string::npos && _rotateEnd-_rotateStart > 1 )
           {
               _rotateString  = _template.substr(_rotateStart, _rotateEnd-_rotateStart+1);

--- a/src/osgEarthFeatures/Filter.cpp
+++ b/src/osgEarthFeatures/Filter.cpp
@@ -78,7 +78,7 @@ FeatureFilterRegistry::add( FeatureFilterFactory* factory )
 FeatureFilter*
 FeatureFilterRegistry::create(const Config& conf, const osgDB::Options* dbo)
 {
-    std::string driver = conf.key();
+    const std::string& driver = conf.key();
 
     osg::ref_ptr<FeatureFilter> result;
 

--- a/src/osgEarthSymbology/CssUtils.cpp
+++ b/src/osgEarthSymbology/CssUtils.cpp
@@ -55,7 +55,7 @@ CssUtils::readConfig( const std::string& css, const std::string& referrer, Confi
 
     // if there's no brackets, assume this is a single default block.
     std::string temp = css;
-    if ( css.find_first_of("{") == std::string::npos )
+    if ( css.find_first_of('{') == std::string::npos )
     {
         temp = "default { " + css + " }";
     }

--- a/src/osgEarthUtil/Controls.cpp
+++ b/src/osgEarthUtil/Controls.cpp
@@ -932,7 +932,7 @@ LabelControl::calcSize(const ControlContext& cx, osg::Vec2f& out_size)
         if ( cx._viewContextID != ~0u )
         {
             //the Text's autoTransformCache matrix puts some mojo on the bounding box
-            osg::Matrix m = t->getATMatrix( cx._viewContextID );
+            const osg::Matrix& m = t->getATMatrix( cx._viewContextID );
             _bmin = osg::Vec3( bbox.xMin(), bbox.yMin(), bbox.zMin() ) * m;
             _bmax = osg::Vec3( bbox.xMax(), bbox.yMax(), bbox.zMax() ) * m;
         }

--- a/src/osgEarthUtil/SimplePager.cpp
+++ b/src/osgEarthUtil/SimplePager.cpp
@@ -168,7 +168,7 @@ osg::BoundingSphere SimplePager::getBounds(const TileKey& key) const
 {
     int samples = 6;
 
-    GeoExtent extent = key.getExtent();
+    const GeoExtent& extent = key.getExtent();
 
     double xSample = extent.width() / (double)samples;
     double ySample = extent.height() / (double)samples;

--- a/src/osgEarthUtil/TFS.cpp
+++ b/src/osgEarthUtil/TFS.cpp
@@ -44,7 +44,7 @@ TFSReaderWriter::read(const URI& uri, const osgDB::ReaderWriter::Options *option
     osgEarth::ReadResult result = uri.readString(options);
     if (result.succeeded())
     {
-        std::string str = result.getString();
+        const std::string& str = result.getString();
         std::stringstream in( str.c_str()  );
         return read( in, layer);
     }    

--- a/src/osgEarthUtil/TFSPackager.cpp
+++ b/src/osgEarthUtil/TFSPackager.cpp
@@ -378,7 +378,7 @@ TFSPackager::package( FeatureSource* features, const std::string& destination, c
     for (int i = 0; i <= highestLevel; ++i)
     {
         TileKey tileKey(i, 0, 0, profile.get());
-        GeoExtent tileExtent = tileKey.getExtent();
+        const GeoExtent& tileExtent = tileKey.getExtent();
         OE_NOTICE << "Level " << i << " tile size: " << tileExtent.width() << std::endl;
     }
 #endif


### PR DESCRIPTION
1) Used single quotes for single character in string::find (more efficient)
2) Removed unnecessary copy initialization in some places