### PR TITLE
Capabilities: Remove unused Version include that does not compile

### DIFF
--- a/src/osgEarth/Capabilities.cpp
+++ b/src/osgEarth/Capabilities.cpp
@@ -17,7 +17,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 #include "Capabilities"
-#include "Version"
 #include "SpatialReference"
 #include "GEOS"
 #include "Registry"


### PR DESCRIPTION
This was introduced in a recent refactor. Not sure how Windows is working here, as the "Version" file is in the build directory at `build_dir/build_include/osgEarth/Version`

Another fix is to update this back to `"osgEarth/Version"`. I suspect that removing this works simply because one of the other headers already includes it, but removing the header was a clean fix that compiled cleanly for me too.

Without a change here, Linux builds are continuing to fail. Again, unsure how Windows is apparently working.