### PR TITLE
For CesiumNative, use `ktx` library instead of `ktx_read`

### DIFF
--- a/cmake/FindCesiumNative.cmake
+++ b/cmake/FindCesiumNative.cmake
@@ -98,7 +98,7 @@ find_cesium_library(CESIUM_NATIVE_GLTF_CONTENT CesiumGltfContent)
 
 find_cesium_library(CESIUM_NATIVE_CSPRNG csprng)
 find_cesium_library(CESIUM_NATIVE_DRACO draco)
-find_cesium_library(CESIUM_NATIVE_KTX_READ ktx_read)
+find_cesium_library(CESIUM_NATIVE_KTX ktx)
 find_cesium_library(CESIUM_NATIVE_MODPB64 modp_b64)
 find_cesium_library(CESIUM_NATIVE_S2GEOMETRY s2geometry)
 find_cesium_library(CESIUM_NATIVE_SPDLOG spdlog)


### PR DESCRIPTION
Updated content to reflect changes made by cesium-native side. . Otherwise, -DOSGEARTH_BUILD_CESIUM_NODEKIT=ON type cmake configurations were complaining about being ktx_read not found.

Cesium-native is using ktx instead of ktx_read for a while

Check cesium-native commits:
https://github.com/CesiumGS/cesium-native/commit/dd35563ff874e05d3a616cb0a852f36216e8673f

https://github.com/CesiumGS/KTX-Software/pull/1