### PR TITLE
JobArena: Add queueSize() public method.

### DIFF
--- a/src/osgEarth/Threading
+++ b/src/osgEarth/Threading
@@ -713,6 +713,9 @@ namespace osgEarth { namespace Threading
             const std::string& name,
             unsigned numThreads);
 
+        //! Returns the number of queued operations in the named arena
+        static size_t queueSize(const std::string& arenaName);
+
     private:
 
         //! Access the named arena

--- a/src/osgEarth/Threading.cpp
+++ b/src/osgEarth/Threading.cpp
@@ -287,7 +287,7 @@ RecursiveMutex::try_lock()
 //...................................................................
 
 unsigned osgEarth::Threading::getCurrentThreadId()
-{  
+{
 #ifdef _WIN32
   return (unsigned)::GetCurrentThreadId();
 #elif __APPLE__
@@ -486,7 +486,7 @@ void ThreadPool::stopThreads()
     }
 
     _threads.clear();
-    
+
     // Clear out the queue
     {
         Threading::ScopedMutexLock lock(_queueMutex);
@@ -579,6 +579,20 @@ JobArena::setSize(const std::string& name, unsigned numThreads)
         arena->_numThreads = numThreads;
         arena->startThreads();
     }
+}
+
+size_t
+JobArena::queueSize(const std::string& arenaName)
+{
+    osg::ref_ptr<JobArena> arena;
+    {
+        ScopedMutexLock lock(_arenas_mutex);
+        arena = _arenas[arenaName];
+    }
+    if (!arena.valid())
+        return 0u;
+    Threading::ScopedMutexLock lock(arena->_queueMutex);
+    return arena->_queue.size();
 }
 
 JobArena::JobArena(const std::string& name, unsigned numThreads) :


### PR DESCRIPTION
Using this in a client application to determine if there are asynchronous jobs running for the terrain paging.  Previously we were relying on output from the Registry's activities, but asynchronous layers don't show up there.  The easy solution for us was to query both the Registry activities, and to also query whether there are queued async jobs.  Combined, this looks good on our end user app.