### PR TITLE
WindLayer: Fix GL3 build on GLintptr compile error.

### DIFF
--- a/src/osgEarth/WindLayer.cpp
+++ b/src/osgEarth/WindLayer.cpp
@@ -48,6 +48,11 @@ namespace
         GLfloat speed;
     };
 
+    // osg::GLintptr is not defined on all systems, and GLintptr is
+    // also not defined on all systems.  One or the other is defined
+    // in osg/GLDefines; using statement lets compiler pick.
+    using namespace osg;
+
     // GL data that must be stored per-graphics-context
     struct DrawState
     {
@@ -56,7 +61,7 @@ namespace
             _bufferSize(0) { }
 
         GLuint _buffer;
-        osg::GLintptr _bufferSize;
+        GLintptr _bufferSize;
     };
 
     // Data stored per-camera


### PR DESCRIPTION
Attempting to fix issue pointed out by https://github.com/gwaldron/osgearth/commit/896debae11dfc4c9d26e63ae5d3bbbcf82e8b3ae#r38795634

I do not have a system where the osg::GLintptr is defined on which to test this however, I only have the GL3 system where that does not compile and this changeset does.  Tested on Linux gcc 8.3.1 with what looks like `-std=gnu++11`