### PR TITLE
Fix: Shared Image Layer Samples are not pruned when layer is removed

### DIFF
--- a/src/osgEarthDrivers/engine_rex/RexTerrainEngineNode.cpp
+++ b/src/osgEarthDrivers/engine_rex/RexTerrainEngineNode.cpp
@@ -1243,6 +1243,7 @@ RexTerrainEngineNode::removeImageLayer(ImageLayer* layerRemoved)
                     OE_INFO << LC << "Binding (" << binding.samplerName() << " unit " << binding.unit() << ") cleared\n";
                     binding.usage().clear();
                     binding.unit() = -1;
+                    binding.sourceUID().clear();
 
                     // Request an update to reset the shared sampler in the scene graph
                     // GW: running this anyway below (PurgeOrphanedLayers), so no need..?


### PR DESCRIPTION
Suggested fix for #2568 