### PR TITLE
PointDrawable: Respect incoming alpha value.

### DIFF
--- a/src/osgEarth/PointDrawable.glsl
+++ b/src/osgEarth/PointDrawable.glsl
@@ -28,7 +28,7 @@ void oe_PointDrawable_FS(inout vec4 color)
   #ifdef GL_OES_standard_derivatives
     d = fwidth(r);
   #endif
-    color.a = 1.0 - smoothstep(1.0-d, 1.0+d, r);
+    color.a *= 1.0 - smoothstep(1.0-d, 1.0+d, r);
     if (color.a < 0.1)
         discard;
 #endif


### PR DESCRIPTION
I was setting alpha on some points and it wasn't being respected, tracked it down to this.

Note the same problem occurs on master, but master is using what looks like a more up-to-date PointDrawable.glsl that looks improved for compatibility.  Might want to cherrypick that change from master too?