### PR TITLE
bugfix: incorrect WMS URI when using wrong locale

### DIFF
--- a/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
+++ b/src/osgEarthDrivers/wms/ReaderWriterWMS.cpp
@@ -430,9 +430,16 @@ public:
     {
         double minx, miny, maxx, maxy;
         key.getExtent().getBounds( minx, miny, maxx, maxy);
+	
+	// Convert numbers only in "C" locale (decimal point is dot)
+        // Store current numeric locale
+        char *cur_lc_numeric = setlocale(LC_NUMERIC, "C");
         
         char buf[2048];
         sprintf(buf, _prototype.c_str(), minx, miny, maxx, maxy);
+	
+        // Restore current numeric locale
+        setlocale(LC_NUMERIC, cur_lc_numeric);
         
         std::string uri(buf);
 


### PR DESCRIPTION
I have integrated the changes of podsvirov as discussed in https://github.com/gwaldron/osgearth/pull/835#issuecomment-567031484.

I have tested it on a machine with a german locale. Before the fix, decimal numbers of the BBX were written with a ','. After fix the URI is created with a '.' in the decimal numbers.