### PR TITLE
cesium-native: add a simple GLTF "baseColorFactor" support

### DIFF
--- a/src/osgEarthCesium/PrepareRenderResources.cpp
+++ b/src/osgEarthCesium/PrepareRenderResources.cpp
@@ -26,6 +26,7 @@
 #include <osg/Texture2D>
 #include <osg/Geometry>
 #include <osgEarth/ImageUtils>
+#include <osgEarth/Lighting>
 #include <osgEarth/Notify>
 #include <osgEarth/Registry>
 #include <osg/MatrixTransform>
@@ -538,13 +539,21 @@ public:
 
             if (primitive.material >= 0 && primitive.material < _model->materials.size())
             {
+                osg::StateSet* stateSet = geom->getOrCreateStateSet();
                 auto& material = _model->materials[primitive.material];
                 auto pbr = material.pbrMetallicRoughness;
-                unsigned int baseColorTexture = pbr->baseColorTexture->index;
-                if (baseColorTexture >= 0 && baseColorTexture < _textures.size())
-                {
-                    osg::StateSet* stateSet = geom->getOrCreateStateSet();
-                    stateSet->setTextureAttributeAndModes(0, _textures[baseColorTexture], osg::StateAttribute::ON);
+                if (pbr->baseColorFactor.size() > 0) {
+                    osgEarth::MaterialGL3* material = new osgEarth::MaterialGL3();
+                    osg::Vec4d color(pbr->baseColorFactor[0], pbr->baseColorFactor[1], pbr->baseColorFactor[2], pbr->baseColorFactor[3]);
+                    material->setDiffuse(osg::Material::FRONT_AND_BACK, color);
+                    stateSet->setAttributeAndModes(material);
+                }
+                if (pbr->baseColorTexture.has_value()) {
+                    unsigned int baseColorTexture = pbr->baseColorTexture->index;
+                    if (baseColorTexture >= 0 && baseColorTexture < _textures.size())
+                    {
+                        stateSet->setTextureAttributeAndModes(0, _textures[baseColorTexture], osg::StateAttribute::ON);
+                    }
                 }
             }
 


### PR DESCRIPTION
This adds a simple GLTF baseColorFactor support and fix a case when "baseColorTexture" is not initialized.

I understand that the GLTF osgEarth parser requires a new PBR shader to fully support all potential materials. However, this simple modification enables the display of colors in certain 3DTiles layers.

