### PR TITLE
ShaderUtils: _uniformAlt now properly added into state set

### DIFF
--- a/src/osgEarth/ShaderUtils.cpp
+++ b/src/osgEarth/ShaderUtils.cpp
@@ -332,7 +332,7 @@ ArrayUniform::attach( const std::string& name, osg::Uniform::Type type, osg::Sta
         _uniform    = new osg::Uniform( type, name, size );
         _uniformAlt = new osg::Uniform( type, name + "[0]", size );
         stateSet->addUniform( _uniform.get() );
-        //stateSet->addUniform( _uniformAlt.get() );
+        stateSet->addUniform( _uniformAlt.get() );
     }
 
     _stateSet = stateSet;


### PR DESCRIPTION
Uncommented code block that was commented out in 86a72d202. By commenting this out, SIMDIS SDK's capability to accept multiple projectors on a single entity is broken. By uncommenting it, the functionality is fixed again. It looks like this might have been commented out temporarily / accidentally in that changeset to test the impacts of other fixes in the code.