### PR TITLE
TerrainTileModelFactory mutex

### DIFF
--- a/src/osgEarth/TerrainTileModelFactory
+++ b/src/osgEarth/TerrainTileModelFactory
@@ -25,6 +25,7 @@
 #include <osgEarth/TerrainEngineRequirements>
 #include <osgEarth/ImageLayer>
 #include <osgEarth/Progress>
+#include <osgEarth/ThreadingUtils>
 
 namespace osgEarth
 {
@@ -232,6 +233,7 @@ namespace osgEarth
         bool    _heightFieldCacheEnabled;
         osg::ref_ptr<osg::Texture> _emptyColorTexture;
         osg::ref_ptr<osg::Texture> _emptyLandCoverTexture;
+        mutable Threading::Mutex _mipmapMutex;
     };
 }
 

--- a/src/osgEarth/TerrainTileModelFactory.cpp
+++ b/src/osgEarth/TerrainTileModelFactory.cpp
@@ -757,8 +757,10 @@ TerrainTileModelFactory::createImageTexture(osg::Image*       image,
     }
 
     layer->applyTextureCompressionMode(tex);
-
-    ImageUtils::generateMipmaps(tex);
+    {
+        Threading::ScopedMutexLock lock(_mipmapMutex);
+        ImageUtils::generateMipmaps(tex);
+    }
     
     return tex;
 }
@@ -833,7 +835,9 @@ TerrainTileModelFactory::createNormalTexture(osg::Image* image, bool compress) c
     tex->setMaxAnisotropy(1.0f);
     tex->setUnRefImageDataAfterApply(Registry::instance()->unRefImageDataAfterApply().get());
 
-    ImageUtils::generateMipmaps(tex);
-
+    {
+        Threading::ScopedMutexLock lock(_mipmapMutex);
+        ImageUtils::generateMipmaps(tex);
+    }
     return tex;
 }


### PR DESCRIPTION
Add locking around generateMipmaps() call for images that might be
coming from a cache. It's impossible to atomically check if an Image
has a mipmap already, so this code always locks.

resolves gwaldron/osgearth#1502.