### PR TITLE
Containers: MSVC 2015 compile fix

### DIFF
--- a/src/osgEarth/Containers
+++ b/src/osgEarth/Containers
@@ -130,7 +130,7 @@ namespace osgEarth { namespace Util
         inline iterator begin() { return _container.begin(); }
         inline iterator end() { return _container.end(); }
 
-        inline std::pair<vector_set<DATA>::const_iterator, bool> insert(const DATA& data) {
+        inline std::pair<typename vector_set<DATA>::const_iterator, bool> insert(const DATA& data) {
             const_iterator i = find(data);
             if (i != end()) {
                 return std::make_pair(i, false);


### PR DESCRIPTION
Fixes a compile error seen on MSVC 2015.  2017 and 2019 are happy with original, so is gcc 8.3.