### PR TITLE
Chonk, NodeUtils: Fixed Linux gcc compile bugs

### DIFF
--- a/src/osgEarth/Chonk
+++ b/src/osgEarth/Chonk
@@ -68,6 +68,7 @@ namespace osgEarth
     };
 
     class ChonkFactory;
+    class ChonkDrawable;
 
     /**
      * A bindless rendering unit comprised of one VBO and one EBO.

--- a/src/osgEarth/ImGui/AnnotationsGUI
+++ b/src/osgEarth/ImGui/AnnotationsGUI
@@ -76,7 +76,7 @@ namespace
                 auto vp_ptr = data->getViewpoint();
                 auto desc = data->getDescription();
 
-                Viewpoint vp;
+                osgEarth::Viewpoint vp;
                 if (vp_ptr) vp = *vp_ptr;
 
                 if (!vp.valid())

--- a/src/osgEarth/NodeUtils
+++ b/src/osgEarth/NodeUtils
@@ -195,7 +195,7 @@ namespace osgEarth { namespace Util
     template<typename T, typename FUNC>
     struct NodeFunctorVisitor : public osg::NodeVisitor
     {
-        NodeFunctorVisitor(FUNC& func) : osg::NodeVisitor(osg::NodeVisitor::TRAVERSE_ALL_CHILDREN), _func(func) { }
+        NodeFunctorVisitor(const FUNC& func) : osg::NodeVisitor(osg::NodeVisitor::TRAVERSE_ALL_CHILDREN), _func(func) { }
 
         void apply(osg::Node& node) override
         {
@@ -209,7 +209,7 @@ namespace osgEarth { namespace Util
     };  
 
     template<typename T, typename FUNC>
-    inline void forEachNodeOfType(osg::Node* root, FUNC& functor)
+    inline void forEachNodeOfType(osg::Node* root, const FUNC& functor)
     {
         NodeFunctorVisitor<T, FUNC> visitor(functor);
         if (root)


### PR DESCRIPTION
Fixed compile bugs seen on Linux side:
* `ChonkDrawable` is now forward declared. Previously it was mentioned below in a `friend class ChonkDrawable` but gcc doesn't treat that the same as a `class ChonkDrawable` declaration, though MSVC accepts it.
* Lambdas are now passed by const reference instead of non-const reference. The Lambda gets copied anyways, so const is fine, and allows for r-values. MSVC also lets you get away without the const but probably shouldn't.

No functionality changes, just compiler fixes.