### PR TITLE
Fix target names in osgEarthConfig.cmake.in

### DIFF
--- a/osgEarthConfig.cmake.in
+++ b/osgEarthConfig.cmake.in
@@ -5,53 +5,54 @@ set(OSGEARTH_VERSION 3.1.0)
 set(XPREFIX OSGEARTH)
 
 
-
-if (osgearth_USE_STATIC_LIBS)
+if (osgEarth_USE_STATIC_LIBS)
     set(XPREFIX ${XPREFIX}_STATIC)
 endif()
 
-set(osgearth_DEFINITIONS ${${XPREFIX}_CFLAGS})
+set(osgEarth_DEFINITIONS ${${XPREFIX}_CFLAGS})
 
-find_path(osgearth_INCLUDE_DIR
-    NAMES OSGEARTH/RTREE.H
+find_path(osgEarth_INCLUDE_DIR
+    NAMES osgEarth/rtree.h
     HINTS ${${XPREFIX}_INCLUDE_DIRS}
 )
 
-set(OSGEARTH_NAMES osgearth)
+set(OSGEARTH_NAMES osgEarth)
 
-find_library(osgearth_LIBRARY
+find_library(osgEarth_LIBRARY
     NAMES ${OSGEARTH_NAMES}
     HINTS ${${XPREFIX}_LIBRARY_DIRS}
 )
 
-set(osgearth_LIBRARIES    ${osgearth_LIBRARY})
-set(osgearth_LIBRARY_DIRS ${${XPREFIX}_LIBRARY_DIRS})
-set(osgearth_LIBRARY_DIR  ${osgearth_LIBRARY_DIRS})
-set(osgearth_INCLUDE_DIRS ${osgearth_INCLUDE_DIR})
-set(osgearth_LDFLAGS      ${${XPREFIX}_LDFLAGS})
+set(osgEarth_LIBRARIES    ${osgEarth_LIBRARY})
+set(osgEarth_LIBRARY_DIRS ${${XPREFIX}_LIBRARY_DIRS})
+set(osgEarth_LIBRARY_DIR  ${osgEarth_LIBRARY_DIRS})
+set(osgEarth_INCLUDE_DIRS ${osgEarth_INCLUDE_DIR})
+set(osgEarth_LDFLAGS      ${${XPREFIX}_LDFLAGS})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(osgearth DEFAULT_MSG
-    osgearth_LIBRARY
-    osgearth_INCLUDE_DIR
+find_package_handle_standard_args(osgEarth DEFAULT_MSG
+    osgEarth_LIBRARY
+    osgEarth_INCLUDE_DIR
 )
 
-string (REPLACE ";" " " osgearth_LDFLAGS "${osgearth_LDFLAGS}")
+if (osgEarth_FOUND)
+    string (REPLACE ";" " " osgEarth_LDFLAGS "${osgEarth_LDFLAGS}")
 
-set_target_properties(osgearth
-  PROPERTIES
-  IMPORTED_LOCATION             "${osgearth_LIBRARIES}"
-  INTERFACE_INCLUDE_DIRECTORIES "${osgearth_INCLUDE_DIRS}"
-  INTERFACE_LINK_LIBRARIES      "${osgearth_LDFLAGS}"
-  INTERFACE_COMPILE_OPTIONS     "${osgearth_DEFINITIONS}"
-)
+    add_library(osgEarth UNKNOWN IMPORTED)
 
-  message(STATUS "osgearth_FOUND: ${osgearth_FOUND}")
-  message(STATUS "osgearth_INCLUDE_DIRS: ${osgearth_INCLUDE_DIRS}")
-  message(STATUS "osgearth_LIBRARIES: ${osgearth_LIBRARIES}")
-  message(STATUS "osgearth_LDFLAGS: ${osgearth_LDFLAGS}")
-  message(STATUS "osgearth_DEFINITIONS: ${osgearth_DEFINITIONS}")
+    set_target_properties(osgEarth
+      PROPERTIES
+      IMPORTED_LOCATION             "${osgEarth_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${osgEarth_INCLUDE_DIRS}"
+      INTERFACE_LINK_LIBRARIES      "${osgEarth_LDFLAGS}"
+      INTERFACE_COMPILE_OPTIONS     "${osgEarth_DEFINITIONS}"
+    )
+endif()
 
+message(STATUS "osgEarth_FOUND: ${osgEarth_FOUND}")
+message(STATUS "osgEarth_INCLUDE_DIRS: ${osgEarth_INCLUDE_DIRS}")
+message(STATUS "osgEarth_LIBRARIES: ${osgEarth_LIBRARIES}")
+message(STATUS "osgEarth_LDFLAGS: ${osgEarth_LDFLAGS}")
+message(STATUS "osgEarth_DEFINITIONS: ${osgEarth_DEFINITIONS}")
 
-
-check_required_components(osgearth)
+check_required_components(osgEarth)


### PR DESCRIPTION
The osgEarthConfig.cmake.in file does not create an `osgEarth` target, which causes configuration to fail in CMake upon calling `set_target_properties(osgearth ...)` on a nonexistent target here: https://github.com/gwaldron/osgearth/blob/218e23fb7fee6443dcfeec3d60f0d2c79dbbedde/osgEarthConfig.cmake.in#L41

---

In addition, I believe the variable and target names are not capitalized correctly. As defined in src/osgEarth/CMakeLists.txt, the library name is "osgEarth".
https://github.com/gwaldron/osgearth/blob/218e23fb7fee6443dcfeec3d60f0d2c79dbbedde/src/osgEarth/CMakeLists.txt#L53

However, all variable and target names in osgEarthConfig.cmake.in use the lowercase "osgearth", which can result in unexpected behavior or configuration errors. With standard variables such as `<library_name>_INCLUDE_DIRS`, `<library_name>` is expected to exactly match the spelling of the target.

---

The final issue I encountered is the capitalization of the path provided to `find_path()`. This can cause problems finding the path to osgEarth. I've observed that it does not find the correct path on a system running Ubuntu 20.04.
https://github.com/gwaldron/osgearth/blob/218e23fb7fee6443dcfeec3d60f0d2c79dbbedde/osgEarthConfig.cmake.in#L16