### PR TITLE
WMS: Avoid nullptr dereference on wms_srs.  Avoid soft assert on Profile::create() with nullptr srs

### DIFF
--- a/src/osgEarth/WMS.cpp
+++ b/src/osgEarth/WMS.cpp
@@ -573,20 +573,23 @@ WMS::Driver::open(osg::ref_ptr<const Profile>& profile,
         if (!result.valid())
         {
             const SpatialReference* srs = SpatialReference::create(_srsToUse);
-            GeoExtent totalExtent(srs);
-            for (DataExtentList::const_iterator itr = dataExtents.begin(); itr != dataExtents.end(); ++itr)
+            if (srs)
             {
-                GeoExtent dataExtent = *itr;
-                GeoExtent nativeExtent;
-                dataExtent.transform(srs, nativeExtent);
-                totalExtent.expandToInclude(nativeExtent);
+                GeoExtent totalExtent(srs);
+                for (DataExtentList::const_iterator itr = dataExtents.begin(); itr != dataExtents.end(); ++itr)
+                {
+                    GeoExtent dataExtent = *itr;
+                    GeoExtent nativeExtent;
+                    dataExtent.transform(srs, nativeExtent);
+                    totalExtent.expandToInclude(nativeExtent);
+                }
+                result = Profile::create(srs, totalExtent.xMin(), totalExtent.yMin(), totalExtent.xMax(), totalExtent.yMax());
             }
-            result = Profile::create(srs, totalExtent.xMin(), totalExtent.yMin(), totalExtent.xMax(), totalExtent.yMax());
         }
     }
 
     // Last resort: create a global extent profile (only valid for global maps)
-    if (!result.valid() && wms_srs->isGeographic())
+    if (!result.valid() && wms_srs.valid() && wms_srs->isGeographic())
     {
         result = osgEarth::Registry::instance()->getGlobalGeodeticProfile();
     }


### PR DESCRIPTION
Was getting a crash with a WMS server that reported ESPG:26915 SRS, and my system returns nullptr when trying to create.  This patch avoids a `nullptr` dereference on `wms_srs` in the lower portion, that was crashing the application.

Afterwards I was still getting a soft assert in Profile::create() due to the null SRS.  I protected against that too.