### PR TITLE
KML_Geometry parseCoords ensures all coords are parsed in case of comment in the coord list

### DIFF
--- a/src/osgEarthDrivers/kml/KML_Geometry.cpp
+++ b/src/osgEarthDrivers/kml/KML_Geometry.cpp
@@ -97,22 +97,28 @@ KML_Geometry::parseCoords( xml_node<>* node, KMLContext& cx )
     xml_node<>* coords = node->first_node("coordinates", 0, false);
     if ( coords )
     {
-        StringVector tuples;
-        StringTokenizer( coords->value(), tuples, " \n", "", false, true );
-        for( StringVector::const_iterator s=tuples.begin(); s != tuples.end(); ++s )
+        xml_node<>* coord = coords->first_node();
+        while (coord)
         {
-            StringVector parts;
-            StringTokenizer( *s, parts, ",", "", false, true );
-            if ( parts.size() >= 2 )
+            StringVector tuples;
+            StringTokenizer(coord->value(), tuples, " \n", "", false, true);
+            for (StringVector::const_iterator s = tuples.begin(); s != tuples.end(); ++s)
             {
-                osg::Vec3d point;
-                point.x() = as<double>( parts[0], 0.0 );
-                point.y() = as<double>( parts[1], 0.0 );
-                if ( parts.size() >= 3 ) {
-                    point.z() = as<double>( parts[2], 0.0 );
+                StringVector parts;
+                StringTokenizer(*s, parts, ",", "", false, true);
+                if (parts.size() >= 2)
+                {
+                    osg::Vec3d point;
+                    point.x() = as<double>(parts[0], 0.0);
+                    point.y() = as<double>(parts[1], 0.0);
+                    if (parts.size() >= 3) {
+                        point.z() = as<double>(parts[2], 0.0);
+                    }
+                    _geom->push_back(point);
                 }
-                _geom->push_back(point);
             }
+            coords->remove_first_node();
+            coord = coords->first_node();
         }
     }
 }


### PR DESCRIPTION
If a comment is found while parsing the coordinate list in the rapidxml.hpp, the coords found after the comment are all added as another child node, but the m_value field string only reflects the first node. Instead, iterate through all of the coordinate node's child nodes to make sure all coordinates are parsed.