### PR TITLE
MBTiles: Close database on destruction, fixing leak and #1738

### DIFF
--- a/src/osgEarth/MBTiles
+++ b/src/osgEarth/MBTiles
@@ -53,6 +53,7 @@ namespace osgEarth { namespace MBTiles
     {
     public:
         Driver();
+        virtual ~Driver();
 
         Status open(
             const std::string& name,

--- a/src/osgEarth/MBTiles.cpp
+++ b/src/osgEarth/MBTiles.cpp
@@ -332,6 +332,13 @@ MBTiles::Driver::Driver() :
     //nop
 }
 
+Driver::~Driver()
+{
+    sqlite3* database = (sqlite3*)_database;
+    if (database)
+        sqlite3_close_v2(database);
+}
+
 Status
 MBTiles::Driver::open(
     const std::string& name,


### PR DESCRIPTION
We found a leak when loading multiple .earth files in a row in the range of several megabytes. Tracked it down to missing sqlite_close statement. https://github.com/gwaldron/osgearth/issues/1738 appears to be the same issue.

After implementing this, I was able to move files on disk after the terrain closed out, and I was seeing much less memory growth over time when repeatedly loading .earth files at runtime.