### PR TITLE
FeatureSource: Avoid null dereference in rare case where feature prof…

### DIFF
--- a/src/osgEarth/FeatureSource.cpp
+++ b/src/osgEarth/FeatureSource.cpp
@@ -425,6 +425,8 @@ FeatureSource::createFeatureCursor(
 
     else
     {
+        if (!_featureProfile)
+            return nullptr;
         GeoExtent localExtent = key.getExtent().transform(_featureProfile->getSRS());
         if (localExtent.isInvalid())
             return nullptr;


### PR DESCRIPTION
…ile is not set, such as in some cases when loading a VTPK file.