### PR TITLE
fix build issue with tinygltf on MacOS/XCode

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,8 +39,6 @@ jobs:
         # patch for opengl warnings
         macos_xcode_defs="ADD_DEFINITIONS(-DGL_SILENCE_DEPRECATION=1)\nadd_compile_options(-Wno-inconsistent-missing-override)\n"
         echo -e "${macos_xcode_defs}\n$(cat ${{runner.workspace}}/osgearth/src/CMakeLists.txt)" > ${{runner.workspace}}/osgearth/src/CMakeLists.txt
-        # gltf doesn't compile
-        sed -i '' "s/add_subdirectory(gltf)//g" ${{runner.workspace}}/osgearth/src/osgEarthDrivers/CMakeLists.txt
         cmake -E make_directory ${{runner.workspace}}/build
 
     - name: Configure CMake

--- a/src/osgEarthDrivers/gltf/ReaderWriterGLTF.cpp
+++ b/src/osgEarthDrivers/gltf/ReaderWriterGLTF.cpp
@@ -33,6 +33,7 @@
 #define TINYGLTF_USE_RAPIDJSON
 #define TINYGLTF_USE_RAPIDJSON_CRTALLOCATOR
 
+#include <cmath>
 #include "tiny_gltf.h"
 using namespace tinygltf;
 

--- a/src/third_party/tinygltf/tiny_gltf.h
+++ b/src/third_party/tinygltf/tiny_gltf.h
@@ -6182,6 +6182,13 @@ static void SerializeNumberProperty(const std::string &key, T number,
   JsonAddMember(obj, key.c_str(), json(number));
 }
 
+#ifdef TINYGLTF_USE_RAPIDJSON
+template <>
+void SerializeNumberProperty(const std::string &key, size_t number, json &obj) {
+  JsonAddMember(obj, key.c_str(), json(static_cast<uint64_t>(number)));
+}
+#endif
+
 template <typename T>
 static void SerializeNumberArrayProperty(const std::string &key,
                                          const std::vector<T> &value,


### PR DESCRIPTION
This is the simplest fix to build the current integrated version of tinygltf with MacOS/XCode. Future fixes need to port tinygltf to >=2.5