### PR TITLE
DrapingTechnique: Forward declare friend MapNode.

### DIFF
--- a/src/osgEarth/DrapingTechnique
+++ b/src/osgEarth/DrapingTechnique
@@ -32,6 +32,7 @@
 
 namespace osgEarth
 {
+    class MapNode;
     class TerrainEngineNode;
 }
 


### PR DESCRIPTION
gcc (sometimes?) requires declaration of the class prior to friend declaration.  MSVC lets the friend declaration also declare the class.  This fixes the build for me on GCC 8.3.1.