### PR TITLE
Utils: Fix compile error with incorrect variable name.

### DIFF
--- a/src/osgEarth/Utils
+++ b/src/osgEarth/Utils
@@ -74,7 +74,7 @@ namespace osgEarth { namespace Util
             obj = nullptr;
             if (o == nullptr) return false;
             const Data<T>* data = dynamic_cast<const Data<T>*>(osg::getUserObject(o, name));
-            return data ? data->_obj.lock(out) : false;
+            return data ? data->_obj.lock(obj) : false;
         }
         template<typename T>
         static void set(osg::Object* o, T* obj) {


### PR DESCRIPTION
Did a quick look at the code after seeing compile failure on gcc.  I think this is what was intended.