### PR TITLE
TileNode: Fix naked pointer that can be dereferenced after deletion during UnloaderGroup dormant tile collection.

### DIFF
--- a/src/osgEarthDrivers/engine_rex/TileNode
+++ b/src/osgEarthDrivers/engine_rex/TileNode
@@ -102,9 +102,11 @@ namespace osgEarth { namespace REX
         void notifyOfArrival(TileNode* that);
 
         /** Returns the tile's parent; convenience function */
-        inline TileNode* getParentTile() { return _parentTile; } //.get();
-    
-        inline const TileNode* getParentTile() const { return _parentTile; } //.get();
+        inline TileNode* getParentTile() { return _parentTile.get(); } //.get();
+
+        inline const TileNode* getParentTile() const { return _parentTile.get(); } //.get();
+
+        inline bool getParentTile(osg::ref_ptr<TileNode>& parent) { return _parentTile.lock(parent); }
 
         /** Returns the SurfaceNode under this node. */
         SurfaceNode* getSurfaceNode() { return _surface.get(); }
@@ -146,10 +148,10 @@ namespace osgEarth { namespace REX
             return _imageUpdatesActive;
         }
 
-        // update-traverse this node, updating any images that require 
+        // update-traverse this node, updating any images that require
         // and update-traverse
         void update(osg::NodeVisitor& nv);
-        
+
     public: // osg::Node
 
         osg::BoundingSphere computeBound() const;
@@ -163,7 +165,7 @@ namespace osgEarth { namespace REX
     protected:
 
         TileKey _key;
-        TileNode* _parentTile;
+        osg::observer_ptr<TileNode> _parentTile;
         osg::ref_ptr<SurfaceNode>          _surface;
         osg::ref_ptr<EngineContext>        _context;
         Threading::Mutex                   _mutex;
@@ -189,7 +191,7 @@ namespace osgEarth { namespace REX
         unsigned _loadsInQueue;
         const CreateTileManifest* _nextLoadManifestPtr;
 
-        bool dirty() const { 
+        bool dirty() const {
             return _loadsInQueue > 0;
         }
 

--- a/src/osgEarthDrivers/engine_rex/Unloader.cpp
+++ b/src/osgEarthDrivers/engine_rex/Unloader.cpp
@@ -65,7 +65,7 @@ UnloaderGroup::traverse(osg::NodeVisitor& nv)
 
             // Remove them from the registry:
             _tiles->collectDormantTiles(
-                nv, 
+                nv,
                 oldestAllowableTime,
                 oldestAllowableFrame,
                 _minRange,
@@ -77,16 +77,19 @@ UnloaderGroup::traverse(osg::NodeVisitor& nv)
                 ++i)
             {
                 // may be NULL since we're removing scene graph objects as we go!
-                osg::ref_ptr<TileNode> tile = i->get();
+                osg::ref_ptr<TileNode> tile;
+                if (!i->lock(tile))
+                    continue;
 
                 if (tile.valid())
                 {
-                    TileNode* parent = tile->getParentTile();
+                    osg::ref_ptr<TileNode> parent;
+                    tile->getParentTile(parent);
 
                     // Check that this tile doesn't have any live quadtree siblings. If it does,
                     // we don't want to remove them too!
                     // GW: moved this check to the collectAbandonedTiles function where it belongs
-                    if (parent)
+                    if (parent.valid())
                     {
                         parent->removeSubTiles();
                         ++count;


### PR DESCRIPTION
Basically, during an update traversal, UnloaderGroup is going through its dead pool, after collecting dormant tiles. As it looks through the dead pool, it pulls out a tile’s parent. This is a naked pointer inside the TileNode. The parent appears to have been deleted already. Several fields are 0xdddddddd. The tile itself seems OK and valid, it’s just the parent tile that appears invalid.

I have not had success reproducing this in osgEarth examples. The crash happens during the update traversal through UnloaderGroup.