### PR TITLE
PBRMaterial: Fix Linux constructor build error

### DIFF
--- a/src/osgEarth/PBRMaterial.cpp
+++ b/src/osgEarth/PBRMaterial.cpp
@@ -217,8 +217,7 @@ namespace
         auto rr = uri.readImage(o);
         if (rr.failed())
             return Status(Status::ResourceUnavailable, rr.errorDetail());
-        else
-            return rr.getImage();
+        return osg::ref_ptr<osg::Image>(rr.getImage());
     }
 }
 


### PR DESCRIPTION
While Windows was happy to convert the `osg::Image*` to a `ref_ptr<osg::Image>` and construct a `Result` from that, gcc was unhappy. Explicitly constructing the `ref_ptr` fixes the issue.