### PR TITLE
HTTPClient: Store impl as ref_ptr to avoid copy constructor crash on …

### DIFF
--- a/src/osgEarth/HTTPClient
+++ b/src/osgEarth/HTTPClient
@@ -257,7 +257,7 @@ namespace osgEarth { namespace Util
     {
     public:
         //! Interface for pluggable HTTP implementations
-        class Implementation
+        class Implementation : public osg::Referenced
         {
         public:
             virtual void initialize() = 0;
@@ -275,6 +275,9 @@ namespace osgEarth { namespace Util
 
             //! Implementation-specific handle if applicable
             virtual void* getHandle() const { return NULL; }
+
+        protected:
+            virtual ~Implementation() {}
         };
 
         //! Factory object to create implementation instances.
@@ -457,7 +460,7 @@ namespace osgEarth { namespace Util
         bool        _initialized;
         long        _simResponseCode;
 
-        Implementation* _impl;
+        osg::ref_ptr<Implementation> _impl;
 
         void initialize() const;
         void initializeImpl();

--- a/src/osgEarth/HTTPClient.cpp
+++ b/src/osgEarth/HTTPClient.cpp
@@ -753,7 +753,7 @@ namespace
             }
 
             // read the file time:
-            response.setLastModified(getCurlFileTime( _curl_handle ));
+     response.setLastModified(getCurlFileTime( _curl_handle ));
 
             if (res == CURLE_OK)
             {
@@ -1358,8 +1358,6 @@ HTTPClient::initializeImpl()
 
 HTTPClient::~HTTPClient()
 {
-    if (_impl)
-        delete _impl;
 }
 
 void


### PR DESCRIPTION
…gcc.

The crash happens because PerThread stores `HTTPClient` in a `std::map`, and in older C++ standard without `emplace`, that causes a copy constructor.  The copy constructor for `HTTPClient` is not implemented, so you get a double delete on `_impl`.  This change makes it a `ref_ptr`, fixing the double delete issue.  This does not impact MSVC presumably because it uses the emplace automatically, moving without invoking copy constructor.