### PR TITLE
AnnotationsGUI: Namespace issues, fix missing include for dynamic_cast

### DIFF
--- a/src/osgEarth/ImGui/AnnotationsGUI
+++ b/src/osgEarth/ImGui/AnnotationsGUI
@@ -21,6 +21,7 @@
 
 #include "ImGui"
 #include <osgEarth/AnnotationData>
+#include <osgEarth/AnnotationNode>
 #include <osgEarth/ViewFitter>
 #include <osg/NodeVisitor>
 
@@ -108,8 +109,8 @@ namespace
                 bool is_selected = false;
                 if (ImGui::Selectable(name.c_str(), &is_selected) && manip)
                 {
-                    ViewFitter fitter(srs, camera);
-                    Viewpoint vp;
+                    osgEarth::Util::ViewFitter fitter(srs, camera);
+                    osgEarth::Viewpoint vp;
                     fitter.createViewpoint(anode, vp);
                     manip->setViewpoint(vp);
                 }


### PR DESCRIPTION
After fixing my local issue with getting GEOS linking (which I was able to fix in my own internal configuration), I started to get build errors with my own code that was including ImGui/AnnotationsGUI. These fixes allow the code to continue to compile on CentOS 7.9, gcc 11.2.1. Note that this compiles fine inside osgEarth and is only a problem in code that uses osgEarth as a third party library.

AnnotationNode include is required because of a dynamic_cast in the file needing to know how to cast; forward declare is insufficient. Namespace declarations required because external code does not include `using namespace osgEarth; using namespace osgEarth::Util;` like some of the osgEarth examples.