### PR TITLE
Rex DrawState: Fix crash from accessing possible null.

### DIFF
--- a/src/osgEarthDrivers/engine_rex/DrawState.cpp
+++ b/src/osgEarthDrivers/engine_rex/DrawState.cpp
@@ -39,22 +39,28 @@ ProgramState::init(
     // Size the sampler states property:
     _samplerState._samplers.resize(bindings->size());
 
-    // for each sampler binding, initialize its state tracking structure 
+    // for each sampler binding, initialize its state tracking structure
     // and resolve its matrix uniform location:
     for (unsigned i = 0; i < bindings->size(); ++i)
     {
         const SamplerBinding& binding = (*bindings)[i];
         _samplerState._samplers[i]._name = binding.samplerName();
-        _samplerState._samplers[i]._matrixUL = _pcp->getUniformLocation(
-            osg::Uniform::getNameID(binding.matrixName()));
+        if (_pcp)
+        {
+            _samplerState._samplers[i]._matrixUL = _pcp->getUniformLocation(
+                osg::Uniform::getNameID(binding.matrixName()));
+        }
     }
 
     // resolve all the other uniform locations:
-    _tileKeyUL = _pcp->getUniformLocation(osg::Uniform::getNameID("oe_tile_key_u"));
-    _parentTextureExistsUL = _pcp->getUniformLocation(osg::Uniform::getNameID("oe_layer_texParentExists"));
-    _layerUidUL = _pcp->getUniformLocation(osg::Uniform::getNameID("oe_layer_uid"));
-    _layerOrderUL = _pcp->getUniformLocation(osg::Uniform::getNameID("oe_layer_order"));
-    _morphConstantsUL = _pcp->getUniformLocation(osg::Uniform::getNameID("oe_tile_morph"));
+    if (_pcp)
+    {
+        _tileKeyUL = _pcp->getUniformLocation(osg::Uniform::getNameID("oe_tile_key_u"));
+        _parentTextureExistsUL = _pcp->getUniformLocation(osg::Uniform::getNameID("oe_layer_texParentExists"));
+        _layerUidUL = _pcp->getUniformLocation(osg::Uniform::getNameID("oe_layer_uid"));
+        _layerOrderUL = _pcp->getUniformLocation(osg::Uniform::getNameID("oe_layer_order"));
+        _morphConstantsUL = _pcp->getUniformLocation(osg::Uniform::getNameID("oe_tile_morph"));
+    }
 
     // Reset all optional states
     reset();


### PR DESCRIPTION
If one of the programs (e.g. HexTiler) fails to compile, it's possible to get `_pcp` as null. This patch fixes the immediate crash from that behavior. The globe still isn't shown in that case, but at least the software doesn't segfault immediately.

I know this is an unexpected case of null `_pcp`. I'd rather fix the root cause but since it looks like this can happen from a bad glsl, it might be easily triggered, so there should be some protection. I'm still looking for/at the root cause in the shader, it's something in the new Hex Tile stuff.