### PR TITLE
GLTF: Fix g++ 8.3 compile issue with extra qualification.

### DIFF
--- a/src/osgEarthDrivers/gltf/GLTFReader.h
+++ b/src/osgEarthDrivers/gltf/GLTFReader.h
@@ -67,7 +67,7 @@ public:
 public:
     mutable TextureCache* _texCache;
 
-    GLTFReader::GLTFReader() : _texCache(NULL)
+    GLTFReader() : _texCache(NULL)
     {
         //NOP
     }


### PR DESCRIPTION
Seeing this on g++ 8.3, but not on g++ 4.8.5.