### PR TITLE
convert CLAMP_TO_BORDER to CLAMP_TO_EDGE in GLTFWriter

### DIFF
--- a/src/osgEarthDrivers/gltf/GLTFWriter.h
+++ b/src/osgEarthDrivers/gltf/GLTFWriter.h
@@ -360,15 +360,15 @@ public:
                     osg::Texture::WrapMode wrapR = osgTexture->getWrap(osg::Texture::WRAP_R);
 
                     // Validate the clamp mode to be compatible with webgl
-                    if (wrapS == osg::Texture::CLAMP)
+                    if ((wrapS == osg::Texture::CLAMP) || (wrapS == osg::Texture::CLAMP_TO_BORDER))
                     {                     
                         wrapS = osg::Texture::CLAMP_TO_EDGE;
                     }
-                    if (wrapT == osg::Texture::CLAMP)
+                    if ((wrapT == osg::Texture::CLAMP) || (wrapT == osg::Texture::CLAMP_TO_BORDER))
                     {                     
                         wrapT = osg::Texture::CLAMP_TO_EDGE;
                     }
-                    if (wrapR == osg::Texture::CLAMP)
+                    if ((wrapR == osg::Texture::CLAMP) || (wrapR == osg::Texture::CLAMP_TO_BORDER))
                     {                     
                         wrapR = osg::Texture::CLAMP_TO_EDGE;
                     }                    


### PR DESCRIPTION
GLTF doesn't accept CLAMP_TO_BORDER so use CLAMP_TO_EDGE instead