### PR TITLE
Valgrind fixes: ~Map is now protected because it is a ref_ptr; unused…

### DIFF
--- a/src/osgEarth/ElevationPool
+++ b/src/osgEarth/ElevationPool
@@ -64,7 +64,7 @@ namespace osgEarth
             //! @param size Cache size
             WorkingSet(unsigned size =32u);
 
-            //! Assign a specific set of elevation layer to use 
+            //! Assign a specific set of elevation layer to use
             //! for sampling. Usually this is unnecessary as the Pool
             //! will synchronize with the map set by setMap, but you
             //! may want to use a custom Pool with a specific subset
@@ -153,7 +153,7 @@ namespace osgEarth
         //! @param ws Optional working set (can be NULL)
         //! @param progress Optional progress callback
         ElevationSample getSample(
-            const GeoPoint& p, 
+            const GeoPoint& p,
             const Distance& resolution,
             WorkingSet* ws,
             ProgressCallback* progress =nullptr);
@@ -211,6 +211,7 @@ namespace osgEarth
         //! Invalidates all caches in the ElevationPool
         void clear();
 
+    protected:
         //! Destructor
         virtual ~ElevationPool();
 
@@ -245,12 +246,12 @@ namespace osgEarth
             void onMapModelChanged(const MapModelChange&);
             ElevationPool* _pool;
         };
-        friend struct MapCallbackAdapter; 
+        friend struct MapCallbackAdapter;
 
         osg::ref_ptr<MapCallbackAdapter> _mapCallback;
 
         ElevationLayerVector _elevationLayers;
-        
+
         std::atomic<int> _workers;
 
         int getElevationRevision(const Map* map) const;
@@ -260,9 +261,9 @@ namespace osgEarth
         void refresh(const Map*);
 
         ElevationSample getSample(
-            const GeoPoint& p, 
-            unsigned maxLOD, 
-            const Map* map, 
+            const GeoPoint& p,
+            unsigned maxLOD,
+            const Map* map,
             WorkingSet* ws,
             ProgressCallback* progress);
 
@@ -270,8 +271,8 @@ namespace osgEarth
         int getLOD(double x, double y) const;
 
         osg::ref_ptr<ElevationTexture> getOrCreateRaster(
-            const Internal::RevElevationKey& key, 
-            const Map* map, 
+            const Internal::RevElevationKey& key,
+            const Map* map,
             bool acceptLowerRes,
             WorkingSet* ws,
             ProgressCallback* progress);

--- a/src/osgEarth/ElevationPool.cpp
+++ b/src/osgEarth/ElevationPool.cpp
@@ -80,9 +80,13 @@ ElevationPool::ElevationPool() :
     _mapCallback = new MapCallbackAdapter();
 }
 
+typedef RTree<unsigned, double, 2> MaxLevelIndex;
+
 ElevationPool::~ElevationPool()
 {
     setMap(NULL);
+    if (_index)
+        delete static_cast<MaxLevelIndex*>(_index);
 }
 
 void
@@ -125,8 +129,6 @@ ElevationPool::getElevationRevision(const Map* map) const
             revision += i->getRevision();
     return revision;
 }
-
-typedef RTree<unsigned, double, 2> MaxLevelIndex;
 
 void
 ElevationPool::sync(const Map* map, WorkingSet* ws)

--- a/src/osgEarth/Map
+++ b/src/osgEarth/Map
@@ -35,7 +35,7 @@ namespace osgEarth
 {
     /**
      * Map is the main data model. A Map hold a collection of
-     * Layers, each of which provides data of some kind to the 
+     * Layers, each of which provides data of some kind to the
      * overall Map. Use a MapNode to render the contents of a
      * Map.
      */
@@ -127,7 +127,7 @@ namespace osgEarth
         //! and returns the corresponding revision number.
         template<typename T>
         Revision getLayers(
-            std::vector< osg::ref_ptr<T> >& output, 
+            std::vector< osg::ref_ptr<T> >& output,
             const std::function<bool(const Layer*)>& predicate) const;
 
         //! Fills the vector with references to all layers of the specified type.
@@ -251,7 +251,6 @@ namespace osgEarth
         Revision _dataModelRevision;
         osg::ref_ptr<osgDB::Options> _readOptions;
         osg::ref_ptr<ElevationPool> _elevationPool;
-        mutable ElevationPool _ElevationPool;
         osg::ref_ptr<CacheSettings> _cacheSettings;
         int _numTerrainPatchLayers;
 


### PR DESCRIPTION
… _ElevationPool removed; fixed leak of ElevationPool::_index.