### PR TITLE
FeatureRasterizer: Fix null access on undefined glyph

### DIFF
--- a/src/osgEarth/FeatureRasterizer.cpp
+++ b/src/osgEarth/FeatureRasterizer.cpp
@@ -347,8 +347,11 @@ namespace osgEarth {
             // Compute the line width and line height
             for (auto& g : textGlyphs)
             {
-                lineWidth += g->advance * scale;
-                lineHeight += std::max(lineHeight, g->height * scale);
+                if (g.valid())
+                {
+                    lineWidth += g->advance * scale;
+                    lineHeight += std::max(lineHeight, g->height * scale);
+                }
             }
 
             // Adjust the cursor based on the alignment


### PR DESCRIPTION
Caused when loading .json files for VTPK where a style is defined like:

```
			"layout": {
				"text-size": 12,
				"text-font": [
					"Georgia Bold Italic"
				],
```

... and font "Georgia Bold Italic" is not found.