### PR TITLE
simple support of AlphaBlend material in GLTFWriter

### DIFF
--- a/src/osgEarthDrivers/gltf/GLTFWriter.h
+++ b/src/osgEarthDrivers/gltf/GLTFWriter.h
@@ -409,6 +409,10 @@ public:
                     roughnessFactor.has_number_value = true;
                     mat.values["roughnessFactor"] = roughnessFactor;
 
+					if (stateSet->getMode(GL_BLEND) & osg::StateAttribute::ON) {
+						mat.alphaMode = "BLEND";
+					}
+                    
                     _model.materials.push_back(mat);
                     return index;
                 }


### PR DESCRIPTION
when stateSet's GL_BLEND is ON, set GLTF alphaMode to "BLEND"