### PR TITLE
MapboxGLImageLayer: Fixed capitalization in CMake for Linux

### DIFF
--- a/src/osgEarth/CMakeLists.txt
+++ b/src/osgEarth/CMakeLists.txt
@@ -177,7 +177,7 @@ SET(LIB_PUBLIC_HEADERS
     LocalTangentPlane
     Math
     Map
-    MapBoxGLImageLayer
+    MapboxGLImageLayer
     MapCallback
     MapInfo
     MapModelChange
@@ -564,7 +564,7 @@ set(TARGET_SRC
     LocalTangentPlane.cpp
     Math.cpp
     Map.cpp
-    MapBoxGLImageLayer.cpp
+    MapboxGLImageLayer.cpp
     MapCallback.cpp
     MapInfo.cpp
     MapNode.cpp


### PR DESCRIPTION
Works fine on Windows.  Linux complains because the 'b' in MapboxGLImageLayer is lowercase in the filename but not in CMakeLists.txt file.