### PR TITLE
Units: remove unneeded template on qualified_double constructor

### DIFF
--- a/src/osgEarth/Units
+++ b/src/osgEarth/Units
@@ -196,17 +196,17 @@ namespace osgEarth
     class qualified_double
     {
     public:
-        qualified_double<T>( double value, const Units& units ) : _value(value), _units(units) { }
+        qualified_double( double value, const Units& units ) : _value(value), _units(units) { }
 
-        qualified_double<T>( const T& rhs ) : _value(rhs._value), _units(rhs._units) { }
+        qualified_double( const T& rhs ) : _value(rhs._value), _units(rhs._units) { }
 
         // parses the qualified number from a parseable string (e.g., "123km")
-        qualified_double<T>(const std::string& parseable, const Units& defaultUnits) : _value(0.0), _units(defaultUnits) {
+        qualified_double(const std::string& parseable, const Units& defaultUnits) : _value(0.0), _units(defaultUnits) {
             Units::parse( parseable, _value, _units, defaultUnits );
         }
 
         // loads the qualified number from an old-school config (e.g., { value="123" units="km" } )
-        qualified_double<T>( const Config& conf, const Units& defaultUnits ) : _value(0.0) {
+        qualified_double( const Config& conf, const Units& defaultUnits ) : _value(0.0) {
             if ( conf.hasValue("value") ) {
                 _value = conf.value<double>("value", 0.0);
                 if ( !Units::parse( conf.value("units"), _units ) )


### PR DESCRIPTION
Found while building with GCC 11 with the -std=c++20 flag turned on. Will cause compilation to fail, and the template on the constructor is unnecessary.