### PR TITLE
ElevationPool: Fix Linux g++ 8.3 build errors.

### DIFF
--- a/src/osgEarth/ElevationPool.cpp
+++ b/src/osgEarth/ElevationPool.cpp
@@ -90,7 +90,7 @@ ElevationPool::getElevationRevision(const Map* map) const
 {
     // yes, must do this every time because individual
     // layers can "bump" their revisions (dynamic layers)
-    int revision = map ? map->getDataModelRevision() : 0;
+    int revision = map ? static_cast<int>(map->getDataModelRevision()) : 0;
 
     for(auto i : _elevationLayers)
         if (i->getEnabled())
@@ -128,7 +128,7 @@ ElevationPool::refresh(const Map* map)
     _elevationLayers.clear();
 
     if (_index)
-        delete _index;
+        delete static_cast<MaxLevelIndex*>(_index);
 
     map->getLayers(_elevationLayers);
 


### PR DESCRIPTION
Ternary operator did not want to use the to-int operator automatically.  Delete did not want to delete a `void*` pointer.