### PR TITLE
ArcGISTilePackage: Remove extraneous slash that caused ArcGIS Tile Package to fail under Linux

### DIFF
--- a/src/osgEarth/ArcGISTilePackage.cpp
+++ b/src/osgEarth/ArcGISTilePackage.cpp
@@ -391,7 +391,7 @@ GeoImage
 ArcGISTilePackageImageLayer::createImageImplementation(const TileKey& key, ProgressCallback* progress) const
 {
     std::stringstream buf;    
-    buf << osgEarth::getFullPath(options().url()->full(), "/_alllayers/");
+    buf << osgEarth::getFullPath(options().url()->full(), "_alllayers/");
     buf << "L" << padLeft(toString<unsigned int>(key.getLevelOfDetail()), 2) << "/";
 
     unsigned int colOffset = static_cast<unsigned int>(floor(static_cast<double>(key.getTileX() / _bundleSize) * _bundleSize));
@@ -537,7 +537,7 @@ GeoHeightField
 ArcGISTilePackageElevationLayer::createHeightFieldImplementation(const TileKey& key, ProgressCallback* progress) const
 {
     std::stringstream buf;
-    buf << osgEarth::getFullPath(options().url()->full(), "/_alllayers/");
+    buf << osgEarth::getFullPath(options().url()->full(), "_alllayers/");
     buf << "L" << padLeft(toString<unsigned int>(key.getLevelOfDetail()), 2) << "/";
 
     unsigned int colOffset = static_cast<unsigned int>(floor(static_cast<double>(key.getTileX() / _bundleSize) * _bundleSize));


### PR DESCRIPTION
`osgEarth::getFullPath()` behaves differently when absolute paths are passed into the second parameter. This removes the leading slash, which is used to indicate absolute path on Linux, fixing display of ArcGIS Tile Packages on Linux.