### PR TITLE
fix a spell error in src/osgEarth/TDTiles in line 223, from `Tileet` to `Tileset`

### DIFF
--- a/src/osgEarth/TDTiles
+++ b/src/osgEarth/TDTiles
@@ -231,7 +231,7 @@ namespace osgEarth { namespace Contrib { namespace ThreeDTiles
     };
 
     /**
-    * Node representing a 3D-Tiles Tileet.
+    * Node representing a 3D-Tiles Tileset.
     */
     class OSGEARTH_EXPORT ThreeDTilesetNode : public osg::Group
     {


### PR DESCRIPTION
fix a spell error in src/osgEarth/TDTiles in line 223, from `Tileet` to `Tileset`