### PR TITLE
Rex Loader: Fix gcc compile issue with reference to temporary.

### DIFF
--- a/src/osgEarthDrivers/engine_rex/Loader.cpp
+++ b/src/osgEarthDrivers/engine_rex/Loader.cpp
@@ -58,8 +58,10 @@ void
 Merger::clear()
 {
     ScopedMutexLock lock(_mutex);
-    _compileQueue.swap(CompileQueue());
-    _mergeQueue.swap(MergeQueue());
+    CompileQueue emptyCq;
+    _compileQueue.swap(emptyCq);
+    MergeQueue emptyMq;
+    _mergeQueue.swap(emptyMq);
 }
 
 void


### PR DESCRIPTION
Fixes gcc 8.3.1