### PR TITLE
Apps: Fixed ImGui for Windows and CollectTriangles apps

### DIFF
--- a/src/applications/osgearth_collecttriangles/osgearth_collecttriangles.cpp
+++ b/src/applications/osgearth_collecttriangles/osgearth_collecttriangles.cpp
@@ -19,7 +19,7 @@
 * You should have received a copy of the GNU Lesser General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
-#include <osgEarth/ImGui/ImGuiApp>
+#include <osgEarthImGui/ImGuiApp>
 
 #include <osgViewer/Viewer>
 #include <osgEarth/Notify>

--- a/src/applications/osgearth_windows/CMakeLists.txt
+++ b/src/applications/osgearth_windows/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_osgearth_app(
     TARGET osgearth_windows
     SOURCES osgearth_windows.cpp
-    USE_IMGUI
+    LIBRARIES osgEarthImGui
     FOLDER Tests)

--- a/src/applications/osgearth_windows/osgearth_windows.cpp
+++ b/src/applications/osgearth_windows/osgearth_windows.cpp
@@ -19,7 +19,7 @@
 * You should have received a copy of the GNU Lesser General Public License
 * along with this program.  If not, see <http://www.gnu.org/licenses/>
 */
-#include <osgEarth/ImGui/ImGuiApp>
+#include <osgEarthImGui/ImGuiApp>
 
 #include <osgViewer/CompositeViewer>
 #include <osgEarth/EarthManipulator>


### PR DESCRIPTION
I was getting build errors in my Windows configuration without these fixes. Looks like they might have been overlooked during a recent refactor.