### PR TITLE
Linux: Fixed syntax errors in build

### DIFF
--- a/src/osgEarth/TileMesher.cpp
+++ b/src/osgEarth/TileMesher.cpp
@@ -595,7 +595,7 @@ TileMesher::createMeshWithConstraints(
 
                         // Note: the part was already transformed in a previous step.
 
-                        auto& bb = part->getBounds();
+                        const auto& bb = part->getBounds();
                         if (part->isPolygon() && bb.intersects(localBounds))
                         {
                             if (edit.removeExterior)

--- a/src/osgEarth/rtree.h
+++ b/src/osgEarth/rtree.h
@@ -100,7 +100,7 @@ public:
     using DefaultCallbackType = std::function<bool(const DATATYPE&)>;
     template<typename CALLBACK_TYPE = DefaultCallbackType>
     int Search(const ELEMTYPE a_min[NUMDIMS], const ELEMTYPE a_max[NUMDIMS],
-        CALLBACK_TYPE callback = [&](const DATATYPE&) { return true; }) const;
+        CALLBACK_TYPE callback = [](const DATATYPE&) { return true; }) const;
 
     /// Remove all entries from tree
     void RemoveAll();


### PR DESCRIPTION
Using `[&]` is not going to be supported as a default parameter for a function. Bounding box can take a const reference, but not a non-const reference. These two fix #2345 also.