### PR TITLE
Change webp -> libwebp in build.md

### DIFF
--- a/docs/source/build.md
+++ b/docs/source/build.md
@@ -21,7 +21,7 @@ vcpkg install osg:x64-windows gdal:x64-windows curl:x64-windows
 For full functionality, you can install optional dependences as well:
 
 ```
-vcpkg install sqlite3:x64-windows protobuf:x64-windows geos:x64-windows blend2d:x64-windows webp:x64-windows basisu:x64-windows draco:x64-windows libzip:x64-windows
+vcpkg install sqlite3:x64-windows protobuf:x64-windows geos:x64-windows blend2d:x64-windows libwebp:x64-windows basisu:x64-windows draco:x64-windows libzip:x64-windows
 ```
 
 This will take awhile the first time you run it as this pulls down lots of dependencies, so go get a cup of coffee.


### PR DESCRIPTION
The instructions say to install the optional dependency `webp:x64-windows` which throws the error:

```
Error: while loading web:
The port directory (C:\src\vcpkg\ports\webp) does not exist
Error: failed to load port from C:\src\vcpkg\ports\webp
Note: Updating vcpkg by rerunning bootstrap-vcpkg may resolve this failure.
```

Changing the package name to `libwebp:x64-windows` removes the error.  Was the package name changed recently?  I'm not certain that this is the correct fix, so someone in-the-know should verify that it is.