### PR TITLE
Moved PrimiveIntersector::Intersection copy constructor

### DIFF
--- a/src/osgEarth/PrimitiveIntersector
+++ b/src/osgEarth/PrimitiveIntersector
@@ -45,7 +45,18 @@ public:
             ratio(-1.0),
             primitiveIndex(0) {}
 
-        Intersection(const Intersection &rhs);
+        Intersection(const Intersection &rhs)
+        {
+            ratio = rhs.ratio;
+            nodePath = rhs.nodePath;
+            drawable = rhs.drawable;
+            matrix = rhs.matrix;
+            localIntersectionPoint = rhs.localIntersectionPoint;
+            localIntersectionNormal = rhs.localIntersectionNormal;
+            indexList = rhs.indexList;
+            ratioList = rhs.ratioList;
+            primitiveIndex = rhs.primitiveIndex;
+        }
 
         bool operator < (const Intersection& rhs) const { return ratio < rhs.ratio; }
 
@@ -57,7 +68,7 @@ public:
         osg::ref_ptr<osg::Drawable>     drawable;
         osg::ref_ptr<osg::RefMatrix>    matrix;
         osg::Vec3d                      localIntersectionPoint;
-        osg::Vec3d                       localIntersectionNormal;
+        osg::Vec3d                      localIntersectionNormal;
         IndexList                       indexList;
         RatioList                       ratioList;
         unsigned int                    primitiveIndex;

--- a/src/osgEarth/PrimitiveIntersector.cpp
+++ b/src/osgEarth/PrimitiveIntersector.cpp
@@ -346,19 +346,6 @@ PrimitiveIntersector::PrimitiveIntersector(CoordinateFrame cf, const osg::Vec3d&
   setThickness(thickness);
 }
 
-PrimitiveIntersector::Intersection::Intersection(const PrimitiveIntersector::Intersection &rhs)
-{
-  ratio = rhs.ratio;
-  nodePath = rhs.nodePath;
-  drawable = rhs.drawable;
-  matrix = rhs.matrix;
-  localIntersectionPoint = rhs.localIntersectionPoint;
-  localIntersectionNormal = rhs.localIntersectionNormal;
-  indexList = rhs.indexList;
-  ratioList = rhs.ratioList;
-  primitiveIndex = rhs.primitiveIndex;
-}
-
 void PrimitiveIntersector::setThickness(double thickness)
 {
   _thicknessVal = thickness;


### PR DESCRIPTION
The copy constructor for PrimitiveIntersector::Intersection was defined in
the cpp file while the rest of the struct was defined inline in the
header.  This meant that you couldn't copy the struct without from your
own project without getting linker errors.  I simply moved the copy ctor
to be inline like the rest of the struct.