### PR TITLE
ImageUtils nnUVtoST: Replace IN and OUT type with T_IN and T_OUT to a…

### DIFF
--- a/src/osgEarth/ImageUtils
+++ b/src/osgEarth/ImageUtils
@@ -359,10 +359,10 @@ namespace osgEarth { namespace Util
         static osg::Texture2DArray* makeTexture2DArray(osg::Image* image);
 
         //! Convert u,v [0..1] into s,t [pixels] with nearest neighbor sampling.
-        template<typename IN, typename OUT>
-        static void nnUVtoST(IN u, IN v, OUT& s, OUT& t, unsigned width, unsigned height) {
-            const IN umin = 1.0 / (2.0 * width);
-            const IN vmin = 1.0 / (2.0 * height);
+        template<typename T_IN, typename T_OUT>
+        static void nnUVtoST(T_IN u, T_IN v, T_OUT& s, T_OUT& t, unsigned width, unsigned height) {
+            const T_IN umin = 1.0 / (2.0 * width);
+            const T_IN vmin = 1.0 / (2.0 * height);
             s = u<umin ? 0 : u>(1.0 - umin) ? width - 1 : (int)floor(u*(double)width);
             t = v<vmin ? 0 : v>(1.0 - vmin) ? height - 1 : (int)floor(v*(double)height);
         }


### PR DESCRIPTION
…void define conflicts with Windows SDK headers wincrypt.h, minwindef.h, bcrypt.h, and rpcdce.h.