### PR TITLE
glEnableClientState: Getting pointer from osg::setGLExtensionFuncPtr() for use in GL Core profile.

### DIFF
--- a/src/osgEarth/Chonk
+++ b/src/osgEarth/Chonk
@@ -49,7 +49,7 @@ namespace osgEarth
 
     /**
      * A bindless rendering unit comprised of one VBO and one EBO.
-     * A single Chonk usually represents one drawable "Object" in 
+     * A single Chonk usually represents one drawable "Object" in
      * the scene. It can include multiple "variants" which are
      * typically used as LODs.
      */
@@ -119,7 +119,7 @@ namespace osgEarth
             DrawCommands commands;
         };
         mutable osg::buffered_object<GCState> _gs;
-        
+
         //! Gets (or creates) a draw command, possibly
         //! resolving texture handles and uploading buffers.
         const DrawCommands& getOrCreateCommands(osg::State&) const;
@@ -248,13 +248,15 @@ namespace osgEarth
             bool _cull;
             void(GL_APIENTRY * _glMultiDrawElementsIndirectBindlessNV)
                 (GLenum, GLenum, const GLvoid*, GLsizei, GLsizei, GLint);
+            void(GL_APIENTRY* _glEnableClientState)
+                (GLenum);
 
             struct PCPState {
                 GLint _passUL;
                 PCPState() : _passUL(-1) { }
             };
             mutable std::unordered_map<const void*, PCPState> _pcps;
-                
+
             GCState() : _dirty(true), _cull(true) { }
             void initialize(osg::State& state);
             void update(const Batches&, osg::State&);

--- a/src/osgEarth/Chonk.cpp
+++ b/src/osgEarth/Chonk.cpp
@@ -196,7 +196,7 @@ void compact()
 {
     const uint i = gl_GlobalInvocationID.x; // instance
     const uint variant = gl_GlobalInvocationID.y; // variant
-    
+
     float fade = input_instances[i].visibility[variant];
     if (fade < 0.15)
         return;
@@ -351,7 +351,7 @@ void main()
                 {
                     v.position = (*verts)[i] * _transformStack.top();
                 }
-                
+
                 if (colors)
                 {
                     if (colors->getBinding() == colors->BIND_PER_VERTEX)
@@ -410,7 +410,7 @@ void main()
                     {
                         int index = de->getElement(k);
                         // by using a "model-local" offset here, we can use UShort even
-                        // if our vertex array size exceeds 65535 by storing the 
+                        // if our vertex array size exceeds 65535 by storing the
                         // baseVertex in our DrawElements structure
                         _result._ebo_store.push_back(vbo_offset + index);
                     }
@@ -681,7 +681,7 @@ ChonkDrawable::setCustomCullingShader(osg::Shader* value)
     if (_s_baseShader.valid() == false)
     {
         _s_baseShader = new osg::Shader(
-            osg::Shader::COMPUTE, 
+            osg::Shader::COMPUTE,
             s_chonk_cull_compute_shader);
     }
 
@@ -719,7 +719,7 @@ ChonkDrawable::drawImplementation(osg::RenderInfo& ri) const
     }
     else if (!_batches.empty())
     {
-        // save the pcp b/c osg will not re-apply it 
+        // save the pcp b/c osg will not re-apply it
         // when we can state.apply(). boo
         auto pcp = state.getLastAppliedProgramObject();
 
@@ -833,12 +833,12 @@ osg::BoundingBox
 ChonkDrawable::computeBoundingBox() const
 {
     ScopedMutexLock lock(_m);
-    
+
     osg::BoundingBox result;
 
     for(auto& batch : _batches)
     {
-        auto& chonk = batch.first;   
+        auto& chonk = batch.first;
 
         auto& box = chonk->getBound();
         if (box.valid())
@@ -966,8 +966,14 @@ ChonkDrawable::GCState::initialize(osg::State& state)
     _vao->bind();
 
     // required in order to use BindlessNV extension
-    glEnableClientState(GL_VERTEX_ATTRIB_ARRAY_UNIFIED_NV);
-    glEnableClientState(GL_ELEMENT_ARRAY_UNIFIED_NV);
+    osg::setGLExtensionFuncPtr(
+        _glEnableClientState,
+        "glEnableClientState");
+    if (_glEnableClientState)
+    {
+        _glEnableClientState(GL_VERTEX_ATTRIB_ARRAY_UNIFIED_NV);
+        _glEnableClientState(GL_ELEMENT_ARRAY_UNIFIED_NV);
+    }
 
     const VADef formats[7] = {
         {3, GL_FLOAT,         GL_FALSE, offsetof(Chonk::VertexGPU, position)},
@@ -1013,7 +1019,7 @@ ChonkDrawable::GCState::update(
         initialize(state);
     }
 
-    // build a list of draw commands, each of which will 
+    // build a list of draw commands, each of which will
     // have N instances, one per chonk meta.
     _commands.clear();
 
@@ -1078,7 +1084,7 @@ ChonkDrawable::GCState::update(
     if (_cull)
     {
         _chonkBuf->uploadData(_chonk_variants);
-        
+
         // just reserve space if necessary.
         // this is a NOP if the buffer is already sized properly
         _instanceOutputBuf->uploadData(_instanceInputBuf->size(), nullptr);

--- a/src/osgEarthDrivers/engine_rex/LayerDrawable
+++ b/src/osgEarthDrivers/engine_rex/LayerDrawable
@@ -38,9 +38,9 @@ namespace osgEarth { namespace REX
     class TerrainRenderData;
 
     /**
-     * Drawable for single "Layer" i.e. rendering pass. 
+     * Drawable for single "Layer" i.e. rendering pass.
      * It is important that LayerDrawables be rendered in the order in which
-     * they appear. Since all LayerDrawables share a common bounds, this 
+     * they appear. Since all LayerDrawables share a common bounds, this
      * should happen automatically, but let's keep an eye out for trouble.
      */
     class LayerDrawable : public osg::Drawable
@@ -90,7 +90,7 @@ namespace osgEarth { namespace REX
         class EngineContext* _context;
 
     public: // osg::Drawable
-        
+
         void drawImplementation(osg::RenderInfo& ri) const override;
 
         // All LayerDrawables share the common terrain bounds.
@@ -133,6 +133,9 @@ namespace osgEarth { namespace REX
 
             void(GL_APIENTRY * glVertexAttribFormat)
                 (GLuint, GLint, GLenum, GLboolean, GLuint);
+
+            void(GL_APIENTRY* glEnableClientState)
+                (GLenum);
         };
 
         struct GL4RenderState
@@ -140,7 +143,7 @@ namespace osgEarth { namespace REX
             GL4RenderState();
 
             bool dirty;
-           
+
             DrawTileCommands tiles;
             std::vector<GL4Tile> tilebuf;
 
@@ -161,6 +164,6 @@ namespace osgEarth { namespace REX
     using LayerDrawableList = std::vector<osg::ref_ptr<LayerDrawable>>;
     using LayerDrawableMap = std::unordered_map<UID, osg::ref_ptr<LayerDrawable>>;
 
-} } // namespace 
+} } // namespace
 
 #endif // OSGEARTH_REX_TERRAIN_LAYER_DRAWABLE_H


### PR DESCRIPTION
The glcorearb.h does not define `glEnableClientState()`. When compiling in core profile, I cannot use `glEnableClientState()` directly. This patch allows for use of `glEnableClientState()` in core profile. I tested that it returns a valid non-NULL pointer on my NVidia card. I did not test compatibility mode because I do not have a compatibility mode build of OSG/osgEarth.