### PR TITLE
Earth Serializer: Apply relative path now also to fields containing underscores

### DIFF
--- a/src/osgEarthDrivers/earth/EarthFileSerializer2.cpp
+++ b/src/osgEarthDrivers/earth/EarthFileSerializer2.cpp
@@ -189,6 +189,12 @@ namespace
             _rewriteAbsolutePaths = value;
         }
 
+        /** Returns true if key contains "_fragment", or is identical to "fragment" */
+        bool keyContainsFragment(const std::string& key, const std::string& fragment) const
+        {
+            return key == fragment || key.find("_" + fragment) != std::string::npos;
+        }
+
         bool isLocation(const Config& input) const
         {
             if ( input.value().empty() )
@@ -198,13 +204,13 @@ namespace
                 return false;
 
             return 
-                input.key() == "url"      ||
-                input.key() == "uri"      ||
-                input.key() == "href"     ||
-                input.key() == "filename" ||
-                input.key() == "file"     ||
-                input.key() == "pathname" ||
-                input.key() == "path";
+                keyContainsFragment(input.key(), "url")      ||
+                keyContainsFragment(input.key(), "uri")      ||
+                keyContainsFragment(input.key(), "href")     ||
+                keyContainsFragment(input.key(), "filename") ||
+                keyContainsFragment(input.key(), "file")     ||
+                keyContainsFragment(input.key(), "pathname") ||
+                keyContainsFragment(input.key(), "path");
         }
 
         void apply(Config& input)


### PR DESCRIPTION
For example, field names uri and url were converted for relative path, but field names like texture_uri and cursor_url were not converted.  This led to saved earth files not being able to be loaded properly in some conditions.

This change basically expands the definition of which fields will be processed for URL handling for rewriting paths as relative, so more field names will be included.