### PR TITLE
PointDrawable: New insert() method.

### DIFF
--- a/src/osgEarth/PointDrawable
+++ b/src/osgEarth/PointDrawable
@@ -59,6 +59,9 @@ namespace osgEarth
         //! Append a vertex to the drawable
         void pushVertex(const osg::Vec3& vert);
 
+        //! Insert a vertex to the drawable
+        void insert(unsigned where, const osg::Vec3& vert);
+
         //! Set the value of a vertex at index i
         void setVertex(unsigned i, const osg::Vec3& vert);
 

--- a/src/osgEarth/PointDrawable.cpp
+++ b/src/osgEarth/PointDrawable.cpp
@@ -465,6 +465,20 @@ PointDrawable::pushVertex(const osg::Vec3& vert)
 }
 
 void
+PointDrawable::insert(unsigned where, const osg::Vec3& vert)
+{
+  initialize();
+
+  _current->insert(_current->begin() + where, vert);
+  _current->dirty();
+
+  _colors->insert(_colors->begin() + where, _color);
+  _colors->dirty();
+
+  dirtyBound();
+}
+
+void
 PointDrawable::setVertex(unsigned vi, const osg::Vec3& vert)
 {
     initialize();


### PR DESCRIPTION
Unlike `LineDrawable`, `PointDrawable::insert()` is pretty simple to support.  We insert points into an ordered vector for code that we use that currently uses `GL_POINTS`, that we're trying to upgrade to `PointDrawable`.  Having access to an `insert()` method helps us avoid accessing the internals of `PointDrawable` directly to get done what we need to do.