### PR TITLE
EarthManipulator: Decouple Pen/Touch Drag from Left Mouse Drag

### DIFF
--- a/src/osgEarth/EarthManipulator
+++ b/src/osgEarth/EarthManipulator
@@ -79,7 +79,8 @@ namespace osgEarth { namespace Util
             EVENT_MOUSE_CLICK        = osgGA::GUIEventAdapter::USER << 1,
             EVENT_MULTI_DRAG         = osgGA::GUIEventAdapter::USER << 2,   // drag with 2 fingers
             EVENT_MULTI_PINCH        = osgGA::GUIEventAdapter::USER << 3,   // pinch with 2 fingers
-            EVENT_MULTI_TWIST        = osgGA::GUIEventAdapter::USER << 4    // drag 2 fingers in different directions
+            EVENT_MULTI_TWIST        = osgGA::GUIEventAdapter::USER << 4,   // drag 2 fingers in different directions
+            EVENT_TOUCH_DRAG         = osgGA::GUIEventAdapter::USER << 5    // drag 1 finger or pen with touch-screen
         };
 
         /** Bindable mouse buttons. */
@@ -338,6 +339,9 @@ namespace osgEarth { namespace Util
 
 
             void bindMultiDrag(
+                ActionType action, const ActionOptions& =ActionOptions() );
+
+            void bindTouchDrag(
                 ActionType action, const ActionOptions& =ActionOptions() );
 
             /**

--- a/src/osgEarth/EarthManipulator.cpp
+++ b/src/osgEarth/EarthManipulator.cpp
@@ -479,6 +479,14 @@ EarthManipulator::Settings::bindMultiDrag(ActionType action, const ActionOptions
         Action( action, options ) );
 }
 
+void
+EarthManipulator::Settings::bindTouchDrag(ActionType action, const ActionOptions& options)
+{
+    bind(
+        InputSpec(EarthManipulator::EVENT_TOUCH_DRAG, 0, 0),
+        Action(action, options));
+}
+
 const EarthManipulator::Action&
 EarthManipulator::Settings::getAction(int event_type, int input_mask, int modkey_mask) const
 {
@@ -674,6 +682,7 @@ EarthManipulator::configureDefaultSettings()
     options.clear();
     _settings->bindTwist( ACTION_ROTATE, options );
     _settings->bindMultiDrag( ACTION_ROTATE, options );
+    _settings->bindTouchDrag( ACTION_PAN, options );
 
     //_settings->setThrowingEnabled( false );
     _settings->setLockAzimuthWhilePanning( true );
@@ -2127,8 +2136,8 @@ EarthManipulator::parseTouchEvents( TouchEvents& output )
 
     if (_touchPointQueue.size() == 2 )
     {
-        if (_touchPointQueue[0].size()   == 2 &&     // two fingers
-            _touchPointQueue[1].size()   == 2)       // two fingers
+        if (_touchPointQueue[0].size()   >= 2 &&     // two fingers
+            _touchPointQueue[1].size()   >= 2)       // two fingers
         {
             MultiTouchPoint& p0 = _touchPointQueue[0];
             MultiTouchPoint& p1 = _touchPointQueue[1];
@@ -2216,8 +2225,7 @@ EarthManipulator::parseTouchEvents( TouchEvents& output )
             {
                 output.push_back(TouchEvent());
                 TouchEvent& ev = output.back();
-                ev._eventType = EVENT_MOUSE_DRAG;
-                ev._mbmask = osgGA::GUIEventAdapter::LEFT_MOUSE_BUTTON;
+                ev._eventType = EVENT_TOUCH_DRAG;
                 ev._dx =  (p1[0].x - p0[0].x) * sens;
                 ev._dy =  (p1[0].y - p0[0].y) * sens;
             }


### PR DESCRIPTION
Touch improvements on `EarthManipulator`, including:
* `Settings` gets new `bindTouchDrag()`, defaulting to `ACTION_PAN`. New `EVENT_TOUCH_DRAG` to support this.
* Single touch now uses the new `EVENT_TOUCH_DRAG` instead of `EVENT_MOUSE_DRAG` from left mouse
* Multi-touch now works with 2 or more fingers, rather than just 2 fingers, ensuring that single touch/drag only ever gets a single finger.

This is most useful in cases where the `EarthManipulator` settings for left click/drag are different from what you'd want in the touch/drag case. This is the case with SIMDIS SDK, where we change the default left drag operation but doing so makes touch operations basically unusable.

This does introduce a new enum and public method, and I recommend an osgEarth API version update if/when this is merged in (I can add it to PR if you want).