### PR TITLE
Collect Triangles: Fix 64-bit Linux compile error with downcast.

### DIFF
--- a/src/applications/osgearth_collecttriangles/osgearth_collecttriangles.cpp
+++ b/src/applications/osgearth_collecttriangles/osgearth_collecttriangles.cpp
@@ -209,7 +209,7 @@ struct CollectTrianglesVisitor : public osg::NodeVisitor
     {
         if (intersects(drawable))
         {
-            Random prng((unsigned int)&drawable);
+            Random prng(static_cast<unsigned int>(reinterpret_cast<uint64_t>(&drawable)));
             osg::Vec4 color(prng.next(), prng.next(), prng.next(), 1.0f);
 
             osg::TriangleFunctor<CollectTriangles> triangleCollector;


### PR DESCRIPTION
Fixes an error when building x64 Linux with gcc 8.3:

```
/usr/people/github/osgearth/src/applications/osgearth_collecttriangles/osgearth_collecttriangles.cpp:212:65: error: cast from ‘osg::Drawable*’ to ‘unsigned int’ loses precision [-fpermissive]
             Random prng(reinterpret_cast<unsigned int>(&drawable));
```