### PR TITLE
Threading: Fix metrics off-by-one count, fix totalJobsRunning call.

### DIFF
--- a/src/osgEarth/Threading.cpp
+++ b/src/osgEarth/Threading.cpp
@@ -789,7 +789,7 @@ int
 JobArena::Metrics::totalJobsPending() const
 {
     int count = 0;
-    for (int i = 0; i < maxArenaIndex; ++i)
+    for (int i = 0; i <= maxArenaIndex; ++i)
         if (arena(i).active)
             count += arena(i).numJobsPending;
     return count;
@@ -799,9 +799,9 @@ int
 JobArena::Metrics::totalJobsRunning() const
 {
     int count = 0;
-    for (int i = 0; i < maxArenaIndex; ++i)
+    for (int i = 0; i <= maxArenaIndex; ++i)
         if (arena(i).active)
-            count += arena(i).numJobsPending;
+            count += arena(i).numJobsRunning;
     return count;
 }
 
@@ -809,7 +809,7 @@ int
 JobArena::Metrics::totalJobsCanceled() const
 {
     int count = 0;
-    for (int i = 0; i < maxArenaIndex; ++i)
+    for (int i = 0; i <= maxArenaIndex; ++i)
         if (arena(i).active)
             count += arena(i).numJobsCanceled;
     return count;


### PR DESCRIPTION
`maxArenaIndex` stores the maximum index, e.g. `7` for an array of 8 arenas.  There was an off-by-one issue that was causing asynchronously loading layers to not be counted because they were the last in my list of arenas.  I also spotted a minor type in `totalJobsRunning()`.