### PR TITLE
Exposing struct "CameraData" to dll

### DIFF
--- a/src/osgEarth/GeodeticGraticule
+++ b/src/osgEarth/GeodeticGraticule
@@ -141,7 +141,7 @@ namespace osgEarth { namespace Util
         osg::Vec2f _centerOffset;
         std::vector< double > _resolutions;
 
-        struct CameraData
+        struct OSGEARTH_EXPORT CameraData
         {
             osg::ref_ptr<osg::StateSet> _stateset;
             osg::ref_ptr<osg::Uniform> _resolutionUniform;


### PR DESCRIPTION
Please append "OSGEARTH_EXPORT" to the declaration of struct "CameraData". Otherwise,  "CameraData::~CameraData()" won't be found when building "osgearth_geodetic_graticule.exe".