### PR TITLE
Rex: Work-around for MESA 23.1.4 bug with texture coordinates

### DIFF
--- a/src/osgEarth/BuildGeometryFilter.cpp
+++ b/src/osgEarth/BuildGeometryFilter.cpp
@@ -1173,8 +1173,8 @@ BuildGeometryFilter::tileAndBuildPolygon(
 
     else
     {
-        // original tesselation approach
-        Tessellator::Plane plane = Tessellator::PLANE_XY;
+        // original tesselation approach: automatically figure out closest plane
+        Tessellator::Plane plane = Tessellator::PLANE_AUTO;
 
         if (outputSRS)
         {
@@ -1231,12 +1231,6 @@ BuildGeometryFilter::tileAndBuildPolygon(
                     inputSRS->transform(part->asVector(), outputSRS);
                 }
             }
-        }
-        else
-        {
-            // with no SRS, we need to automatically figure out what 
-            // is the closest plane for tessellation
-            plane = Tessellator::PLANE_AUTO;
         }
 
         // tessellate

--- a/src/osgEarthDrivers/engine_rex/RexEngine.ImageLayer.glsl
+++ b/src/osgEarthDrivers/engine_rex/RexEngine.ImageLayer.glsl
@@ -4,7 +4,6 @@
 #pragma vp_order      0.4
 
 // Stage globals
-vec4 oe_layer_tilec;
 vec2 oe_layer_texc;
 vec2 oe_layer_texcParent;
 
@@ -14,8 +13,8 @@ uniform mat4 oe_layer_texParentMatrix;
 void oe_rex_imageLayer_VS(inout vec4 vertexView)
 {
     // calculate the texture coordinates:
-    oe_layer_texc = (oe_layer_texMatrix * oe_layer_tilec).st;
-    oe_layer_texcParent = (oe_layer_texParentMatrix * oe_layer_tilec).st;
+    oe_layer_texc = (oe_layer_texMatrix * gl_MultiTexCoord0).st;
+    oe_layer_texcParent = (oe_layer_texParentMatrix * gl_MultiTexCoord0).st;
 }
 
 

--- a/src/osgEarthDrivers/engine_rex/RexEngine.SDK.glsl
+++ b/src/osgEarthDrivers/engine_rex/RexEngine.SDK.glsl
@@ -1,5 +1,7 @@
 #pragma vp_name Rex Terrain SDK
 
+#pragma import_defines(OE_TERRAIN_MORPH_GEOMETRY)
+
 uniform sampler2D oe_tile_elevationTex;
 uniform mat4 oe_tile_elevationTexMatrix;
 uniform sampler2D oe_tile_normalTex;
@@ -13,8 +15,14 @@ uniform vec2 oe_tile_elevTexelCoeff;
 
 // Stage global
 vec4 oe_tile_key;
+vec4 oe_layer_tilec;
 
+// Mesa driver bug work-around: When morph is disabled, use the gl_MultiTexCoord0 directly
+#ifdef OE_TERRAIN_MORPH_GEOMETRY
+#define TERRAIN_UV oe_layer_tilec
+#else
 #define TERRAIN_UV gl_MultiTexCoord0
+#endif
 
 // Sample the elevation data at a UV tile coordinate.
 float oe_terrain_getElevation(in vec2 uv)

--- a/src/osgEarthDrivers/engine_rex/RexEngine.SDK.glsl
+++ b/src/osgEarthDrivers/engine_rex/RexEngine.SDK.glsl
@@ -12,8 +12,9 @@ uniform mat4 oe_tile_normalTexMatrix;
 uniform vec2 oe_tile_elevTexelCoeff;
 
 // Stage global
-vec4 oe_layer_tilec;
 vec4 oe_tile_key;
+
+#define TERRAIN_UV gl_MultiTexCoord0
 
 // Sample the elevation data at a UV tile coordinate.
 float oe_terrain_getElevation(in vec2 uv)
@@ -31,7 +32,7 @@ float oe_terrain_getElevation(in vec2 uv)
 // Read the elevation at the build-in tile coordinates (convenience)
 float oe_terrain_getElevation()
 {
-    return oe_terrain_getElevation(oe_layer_tilec.st);
+    return oe_terrain_getElevation(TERRAIN_UV.st);
 }
 
 // Read the normal vector and curvature at resolved UV tile coordinates.
@@ -50,7 +51,7 @@ vec4 oe_terrain_getNormalAndCurvature(in vec2 uv_scaledBiased)
 
 vec4 oe_terrain_getNormalAndCurvature()
 {
-    vec2 uv_scaledBiased = oe_layer_tilec.st
+    vec2 uv_scaledBiased = TERRAIN_UV.st
         * oe_tile_elevTexelCoeff.x * oe_tile_normalTexMatrix[0][0]
         + oe_tile_elevTexelCoeff.x * oe_tile_normalTexMatrix[3].st
         + oe_tile_elevTexelCoeff.y;


### PR DESCRIPTION
This addresses the texturing aspect of the Mesa 23.1.4 bug. Terrain morphing is still an issue that needs to be addressed, but is significantly less visible than the texturing aspect that this patch fixes.