### PR TITLE
ImGui: Build fixes against gcc 4.8.5

### DIFF
--- a/src/osgEarth/ImGui/LayersGUI
+++ b/src/osgEarth/ImGui/LayersGUI
@@ -65,6 +65,8 @@ namespace osgEarth {
         {
             AddWMSDialog()
             {
+                strcpy(url, "http://readymap.org/readymap/tiles");
+                memset(name, 0, sizeof(name));
             }
 
             void draw(osgEarth::MapNode* mapNode)
@@ -177,8 +179,8 @@ namespace osgEarth {
             }
 
             bool visible = false;
-            char url[128] = "http://readymap.org/readymap/tiles";
-            char name[1024] = "";
+            char url[128];
+            char name[1024];
             osg::ref_ptr<WMS::Capabilities> capabilities;
             osg::ref_ptr< WMS::Layer > selectedWMSLayer;
         };
@@ -837,7 +839,7 @@ namespace osgEarth {
                                             }
                                             else
                                             {
-                                                ImGui::Text("%s", _imageLayerValueUnderMouse->message());
+                                                ImGui::Text("%s", _imageLayerValueUnderMouse->message().c_str());
                                             }
                                         }
                                         else

--- a/src/osgEarth/ImGui/NetworkMonitorGUI
+++ b/src/osgEarth/ImGui/NetworkMonitorGUI
@@ -32,10 +32,9 @@ namespace osgEarth {
             NetworkMonitorGUI() :
                 BaseGUI("Network Monitor"),
                 _showOnlyActiveRequests(true),
-                _showOnlyFailedRequests(false),
-                _filter("")
+                _showOnlyFailedRequests(false)
             {
-
+                memset(_filter, 0, sizeof(_filter));
             }
 
             void draw(osg::RenderInfo& ri) override

--- a/src/osgEarth/ImGui/TerrainEditGUI
+++ b/src/osgEarth/ImGui/TerrainEditGUI
@@ -90,7 +90,7 @@ namespace osgEarth
                     {
                         float a = 2.0f*(lm_iter.u() - 0.5f);
                         float b = 2.0f*(lm_iter.v() - 0.5f);
-                        float d = clamp(sqrt((a*a) + (b*b)), 0.0f, 1.0f);
+                        float d = clamp(static_cast<float>(sqrt((a*a) + (b*b))), 0.0f, 1.0f);
                         value.set(rugged, dense, lush, (1.0f - (d*d)) * lifemapMix);
 
                         writeLifeMap(value, lm_iter.s(), lm_iter.t());


### PR DESCRIPTION
We are receiving reports that SIMDIS SDK (building against osgEarth) is failing to build on a C++11 compiler. Though RHEL-7's native gcc 4.8.5 isn't exactly C++11, it is close. After this set of changes in osgEarth and a few other changes in SIMDIS SDK, we can get a successful build.