### PR TITLE
TerrainEngineNode: Reset the tile mode factory when shutting down.

### DIFF
--- a/src/osgEarth/TerrainEngineNode
+++ b/src/osgEarth/TerrainEngineNode
@@ -144,7 +144,7 @@ namespace osgEarth
 
         void invalidateRegion(
             const std::vector<const Layer*> layers,
-            const GeoExtent& extent) 
+            const GeoExtent& extent)
         {
             invalidateRegion(layers, extent, 0, INT_MAX);
         }
@@ -162,7 +162,7 @@ namespace osgEarth
         virtual void dirtyTerrain();
 
         //! Shut down the engine
-        virtual void shutdown() { }
+        virtual void shutdown();
 
     public:
         class OSGEARTH_EXPORT ModifyTileBoundingBoxCallback : public osg::Referenced
@@ -215,7 +215,7 @@ namespace osgEarth
         //! Create a standalone terrain tile. This method is not used by the
         //! actual terrain engine, but rather exists to support external
         //! processes that need tile geometry. The terrain engine implementation
-        //! may or may not provide this capability and will return NULL if 
+        //! may or may not provide this capability and will return NULL if
         //! it does not.
         //! @param model Tile model for which to build a tile
         //! @param flags Bitwise-OR of the CreateTileFlags enums
@@ -270,7 +270,7 @@ namespace osgEarth
         bool _requireParentTextures;
         bool _requireElevationBorder;
         bool _requireFullDataAtFirstLOD;
-        
+
         osg::ref_ptr<const Map> _map;
 
     private:
@@ -287,7 +287,7 @@ namespace osgEarth
 
         typedef std::vector<osg::ref_ptr<TerrainEffect> > TerrainEffectVector;
         TerrainEffectVector effects_;
-        
+
         typedef std::vector<osg::ref_ptr<CreateTileModelCallback> > CreateTileModelCallbacks;
         CreateTileModelCallbacks _createTileModelCallbacks;
         mutable Threading::ReadWriteMutex _createTileModelCallbacksMutex;

--- a/src/osgEarth/TerrainEngineNode.cpp
+++ b/src/osgEarth/TerrainEngineNode.cpp
@@ -127,6 +127,12 @@ TerrainEngineNode::dirtyTerrain()
 }
 
 void
+TerrainEngineNode::shutdown()
+{
+    _tileModelFactory = nullptr;
+}
+
+void
 TerrainEngineNode::setMap(const Map* map, const TerrainOptions& options)
 {
     if (!map) return;
@@ -214,6 +220,8 @@ TerrainEngineNode::createTileModel(const Map* map,
                                    const CreateTileManifest& manifest,
                                    ProgressCallback* progress)
 {
+    if ( !_tileModelFactory.valid() )
+        return nullptr;
     TerrainEngineRequirements* requirements = this;
 
     // Ask the factory to create a new tile model:

--- a/src/osgEarthDrivers/engine_rex/RexTerrainEngineNode.cpp
+++ b/src/osgEarthDrivers/engine_rex/RexTerrainEngineNode.cpp
@@ -211,6 +211,7 @@ RexTerrainEngineNode::releaseGLObjects(osg::State* state) const
 void
 RexTerrainEngineNode::shutdown()
 {
+    TerrainEngineNode::shutdown();
     _loader->clear();
 }
 


### PR DESCRIPTION
On start-up I am creating a new map node and putting it into the scene.  The old map node is being destroyed.  The old map node's Tile Model Factory is still active at this time.  It is crashing because of an access to a stale reference to the terrain options.  Tile Model Factory references a terrain options that is owned by the `MapNode`.  So when the `MapNode` gets destroyed, the Tile Model Factory should also stop processing in order to avoid holding a stale reference to the `MapNode` terrain options.

This change does that by leveraging the already-existing `shutdown()` method to drop the `ref_ptr _tileModelFactory`.

There's a minor change in the Rex engine that also makes sure the derived version of the function calls the parent version.