### PR TITLE
Draco: Fix CMake 3.23.2 configure error with unknown select_library_configurations macro

### DIFF
--- a/CMakeModules/FindDraco.cmake
+++ b/CMakeModules/FindDraco.cmake
@@ -30,6 +30,7 @@ else()
   find_library(draco_LIBRARIES NAMES draco.lib libdraco.a)
 endif()
 
+include(SelectLibraryConfigurations)
 select_library_configurations(draco) 
 
 # Store path to library.


### PR DESCRIPTION
This fixes a failure on Linux on CMake 3.23.2. I'm not sure why this is not failing on other systems.