### PR TITLE
Reset OGR order to standard;

### DIFF
--- a/src/osgEarth/GeometryUtils
+++ b/src/osgEarth/GeometryUtils
@@ -31,6 +31,7 @@ namespace osgEarth
     namespace GeometryUtils
     {
         extern OSGEARTH_EXPORT std::string geometryToWKT( const Geometry* geometry );
+        extern OSGEARTH_EXPORT std::string geometryToIsoWKT( const Geometry* geometry );
         extern OSGEARTH_EXPORT Geometry*   geometryFromWKT( const std::string& wkt, bool rewindPolygons = true);
 
         extern OSGEARTH_EXPORT std::string geometryToGeoJSON( const Geometry* geometry );

--- a/src/osgEarth/GeometryUtils.cpp
+++ b/src/osgEarth/GeometryUtils.cpp
@@ -43,6 +43,24 @@ osgEarth::GeometryUtils::geometryToWKT( const Geometry* geometry )
     return result;
 }
 
+std::string
+osgEarth::GeometryUtils::geometryToIsoWKT( const Geometry* geometry )
+{
+    OGRGeometryH g = OgrUtils::createOgrGeometry( geometry );
+    std::string result;
+    if (g)
+    {
+        char* buf;   
+        if (OGR_G_ExportToIsoWkt( g, &buf ) == OGRERR_NONE)
+        {
+            result = std::string(buf);
+            OGRFree( buf );
+        }
+        OGR_G_DestroyGeometry( g );
+    }
+    return result;
+}
+
 std::string 
 osgEarth::GeometryUtils::geometryToGeoJSON( const Geometry* geometry )
 {

--- a/src/osgEarth/OgrUtils.cpp
+++ b/src/osgEarth/OgrUtils.cpp
@@ -274,7 +274,7 @@ OgrUtils::encodeShape( const Geometry* geometry, OGRwkbGeometryType shape_type, 
     {
         if (part_type == wkbNone)
         {
-            for (int v = geometry->size() - 1; v >= 0; v--)
+            for (int v = 0; v < geometry->size(); v++)
             {
                 osg::Vec3d p = (*geometry)[v];
                 OGR_G_AddPoint(shape_handle, p.x(), p.y(), p.z());
@@ -282,7 +282,7 @@ OgrUtils::encodeShape( const Geometry* geometry, OGRwkbGeometryType shape_type, 
         }
         else if (part_type == wkbPoint)
         {
-            for (int v = geometry->size() - 1; v >= 0; v--)
+            for (int v = 0; v < geometry->size(); v++)
             {
                 osg::Vec3d p = (*geometry)[v];
                 OGRGeometryH part_handle = OGR_G_CreateGeometry(part_type);


### PR DESCRIPTION
This commit allows:
1) Reset OGR geometries order to standard order.
2) Add geometryToIsoWKT function. (the geometryFromWKT is capable to read both wkt and isoWkt).

I have tested point, line, polygon geometries and are still loading correctly.
![image](https://github.com/gwaldron/osgearth/assets/7198569/1722d7ed-d678-4c0a-96b4-c8e86abeb522)
