### PR TITLE
rtree: Fix typename for gcc build.

### DIFF
--- a/src/osgEarth/rtree.h
+++ b/src/osgEarth/rtree.h
@@ -642,8 +642,8 @@ int RTREE_QUAL::KNNSearch(
     // priority queue that puts smallest distances first
     std::priority_queue<
         KNNData, 
-        std::vector<typename KNNData>,
-        std::greater<typename KNNData>> queue;
+        typename std::vector<KNNData>,
+        typename std::greater<KNNData>> queue;
 
     ELEMTYPE max_dist_squared = maxDistance * maxDistance;
 


### PR DESCRIPTION
Quick syntax fix complained on by g++ 8.3