### PR TITLE
Explicit namespaces added to macros to allow them to be used in derived non-osgEarth classes.

### DIFF
--- a/src/osgEarth/Config
+++ b/src/osgEarth/Config
@@ -639,10 +639,10 @@ namespace osgEarth
 //! optional property macro
 #define OE_OPTION(TYPE, NAME) \
     private: \
-    optional< TYPE > _ ## NAME ; \
+    osgEarth::optional< TYPE > _ ## NAME ; \
     public: \
-    optional< TYPE >& NAME () { return _ ## NAME; } \
-    const optional< TYPE >& NAME () const { return _ ## NAME; }
+    osgEarth::optional< TYPE >& NAME () { return _ ## NAME; } \
+    const osgEarth::optional< TYPE >& NAME () const { return _ ## NAME; }
 
 //! ref_ptr property macro
 #define OE_OPTION_REFPTR(TYPE, NAME) \

--- a/src/osgEarth/Layer
+++ b/src/osgEarth/Layer
@@ -53,8 +53,8 @@ namespace osgDB {
         OE_COMMENT("Construct layer options from serialized data") \
         MYCLASS (const osgEarth::ConfigOptions& opt) : SUPERCLASS(opt) { fromConfig(_conf); } \
         \
-        Config& _internal() { return _conf; } \
-        const Config& _internal() const { return _conf; }
+        osgEarth::Config& _internal() { return _conf; } \
+        const osgEarth::Config& _internal() const { return _conf; }
 
 
 //! Macro to use when defining a Layer class
@@ -276,7 +276,7 @@ namespace osgEarth
         virtual std::string getAttribution() const;
 
         //! Attribution to be displayed by the application
-		virtual void setAttribution(const std::string& attribution);
+        virtual void setAttribution(const std::string& attribution);
 
         //! Set a serialized user property
         void setUserProperty(
@@ -385,7 +385,7 @@ namespace osgEarth
         //! invoke layer callbacks
         void fireCallback(LayerCallback::MethodPtr);
 
-        //! mutable layer hints for the subclas to optionally access
+        //! mutable layer hints for the subclass to optionally access
         Hints& layerHints();
 
         //! MapNode will call this function when terrain resources are available.


### PR DESCRIPTION
For example, `OE_OPTION` can only be used if in osgEarth namespace, or if `using` is added to a header file. Same with `META_LayerOptions`. This fixes a compilation issue in third party code introduced by https://github.com/gwaldron/osgearth/commit/06925204e9d8266382d924d3a6732df654e1893b