### PR TITLE
EarthManipulator: Multi-touch can now clear tether

### DIFF
--- a/src/osgEarth/EarthManipulator.cpp
+++ b/src/osgEarth/EarthManipulator.cpp
@@ -79,7 +79,7 @@ namespace
                 }
                 for(unsigned i=start; i<nodePaths[0].size(); ++i)
                     p.push_back(nodePaths[0][i]);
-                
+
                 m = osg::computeLocalToWorld(p);
                 //m = osg::computeLocalToWorld( nodePaths[0] );
             }
@@ -1609,7 +1609,7 @@ EarthManipulator::handle(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapt
 
     //double time_s_now = osg::Timer::instance()->time_s();
     _time_s_now = view->getFrameStamp()->getReferenceTime();
-    
+
     if ( ea.getEventType() == osgGA::GUIEventAdapter::FRAME )
     {
         if ( _node.valid() )
@@ -1622,7 +1622,7 @@ EarthManipulator::handle(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapt
                 osg::ref_ptr<MapNode> mapNode;
                 if (_mapNode.lock(mapNode))
                 {
-                    _mapNodeFrame = osg::computeLocalToWorld(mapNode->getParentalNodePaths()[0]); 
+                    _mapNodeFrame = osg::computeLocalToWorld(mapNode->getParentalNodePaths()[0]);
                     _mapNodeFrameInverse.invert(_mapNodeFrame);
                 }
             }
@@ -1699,9 +1699,9 @@ EarthManipulator::handle(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapt
     // form the current Action based on the event type:
     Action action = ACTION_NULL;
 
-    // if tethering is active, check to see whether the incoming event
+    // if tethering is active, check to see whether the incoming mouse event
     // will break the tether.
-    if (isTethering() && ea.getEventType() != ea.FRAME)
+    if (isTethering() && ea.getEventType() != ea.FRAME && !ea.isMultiTouchEvent())
     {
         const ActionTypeVector& atv = _settings->getBreakTetherActions();
         if ( atv.size() > 0 )
@@ -1739,6 +1739,16 @@ EarthManipulator::handle(const osgGA::GUIEventAdapter& ea, osgGA::GUIActionAdapt
             for( TouchEvents::iterator i = te.begin(); i != te.end(); ++i )
             {
                 action = _settings->getAction(i->_eventType, i->_mbmask, 0);
+
+                // Deal with tether breaking for touch
+                if (isTethering())
+                {
+                    const ActionTypeVector& atv = _settings->getBreakTetherActions();
+                    if ( std::find(atv.begin(), atv.end(), action._type) != atv.end() )
+                    {
+                        clearViewpoint();
+                    }
+                }
 
                 if (action._type != ACTION_NULL)
                 {
@@ -2364,7 +2374,7 @@ EarthManipulator::updateCamera(osg::Camera& camera)
 
 
     osgGA::CameraManipulator::updateCamera(camera);
-    
+
     // Invoke the callback once the camera's been udpated for the ensuing render:
     if (_updateCameraCallback.valid())
     {
@@ -2675,7 +2685,7 @@ EarthManipulator::zoom( double dx, double dy, osg::View* in_view )
     bool onEarth = true;
     if (_lastPointOnEarth != zero)
     {
-        // Use the start location (for continuous zoom) 
+        // Use the start location (for continuous zoom)
         target = _lastPointOnEarth;
     }
     else
@@ -2703,7 +2713,7 @@ EarthManipulator::zoom( double dx, double dy, osg::View* in_view )
             double ratio = delta/_distance;
 
             // xform target point into the current focal point's local frame,
-            // and adjust the zoom ratio to account for the difference in 
+            // and adjust the zoom ratio to account for the difference in
             // target distance based on the earth's curvature...approximately!
             osg::Vec3d targetInLocalFrame = _centerRotation.conj()*target;
             double crRatio = _center.length() / targetInLocalFrame.z();
@@ -2736,7 +2746,7 @@ EarthManipulator::zoom( double dx, double dy, osg::View* in_view )
             double newDistance = _distance*scale;
             double delta = _distance - newDistance;
             double ratio = delta/_distance;
-            
+
             osg::Vec3d newEye = eye + eyeToTargetVec*delta;
 
             setByLookAt(newEye, newEye+(at-eye), up);


### PR DESCRIPTION
Multi-touch processes touch events into the `TouchEvents` vector, which then (previously) skipped the is-tether-action check. Now we skip the early tether check on multi-touch, and later on check the `TouchEvents` to see if they match. Tested against SIMDIS SDK with tethered insets, watching tether break for a pan event but not a rotate event.