### PR TITLE
GDALDEM: Clean-up, fix missing functions, add alpha option, rename altitude to lightAltitude.

### DIFF
--- a/src/osgEarth/GDALDEM
+++ b/src/osgEarth/GDALDEM
@@ -39,9 +39,10 @@ namespace osgEarth
             OE_OPTION_LAYER(ElevationLayer, elevationLayer);
             OE_OPTION(std::string, processing);
             OE_OPTION(float, azimuth);
-            OE_OPTION(float, altitude);
+            OE_OPTION(float, lightAltitude);
             OE_OPTION(bool, multidirectional);
             OE_OPTION(bool, combined);
+            OE_OPTION(bool, alpha);
             OE_OPTION(URI, color_filename);
             virtual Config getConfig() const;
         private:
@@ -57,22 +58,31 @@ namespace osgEarth
         void setElevationLayer(ElevationLayer* layer);
         ElevationLayer* getElevationLayer() const;
 
-        //! Processing option
+        //! Processing option.  Depends on GDAL version; typical options: hillshade; slope; aspect; color-relief; TRI; TPI; roughness
         void setProcessing(const std::string& value);
         const std::string& getProcessing() const;
 
+        //! Azimuth of the light, in degrees. 0 if it comes from the top of the raster, 90 from the east; typically 315; useful only for hillshade processing.
         void setAzimuth(const float& value);
         float getAzimuth() const;
 
-        void setAltitude(const float& value);
-        float getAltitude() const;
+        //! Altitude of the light, in degrees. 90 if the light comes from above the DEM, 0 if it is raking light; for hillshade processing
+        void setLightAltitude(const float& value);
+        float getLightAltitude() const;
 
+        //! Multidirectional shading, a combination of hillshading illuminated from 225 deg, 270 deg, 315 deg, and 360 deg azimuth; useful only for hillshade processing.
         void setMultidirectional(const bool& value);
-        float getMultidirectional() const;
+        bool getMultidirectional() const;
 
+        //! Combined shading, a combination of slope and oblique shading; useful only for hillshade processing.
         void setCombined(const bool& value);
-        float getCombined() const;
+        bool getCombined() const;
 
+        //! Color output supports alpha; useful only for color-relief processing.
+        void setAlpha(const bool& value);
+        bool getAlpha() const;
+
+        //! Color text file containing lines of format "elevation_value red green blue [alpha]"; useful only for color-relief processing.
         void setColorFilename(const URI& value);
         const URI& getColorFilename() const;
 

--- a/src/osgEarth/GDALDEM.cpp
+++ b/src/osgEarth/GDALDEM.cpp
@@ -50,10 +50,11 @@ GDALDEMLayer::Options::getConfig() const
     Config conf = ImageLayer::Options::getConfig();
     elevationLayer().set(conf, "layer");
     conf.set("processing", processing());
-    conf.set("altitude", altitude());
+    conf.set("light_altitude", lightAltitude());
     conf.set("azimuth", azimuth());
     conf.set("combined", combined());
     conf.set("multidirectional", multidirectional());
+    conf.set("alpha", alpha());
     conf.set("color_filename", color_filename());
     return conf;
 }
@@ -64,10 +65,11 @@ GDALDEMLayer::Options::fromConfig(const Config& conf)
     processing().init("hillshade");
     elevationLayer().get(conf, "layer");
     conf.get("processing", processing());
-    conf.get("altitude", altitude());
+    conf.get("light_altitude", lightAltitude());
     conf.get("azimuth", azimuth());
     conf.get("combined", combined());
     conf.get("multidirectional", multidirectional());
+    conf.get("alpha", alpha());
     conf.get("color_filename", color_filename());
 }
 
@@ -78,7 +80,10 @@ GDALDEMLayer::setElevationLayer(ElevationLayer* elevationLayer)
 {
     if (getElevationLayer() != elevationLayer)
     {
+        bool wasOpen = isOpen();
+        if (wasOpen) close();
         options().elevationLayer().setLayer(elevationLayer);
+        if (wasOpen) open();
     }
 }
 
@@ -86,6 +91,90 @@ ElevationLayer*
 GDALDEMLayer::getElevationLayer() const
 {
     return options().elevationLayer().getLayer();
+}
+
+void
+GDALDEMLayer::setProcessing(const std::string& value)
+{
+    setOptionThatRequiresReopen(options().processing(), value);
+}
+
+const std::string&
+GDALDEMLayer::getProcessing() const
+{
+    return options().processing().get();
+}
+
+void
+GDALDEMLayer::setAzimuth(const float& value)
+{
+    setOptionThatRequiresReopen(options().azimuth(), value);
+}
+
+float
+GDALDEMLayer::getAzimuth() const
+{
+    return options().azimuth().get();
+}
+
+void
+GDALDEMLayer::setLightAltitude(const float& value)
+{
+    setOptionThatRequiresReopen(options().lightAltitude(), value);
+}
+
+float
+GDALDEMLayer::getLightAltitude() const
+{
+    return options().lightAltitude().get();
+}
+
+void
+GDALDEMLayer::setMultidirectional(const bool& value)
+{
+    setOptionThatRequiresReopen(options().multidirectional(), value);
+}
+
+bool
+GDALDEMLayer::getMultidirectional() const
+{
+    return options().multidirectional().get();
+}
+
+void
+GDALDEMLayer::setCombined(const bool& value)
+{
+    setOptionThatRequiresReopen(options().combined(), value);
+}
+
+bool
+GDALDEMLayer::getCombined() const
+{
+    return options().combined().get();
+}
+
+void
+GDALDEMLayer::setAlpha(const bool& value)
+{
+    setOptionThatRequiresReopen(options().alpha(), value);
+}
+
+bool
+GDALDEMLayer::getAlpha() const
+{
+    return options().alpha().get();
+}
+
+void
+GDALDEMLayer::setColorFilename(const URI& value)
+{
+  setOptionThatRequiresReopen(options().color_filename(), value);
+}
+
+const URI&
+GDALDEMLayer::getColorFilename() const
+{
+  return options().color_filename().get();
 }
 
 void
@@ -349,10 +438,10 @@ GDALDEMLayer::createImageImplementation(const TileKey& key, ProgressCallback* pr
             papsz = CSLAddString(papsz, arg.c_str());
         }
 
-        if (options().altitude().isSet())
+        if (options().lightAltitude().isSet())
         {
             papsz = CSLAddString(papsz, "-alt");
-            std::string arg = Stringify() << *options().altitude();
+            std::string arg = Stringify() << *options().lightAltitude();
             papsz = CSLAddString(papsz, arg.c_str());
         }
 
@@ -366,6 +455,10 @@ GDALDEMLayer::createImageImplementation(const TileKey& key, ProgressCallback* pr
             papsz = CSLAddString(papsz, "-combined");
         }
 
+        if (options().alpha().isSet())
+        {
+            papsz = CSLAddString(papsz, "-alpha");
+        }
 
         GDALDEMProcessingOptions* psOptions = GDALDEMProcessingOptionsNew(papsz, NULL);
 


### PR DESCRIPTION
Have been using `GDALDEM` and ran into several issues that this PR fixes:
* `altitude` option and text appears to be taken already by `ImageLayer::Options::altitude()`.  Renamed to `get/setLightAltitude()` (`light_altitude`) in order to not hide the base class value
* Added 'alpha' option, which is useful on color-relief images
* Added various documentation on the options, since many were not obvious in their intent or usage
* Setting the elevation layer now reopens the layer if needed
* Added implementation for various get/set functions, which were declared but not implemented.
* Fixed return values on `getMultidirectional()` and `getCombined()`
