### PR TITLE
GLUtils: Remove extra class specification in front of function, fixing some builds.

### DIFF
--- a/src/osgEarth/GLUtils
+++ b/src/osgEarth/GLUtils
@@ -431,7 +431,7 @@ namespace osgEarth
 
         GLObjectPool(unsigned contextID);
 
-        static GLObjectPool* GLObjectPool::get(osg::State& state);
+        static GLObjectPool* get(osg::State& state);
 
         void watch(GLObject::Ptr);
         void releaseAll();


### PR DESCRIPTION
Building against master osgEarth I'm seeing errors due to this, on MSVC 2019. Might be related to /sdl flag, did not investigate though.