### PR TITLE
Threading: Initialize atomic<int> values to 0 in constructor.

### DIFF
--- a/src/osgEarth/Threading
+++ b/src/osgEarth/Threading
@@ -751,7 +751,7 @@ namespace osgEarth { namespace Threading
                 std::atomic<int> numJobsRunning;
                 std::atomic<int> numJobsCanceled;
 
-                Arena() : active(false) { }
+                Arena() : active(false), concurrency(0), numJobsPending(0), numJobsRunning(0), numJobsCanceled(0) { }
                 void free() {
                     active = false, numJobsPending = 0, numJobsRunning = 0,
                         numJobsCanceled = 0;


### PR DESCRIPTION
On MSVC 2019 and release mode MSVC 2017, the `atomic<int>` was initializing to 0 as the code expects already.  But on debug MSVC 2017, I was seeing random values.  This meant that the metrics were not starting at 0, and therefore not useful.  This fixes that problem. 