### PR TITLE
Threading: Mark Mutex assignment and copy operators as deleted to avo…

### DIFF
--- a/src/osgEarth/ElevationPool
+++ b/src/osgEarth/ElevationPool
@@ -74,6 +74,9 @@ namespace osgEarth
                 _elevationLayers = layers;
             }
 
+            //! Invalidate the cache.
+            void clear();
+
         private:
             StrongLRU _lru;
             ElevationLayerVector _elevationLayers;

--- a/src/osgEarth/ElevationPool.cpp
+++ b/src/osgEarth/ElevationPool.cpp
@@ -217,6 +217,13 @@ ElevationPool::WorkingSet::WorkingSet(unsigned size) :
     _lru._lru.setName("OE.WorkingSet.LRU");
 }
 
+void
+ElevationPool::WorkingSet::clear()
+{
+    _lru.clear();
+    // No need to clear the elevation layers; only invalidate the cache.
+}
+
 bool
 ElevationPool::findExistingRaster(
     const Internal::RevElevationKey& key,

--- a/src/osgEarth/Threading
+++ b/src/osgEarth/Threading
@@ -64,7 +64,12 @@ namespace osgEarth { namespace Threading
     public:
         Mutex();
         Mutex(const std::string& name, const char* file=nullptr, std::uint32_t line=0);
+        //! Do not permit copy constructor on Mutex
+        Mutex(const Mutex& copy) = delete;
         ~Mutex();
+
+        //! Explicitly block the copy operator
+        Mutex& operator=(const Mutex& copy) = delete;
 
         void lock() override;
         void unlock() override;


### PR DESCRIPTION
…id erronous mutex copies.  Add WorkingSet::clear() as a way to invalidate the cache.

If a Mutex instance is copied, I see a crash on exit.  Marking the copy operators as deleted will prevent this while compiling.

The WorkingSet needs a way to invalidate its cache.  Previously we had been using a copy constructor to do this.  This led to the Mutex being copied, which led to the crash.  Now that the Mutex cannot be copied, there needs to be a way to invalidate the cache in the WorkingSet, hence the new clear() method.