### PR TITLE
TextureArena: Fix crash on exit from accessing invalid array index.

### DIFF
--- a/src/osgEarth/TextureArena.cpp
+++ b/src/osgEarth/TextureArena.cpp
@@ -422,7 +422,7 @@ Texture::resizeGLObjectBuffers(unsigned maxSize)
 void
 Texture::releaseGLObjects(osg::State* state) const
 {
-    if (state)
+    if (state && _gs.size() > state->getContextID())
     {
         if (_gs[state->getContextID()]._gltexture != nullptr)
         {


### PR DESCRIPTION
Crashes consistently on exit on Linux. On Windows I'm seeing odd behavior but it's not crashing.