### PR TITLE
Changed include references from osgEarth/ThreadingUtils

### DIFF
--- a/src/osgEarth/Async
+++ b/src/osgEarth/Async
@@ -22,7 +22,7 @@
 
 #include <osgEarth/Common>
 #include <osgEarth/IOTypes>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osg/Group>
 
 /**

--- a/src/osgEarth/BrightnessContrastColorFilter.cpp
+++ b/src/osgEarth/BrightnessContrastColorFilter.cpp
@@ -24,7 +24,7 @@
 #include <osgEarthUtil/BrightnessContrastColorFilter>
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/StringUtils>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osg/Program>
 #include <OpenThreads/Atomic>
 

--- a/src/osgEarth/CMYKColorFilter.cpp
+++ b/src/osgEarth/CMYKColorFilter.cpp
@@ -24,7 +24,7 @@
 #include <osgEarthUtil/CMYKColorFilter>
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/StringUtils>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osg/Program>
 #include <OpenThreads/Atomic>
 

--- a/src/osgEarth/ChromaKeyColorFilter.cpp
+++ b/src/osgEarth/ChromaKeyColorFilter.cpp
@@ -19,7 +19,7 @@
 #include <osgEarthUtil/ChromaKeyColorFilter>
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/StringUtils>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osg/Program>
 #include <OpenThreads/Atomic>
 

--- a/src/osgEarth/GLSLColorFilter.cpp
+++ b/src/osgEarth/GLSLColorFilter.cpp
@@ -24,7 +24,7 @@
 #include <osgEarthUtil/GLSLColorFilter>
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/StringUtils>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osg/Program>
 #include <OpenThreads/Atomic>
 

--- a/src/osgEarth/GammaColorFilter.cpp
+++ b/src/osgEarth/GammaColorFilter.cpp
@@ -24,7 +24,7 @@
 #include <osgEarthUtil/GammaColorFilter>
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/StringUtils>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osg/Program>
 #include <OpenThreads/Atomic>
 

--- a/src/osgEarth/HSLColorFilter.cpp
+++ b/src/osgEarth/HSLColorFilter.cpp
@@ -22,7 +22,7 @@
 #include <osgEarthUtil/HSLColorFilter>
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/StringUtils>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osg/Program>
 #include <OpenThreads/Atomic>
 

--- a/src/osgEarth/MapNodeObserver.cpp
+++ b/src/osgEarth/MapNodeObserver.cpp
@@ -17,7 +17,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 #include <osgEarth/ColorFilter>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 
 using namespace osgEarth;
 

--- a/src/osgEarth/NightColorFilter.cpp
+++ b/src/osgEarth/NightColorFilter.cpp
@@ -23,7 +23,7 @@
 #include <osgEarthUtil/NightColorFilter>
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/StringUtils>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osg/Program>
 #include <OpenThreads/Atomic>
 

--- a/src/osgEarth/RGBColorFilter.cpp
+++ b/src/osgEarth/RGBColorFilter.cpp
@@ -24,7 +24,7 @@
 #include <osgEarthUtil/RGBColorFilter>
 #include <osgEarth/VirtualProgram>
 #include <osgEarth/StringUtils>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osg/Program>
 #include <OpenThreads/Atomic>
 

--- a/src/osgEarthDrivers/cache_leveldb/LevelDBCache.cpp
+++ b/src/osgEarthDrivers/cache_leveldb/LevelDBCache.cpp
@@ -19,7 +19,7 @@
 #include "LevelDBCache"
 #include "LevelDBCacheBin"
 #include <osgEarth/URI>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osgDB/Registry>
 #include <osgDB/ReaderWriter>
 #include <osgDB/FileUtils>

--- a/src/osgEarthDrivers/cache_leveldb/Tracker
+++ b/src/osgEarthDrivers/cache_leveldb/Tracker
@@ -20,7 +20,7 @@
 #define OSGEARTH_DRIVER_CACHE_LEVELDB_TRACKER 1
 
 #include "LevelDBCacheOptions"
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osgDB/FileUtils>
 #include <osgDB/FileNameUtils>
 #include <osg/Referenced>

--- a/src/osgEarthDrivers/cache_rocksdb/RocksDBCache.cpp
+++ b/src/osgEarthDrivers/cache_rocksdb/RocksDBCache.cpp
@@ -19,7 +19,7 @@
 #include "RocksDBCache"
 #include "RocksDBCacheBin"
 #include <osgEarth/URI>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osgDB/Registry>
 #include <osgDB/ReaderWriter>
 #include <osgDB/FileUtils>

--- a/src/osgEarthDrivers/cache_rocksdb/Tracker
+++ b/src/osgEarthDrivers/cache_rocksdb/Tracker
@@ -20,7 +20,7 @@
 #define OSGEARTH_DRIVER_CACHE_ROCKSDB_TRACKER 1
 
 #include "RocksDBCacheOptions"
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osgDB/FileUtils>
 #include <osgDB/FileNameUtils>
 #include <osg/Referenced>

--- a/src/osgEarthDrivers/engine_mp/GeometryPool
+++ b/src/osgEarthDrivers/engine_mp/GeometryPool
@@ -24,7 +24,7 @@
 #include "MPTerrainEngineOptions"
 #include <osgEarth/MapInfo>
 #include <osgEarth/TileKey>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osg/Geometry>
 
 namespace osgEarth { namespace Drivers { namespace MPTerrainEngine

--- a/src/osgEarthDrivers/engine_mp/HeightFieldCache
+++ b/src/osgEarthDrivers/engine_mp/HeightFieldCache
@@ -28,7 +28,7 @@
 #include "MPTerrainEngineOptions"
 #include <osgEarth/Map>
 #include <osgEarth/Progress>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osgEarth/Containers>
 #include <osgEarth/HeightFieldUtils>
 #include "MapFrame"

--- a/src/osgEarthDrivers/engine_mp/MPTerrainEngineNode
+++ b/src/osgEarthDrivers/engine_mp/MPTerrainEngineNode
@@ -23,7 +23,7 @@
 #include <osgEarth/TerrainResources>
 #include <osgEarth/Map>
 #include <osgEarth/Revisioning>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osgEarth/Containers>
 #include <osgEarth/ResourceReleaser>
 

--- a/src/osgEarthDrivers/engine_mp/TileGroup
+++ b/src/osgEarthDrivers/engine_mp/TileGroup
@@ -26,7 +26,7 @@
 #include "TileNode"
 #include "TileNodeRegistry"
 #include <osg/Group>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osgEarth/ResourceReleaser>
 
 namespace osgEarth { namespace Drivers { namespace MPTerrainEngine

--- a/src/osgEarthDrivers/engine_mp/TileNodeRegistry
+++ b/src/osgEarthDrivers/engine_mp/TileNodeRegistry
@@ -25,7 +25,7 @@
 #include "Common"
 #include "TileNode"
 #include <osgEarth/Revisioning>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osgEarth/ResourceReleaser>
 #include <osgEarth/Terrain>
 #include <OpenThreads/Atomic>

--- a/src/osgEarthDrivers/engine_mp/TilePagedLOD
+++ b/src/osgEarthDrivers/engine_mp/TilePagedLOD
@@ -25,7 +25,7 @@
 #include "Common"
 #include "TileNodeRegistry"
 #include <osg/PagedLOD>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osgEarth/Progress>
 #include <osgEarth/ResourceReleaser>
 

--- a/src/osgEarthDrivers/ocean_simple/ElevationProxyImageLayer
+++ b/src/osgEarthDrivers/ocean_simple/ElevationProxyImageLayer
@@ -20,7 +20,7 @@
 #define OSGEARTH_DRIVER_SIMPLE_OCEAN_ELEV_PROXY_IMAGE_LAYER 1
 
 #include <osgEarth/ImageLayer>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 
 namespace osgEarth {
     class Map;

--- a/src/osgEarthDrivers/ocean_triton/TritonDriver.cpp
+++ b/src/osgEarthDrivers/ocean_triton/TritonDriver.cpp
@@ -22,7 +22,7 @@
 #include <osgDB/FileUtils>
 #include <osgEarth/MapNode>
 #include <osgEarth/Registry>
-#include <osgEarth/ThreadingUtils>
+#include <osgEarth/Threading>
 #include <osgEarthUtil/Ocean>
 
 #include <osgEarthTriton/TritonOptions>


### PR DESCRIPTION
to osgEarth/Threading due to ThreadingUtils no longer existing in version 3.0. osgEarth/Threading seems to be included in several lower level includes so its possible these lines can be removed completely.