### PR TITLE
Mesh Optimizer: No longer link in if not found

### DIFF
--- a/src/osgEarth/CMakeLists.txt
+++ b/src/osgEarth/CMakeLists.txt
@@ -41,8 +41,9 @@ IF(WIN32)
     LIST(APPEND TARGET_EXTERNAL_LIBRARIES psapi)
 ENDIF(WIN32)
 
-
-LIST(APPEND TARGET_EXTERNAL_LIBRARIES meshoptimizer::meshoptimizer)
+IF(meshoptimizer_FOUND)
+    LIST(APPEND TARGET_EXTERNAL_LIBRARIES meshoptimizer::meshoptimizer)
+ENDIF()
 
 
 # Generate the Version header.


### PR DESCRIPTION
Fixes linker error on my Linux system where meshoptimizer library was not found.