### PR TITLE
3.1: github actions for windows, linux and macos

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,70 @@
+name: linux-x64 
+
+on: [workflow_dispatch] # workflow_dispatch push
+
+env:             
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: ['ubuntu-20.04']
+        include:
+          - os: 'ubuntu-20.04'
+            triplet: 'x64-linux'
+
+    steps:       
+    - name: Setup environment
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install libgl-dev
+        sudo apt-get install -y cmake
+        sudo apt-get install -y libopenscenegraph-dev
+        sudo apt-get install -y libgdal-dev
+        sudo apt-get install -y libgeos-dev
+        sudo apt-get install -y libsqlite3-dev
+        sudo apt-get install -y protobuf-compiler libprotobuf-dev
+        sudo apt-get install -y libpoco-dev
+        
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        ref: 3.1  
+             
+    - name: Create Build Environment
+      run: |
+        cmake -E make_directory ${{runner.workspace}}/build 
+    
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{ runner.workspace }}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE 
+
+    - name: 'Upload cmake configure log artifact'
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: cmake-configure-log
+        path: |
+          ${{ runner.workspace }}/build/CMakeCache.txt
+        retention-days: 1
+
+    - name: Build
+      working-directory: ${{ runner.workspace }}/build
+      shell: bash
+      run: cmake --build . --parallel 4 --config $BUILD_TYPE 
+
+    - name: 'Upload cmake build log artifact'
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: cmake-build-log
+        path: |
+          ${{ runner.workspace }}/build/CMakeCache.txt
+        retention-days: 1
+    

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,74 @@
+name: macosx-x64 
+
+on: [workflow_dispatch] # workflow_dispatch push
+
+env:             
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: ['macos-10.15']
+        include:
+          - os: 'macos-10.15'
+            triplet: 'x64-macosx'
+
+    steps:       
+    - name: Setup environment
+      run: |
+        # brew install cmake
+        brew install gdal
+        brew install geos
+        brew install sqlite
+        brew install protobuf
+        brew install poco
+        brew install open-scene-graph
+        sudo xcode-select -p
+        
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        ref: 3.1  
+             
+    - name: Create Build Environment
+      run: |
+        # patch for opengl warnings
+        macos_xcode_defs="ADD_DEFINITIONS(-DGL_SILENCE_DEPRECATION=1)\nadd_compile_options(-Wno-inconsistent-missing-override)\n"
+        echo -e "${macos_xcode_defs}\n$(cat ${{runner.workspace}}/osgearth/src/CMakeLists.txt)" > ${{runner.workspace}}/osgearth/src/CMakeLists.txt
+        # gltf doesn't compile
+        sed -i '' "s/add_subdirectory(gltf)//g" ${{runner.workspace}}/osgearth/src/osgEarthDrivers/CMakeLists.txt
+        cmake -E make_directory ${{runner.workspace}}/build 
+    
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{ runner.workspace }}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_CXX_STANDARD:STRING=11 -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=ON -DCMAKE_CXX_EXTENSIONS:BOOL=OFF -GXcode 
+
+    - name: 'Upload cmake configure log artifact'
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: cmake-configure-log
+        path: |
+          ${{ runner.workspace }}/build/CMakeCache.txt
+        retention-days: 1
+
+    - name: Build
+      working-directory: ${{ runner.workspace }}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE 
+
+    - name: 'Upload cmake build log artifact'
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: cmake-build-log
+        path: |
+          ${{ runner.workspace }}/build/CMakeCache.txt
+        retention-days: 1
+    

