### PR TITLE
src/osgEarthDrivers/gltf/GLTFReader.h include same header `#include <osgDB/FileNameUtils>` twice

### DIFF
--- a/src/osgEarthDrivers/gltf/GLTFReader.h
+++ b/src/osgEarthDrivers/gltf/GLTFReader.h
@@ -30,7 +30,6 @@
 #include <osg/CullFace>
 #include <osgDB/FileNameUtils>
 #include <osgDB/ReaderWriter>
-#include <osgDB/FileNameUtils>
 #include <osgDB/ObjectWrapper>
 #include <osgDB/Registry>
 #include <osgUtil/SmoothingVisitor>


### PR DESCRIPTION
src/osgEarthDrivers/gltf/GLTFReader.h include same header `#include <osgDB/FileNameUtils>` twice