### PR TITLE
GeoPoint: Avoid null access on SRS

### DIFF
--- a/src/osgEarth/GeoData.cpp
+++ b/src/osgEarth/GeoData.cpp
@@ -360,6 +360,8 @@ GeoPoint::transformResolution(const Distance& resolution, const Units& outUnits)
 bool
 GeoPoint::makeGeographic()
 {
+    if (!_srs)
+        return false;
     if (_srs->isGeographic())
         return true;
     else


### PR DESCRIPTION
Avoids a null access on SRS that can be triggered with the following code block:

```
osgEarth::Style style;
auto label = new osgEarth::LabelNode("crash", style);
```

Introduced in https://github.com/gwaldron/osgearth/commit/9454d221