### PR TITLE
Fixed the header guard in GeoPositionNode

### DIFF
--- a/src/osgEarth/GeoPositionNode
+++ b/src/osgEarth/GeoPositionNode
@@ -19,8 +19,8 @@
 * You should have received a copy of the GNU Lesser General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
-#ifndef OSGEARTH_ANNO_ORTHO_NODE_H
-#define OSGEARTH_ANNO_ORTHO_NODE_H 1
+#ifndef OSGEARTH_ANNO_GEO_POSITION_NODE_H
+#define OSGEARTH_ANNO_GEO_POSITION_NODE_H 1
 
 #include <osgEarth/AnnotationNode>
 #include <osgEarth/GeoTransform>
@@ -137,4 +137,4 @@ namespace osgEarth
 
 }
 
-#endif // OSGEARTH_ANNO_LOCALIZED_NODE_H
+#endif // OSGEARTH_ANNO_GEO_POSITION_NODE_H


### PR DESCRIPTION
I realize that this is somewhat meaningless update, but I copied this class into my 2.7 build of osgEarth and later ran into problems because the header guard is the same as the one defined in OrthoNode, which no longer exists in 3.0.  Still, I figured I'd go ahead and fix it since I spotted it.