### PR TITLE
AnnotationsGUI: Fix namespace errors

### DIFF
--- a/src/osgEarth/ImGui/AnnotationsGUI
+++ b/src/osgEarth/ImGui/AnnotationsGUI
@@ -38,7 +38,7 @@ namespace
 
         void apply(osg::Node& node) override
         {
-            auto data = dynamic_cast<AnnotationData*>(node.getUserData());
+            auto data = dynamic_cast<osgEarth::AnnotationData*>(node.getUserData());
             if (data)
             {
                 node.setNodeMask(mask);
@@ -50,7 +50,7 @@ namespace
 
     struct GetAnnotations : public osg::NodeVisitor
     {
-        EarthManipulator* manip = nullptr;
+        osgEarth::EarthManipulator* manip = nullptr;
 
         GetAnnotations()
         {
@@ -60,7 +60,7 @@ namespace
 
         void apply(osg::Node& node) override
         {
-            auto data = dynamic_cast<AnnotationData*>(node.getUserData());
+            auto data = dynamic_cast<osgEarth::AnnotationData*>(node.getUserData());
             if (data)
             {
                 ImGui::PushID((std::uintptr_t)data);
@@ -130,7 +130,7 @@ namespace osgEarth
                 ImGui::Begin(name(), visible());
                 {
                     GetAnnotations getannos;
-                    getannos.manip = dynamic_cast<EarthManipulator*>(view(ri)->getCameraManipulator());
+                    getannos.manip = dynamic_cast<osgEarth::EarthManipulator*>(view(ri)->getCameraManipulator());
                     camera(ri)->accept(getannos);
                 }
                 ImGui::End();


### PR DESCRIPTION
Getting build errors when including this in other code. Appears to be missing `osgEarth::` namespace, due to being in anon namespace without a `using` statement.