### PR TITLE
LayerDrawable: Avoid possible buffer overflow from sprintf() usage.

### DIFF
--- a/src/osgEarthDrivers/engine_rex/LayerDrawable.cpp
+++ b/src/osgEarthDrivers/engine_rex/LayerDrawable.cpp
@@ -83,9 +83,7 @@ void
 LayerDrawable::drawImplementation(osg::RenderInfo& ri) const
 {
     OE_PROFILING_ZONE;
-    char buf[64];
-    sprintf(buf, "%s (%d tiles)", _layer ? _layer->getName().c_str() : "unknown layer", _tiles.size());
-    OE_PROFILING_ZONE_TEXT(buf);
+    OE_PROFILING_ZONE_TEXT(osgEarth::Stringify() << (_layer ? _layer->getName() : "unknown layer") << " (" << _tiles.size() << " tiles)");
     //OE_INFO << LC << (_layer ? _layer->getName() : "[empty]") << " tiles=" << _tiles.size() << std::endl;
 
     // Get this context's state values:


### PR DESCRIPTION
If layer name is unusually long, this could overflow the `buf[64]`.  `Stringify` prevents that.