### PR TITLE
Sky GUI: Window No Longer Always Visible

### DIFF
--- a/src/osgEarth/ImGui/EnvironmentGUI
+++ b/src/osgEarth/ImGui/EnvironmentGUI
@@ -154,7 +154,7 @@ namespace osgEarth
 
             void draw(osg::RenderInfo& ri) override
             {
-                if (!findNodeOrHide(_mapNode, ri))
+                if (!isVisible() || !findNodeOrHide(_mapNode, ri))
                     return;
 
                 if (ImGui::Begin(name(), visible()))


### PR DESCRIPTION
ImGui Environment window is no longer always shown, and now respects the window Close button. This was introduced on 10-23 in 2c78d941 in a fix that lets users install the sky if it isn't installed yet.

I made sure that you can still actually install the sky using the GUI if it wasn't yet installed.

Without this change, the Environment Sky GUI pops up in at start-up of several SIMDIS SDK examples where there are sky nodes. Pressing the "X" button in the top-right doesn't do anything. This change fixes that problem.