### PR TITLE
HexTiling: Define symbol to fix Mesa Intel compile issue; fix PI constant

### DIFF
--- a/src/osgEarth/HexTiling.glsl
+++ b/src/osgEarth/HexTiling.glsl
@@ -1,19 +1,19 @@
 #pragma vp_name osgEarth Hex Tiling Library
 
-#ifdef VP_STAGE_FRAGMENT
-
 // Adapted and ported to GLSL from:
 // https://github.com/mmikk/hextile-demo
 
 float ht_g_fallOffContrast = 0.6;
 float ht_g_exp = 7;
 
+#ifdef VP_STAGE_FRAGMENT
+
 #ifndef mul
 #define mul(X, Y) ((X)*(Y))
 #endif
 
 #ifndef M_PI
-#define M_PI 3.1417927
+#define M_PI 3.1415927
 #endif
 
 #define HEX_SCALE 3.46410161


### PR DESCRIPTION
I have a Linux system that's picking up the embedded Intel HD Graphics 630, which is using the Mesa 22.3.0 driver. osgEarth is crashing (see https://github.com/gwaldron/osgearth/pull/2343) for me. The other PR deals with the CXX cause of the crash. This change fixes the runtime issue.

The GLSL compiler is not happy with the file having no symbols defined and gives `0:279(1): error: syntax error, unexpected end of file`. This fixes that problem by defining some symbols -- any symbol would be fine including `void doNothing() {}` -- outside of the `VP_STAGE_FRAGMENT` ifdef.

After this change, Intel Mesa runs fine with no issues.

I also noticed that `M_PI` was off on a digit so I updated that.