--- a/.github/workflows/test/linux-vcpkg.yml
+++ b/.github/workflows/test/linux-vcpkg.yml
@@ -1,0 +1,126 @@
+name: Linux CMake with VCPKG - not work
+
+on: [workflow_dispatch] # push
+
+env:             
+  VCPKG_BINARY_SOURCES : 'clear;nuget,GitHub,readwrite'  
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  VCPKG_VERSION: '2020.11' 
+
+jobs:
+  
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: ['ubuntu-20.04']
+        include:
+          - os: 'ubuntu-20.04'
+            triplet: 'x64-linux'
+            mono: 'mono'
+            VCPKG_WORKSPACE: '/home/runner/vcpkg_own'
+
+    steps:       
+    - name: Free disk space / Setup environment
+      # https://github.com/actions/virtual-environments/issues/709
+      run: |
+        df -h
+        echo "Removing large packages"
+        sudo rm -rf "/usr/local/share/boost"
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+        docker rmi $(docker image ls -aq)      
+        sudo apt-get autoremove -y
+        sudo apt-get clean
+        df -h
+        sudo apt-get install libgl-dev
+        
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        ref: 3.1  
+
+    - name: vcpkg cache
+      id: vcpkgcache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ matrix.VCPKG_WORKSPACE }}
+          !${{ matrix.VCPKG_WORKSPACE }}/packages
+          !${{ matrix.VCPKG_WORKSPACE }}/buildtrees
+          !${{ matrix.VCPKG_WORKSPACE }}/downloads
+        key: vcpkg-${{ matrix.triplet }}
+    
+    - name: Installing vcpkg (windows)
+      if: steps.vcpkgcache.outputs.cache-hit != 'true'
+      shell: 'bash'
+      run: |
+        cmake -E make_directory ${{ matrix.VCPKG_WORKSPACE }}
+        cd ${{ matrix.VCPKG_WORKSPACE }}
+        git clone --depth 1 --branch ${{env.VCPKG_VERSION}} https://github.com/microsoft/vcpkg 
+        ./vcpkg/bootstrap-vcpkg.sh -disableMetrics
+        ${{ matrix.VCPKG_WORKSPACE }}/vcpkg/vcpkg version
+        
+    # This step assumes `vcpkg` has been bootstrapped (run `./vcpkg/bootstrap-vcpkg`)
+    - name: 'Setup NuGet Credentials'
+      working-directory: ${{ matrix.VCPKG_WORKSPACE }}
+      shell: 'bash'
+      run: >
+        ${{ matrix.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
+        sources add
+        -source "https://nuget.pkg.github.com/remoe/index.json"
+        -storepasswordincleartext
+        -name "GitHub"
+        -username "remoe"
+        -password "${{ secrets.GITHUB_TOKEN }}"
+        
+    # Omit this step if you're using manifests
+    - name: 'vcpkg package restore'
+      working-directory: ${{ matrix.VCPKG_WORKSPACE }}
+      shell: 'bash'
+      run: >
+        ./vcpkg/vcpkg install osg sqlite3 protobuf curl gdal --triplet ${{ matrix.triplet }} 
+        
+    - name: 'Upload library build log artifact'
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: osg-log
+        path: |
+          ${{ matrix.VCPKG_WORKSPACE }}/vcpkg/buildtrees/osg/config-x64-linux-dbg-out.log
+          ${{ matrix.VCPKG_WORKSPACE }}/vcpkg/buildtrees/osg/config-x64-linux-dbg-err.log
+          ${{ matrix.VCPKG_WORKSPACE }}/vcpkg/buildtrees/osg/install-x64-linux-dbg-out.log
+          ${{ matrix.VCPKG_WORKSPACE }}/vcpkg/buildtrees/osg/install-x64-linux-dbg-err.log
+        retention-days: 1
+             
+    - name: Create Build Environment
+      run: |
+        cmake -E make_directory ${{runner.workspace}}/build 
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{ runner.workspace }}/build
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=${{ matrix.VCPKG_WORKSPACE }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+    - name: 'Upload cmake configure log artifact'
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: cmake-configure-log
+        path: |
+          ${{ runner.workspace }}/build/CMakeCache.txt
+        retention-days: 1
+
+    - name: Build
+      working-directory: ${{ runner.workspace }}/build
+      shell: bash
+      run: cmake --build . --parallel 4 --config $BUILD_TYPE 
+
+    - name: 'Upload cmake build log artifact'
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: cmake-build-log
+        path: |
+          ${{ runner.workspace }}/build/CMakeCache.txt
+        retention-days: 1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,104 @@
+name: windows-x64
+
+on: [workflow_dispatch] # workflow_dispatch push
+
+env:             
+  VCPKG_BINARY_SOURCES : 'clear;nuget,GitHub,readwrite'  
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+  VCPKG_VERSION: '2020.11' 
+
+jobs:
+  
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: ['windows-2019']
+        include:
+          - os: 'windows-2019'
+            triplet: 'x64-windows'
+            mono: ''
+            VCPKG_WORKSPACE: 'c:/vcpkg_own'
+
+    steps:       
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        ref: 3.1  
+
+    - name: vcpkg cache
+      id: vcpkgcache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ${{ matrix.VCPKG_WORKSPACE }}
+          !${{ matrix.VCPKG_WORKSPACE }}/packages
+          !${{ matrix.VCPKG_WORKSPACE }}/buildtrees
+          !${{ matrix.VCPKG_WORKSPACE }}/downloads
+        key: vcpkg-${{ matrix.triplet }}
+    
+    - name: Installing vcpkg (windows)
+      if: steps.vcpkgcache.outputs.cache-hit != 'true'
+      shell: 'bash'
+      run: |
+        cmake -E make_directory ${{ matrix.VCPKG_WORKSPACE }}
+        cd ${{ matrix.VCPKG_WORKSPACE }}
+        git clone --depth 1 --branch ${{env.VCPKG_VERSION}} https://github.com/microsoft/vcpkg 
+        ./vcpkg/bootstrap-vcpkg.bat -disableMetrics
+        ${{ matrix.VCPKG_WORKSPACE }}/vcpkg/vcpkg version
+
+    - name: 'Setup NuGet Credentials'
+      working-directory: ${{ matrix.VCPKG_WORKSPACE }}
+      shell: 'bash'
+      run: >
+        ${{ matrix.mono }} `./vcpkg/vcpkg fetch nuget | tail -n 1`
+        sources add
+        -source "https://nuget.pkg.github.com/${{ github.actor }}/index.json"
+        -storepasswordincleartext
+        -name "GitHub"
+        -username "${{ github.actor }}"
+        -password "${{ secrets.GITHUB_TOKEN }}"
+
+    # Omit this step if you're using manifests
+    - name: 'vcpkg package restore'
+      working-directory: ${{ matrix.VCPKG_WORKSPACE }}
+      shell: 'bash'
+      run: >
+        ./vcpkg/vcpkg install osg sqlite3 protobuf curl gdal --triplet ${{ matrix.triplet }} 
+
+    - name: 'Upload library build log artifact'
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: osg-log
+        path: |
+          ${{ env.VCPKG_WORKSPACE }}/vcpkg/buildtrees/osg/install-x64-windows-rel-err.log
+          ${{ env.VCPKG_WORKSPACE }}/vcpkg/buildtrees/osg/install-x64-windows-rel-out.log
+        retention-days: 1
+             
+    - name: Create Build Environment
+      run: |
+        cmake -E make_directory ${{runner.workspace}}/build 
+
+    - name: Configure CMake
+      shell: bash
+      working-directory: ${{ runner.workspace }}/build
+      run: cmake $GITHUB_WORKSPACE -DWIN32_USE_MP=ON -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_TOOLCHAIN_FILE=${{ matrix.VCPKG_WORKSPACE }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+
+    - name: 'Upload cmake configure log artifact'
+      uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: cmake-log
+        path: |
+          ${{ runner.workspace }}/build/CMakeCache.txt
+        retention-days: 1
+
+    - name: Build
+      working-directory: ${{ runner.workspace }}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE
+
+    


### PR DESCRIPTION
Add github actions to build osgEarth 3.1 on windows, linux and macos. "vcpkg" only works with windows. using xcode 12 on macos. I've tested it on my osgEarth 3.1 branch. All builds successed, but one need to test/adapt it for osgEarth repository.

All action have "workflow_dispatch". To build it on push, one can change this to "push". 
Attention: The "windows action" use "vcpkg" and creates "nuget" packages on your current github account!
