### PR TITLE
ElevationPool: Fix overflow error in getSample().

### DIFF
--- a/src/osgEarth/ElevationPool.cpp
+++ b/src/osgEarth/ElevationPool.cpp
@@ -758,6 +758,8 @@ ElevationPool::getSample(
     ScopedAtomicCounter counter(_workers);
 
     Internal::RevElevationKey key;
+    // Need to limit maxLOD <= INT_MAX else osg::minimum for lod will return -1 due to cast
+    maxLOD = osg::minimum(maxLOD, static_cast<unsigned>(std::numeric_limits<int>::max()));
     int lod = osg::minimum( getLOD(p.x(), p.y()), (int)maxLOD );
     if (lod >= 0)
     {   


### PR DESCRIPTION
`ElevationPool::getSample()` provides a signature that omits the maximum LOD parameter.  In this case, it is fed in as `~0`, which is of type `unsigned`.  This function gets it, and on old line 761 typecasts it to an `int` so that `osg::minimum()` can be used.  But that typecast results in a negative number, making `lod` always be `-1` when coming from that other signature.

This fixes that problem by limiting the incoming `maxLOD` value to, at most, `std::numeric_limits<int>::max()`.