### PR TITLE
Fix vcpkg config and usage

### DIFF
--- a/bootstrap-vcpkg.bat
+++ b/bootstrap-vcpkg.bat
@@ -2,15 +2,15 @@
 setlocal
 set ERROR_MSG=
 
-if "%VCPKG_DIR%" == "" (
-    FOR /F "tokens=*" %%X IN ('where vcpkg.exe') do (SET VCPKG_DIR=%%~dpX)
+if "%VCPKG_ROOT%" == "" (
+    FOR /F "tokens=*" %%X IN ('where vcpkg.exe') do (SET VCPKG_ROOT=%%~dpX)
 )
 
 :: Verify vcpkg is available
-set VCPKG_TOOLCHAIN_FILE=%VCPKG_DIR%\scripts\buildsystems\vcpkg.cmake
+set VCPKG_TOOLCHAIN_FILE="%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake"
 
 if not exist %VCPKG_TOOLCHAIN_FILE% (
-    set ERROR_MSG=Cannot find vcpkg. Please ensure vcpkg.exe is in your PATH, or set the VCPKG_DIR environment variable to your vcpkg install location
+    set ERROR_MSG=Cannot find vcpkg. Please ensure vcpkg.exe is in your PATH, or set the VCPKG_ROOT environment variable to your vcpkg install location
     goto :usage
 )
 
@@ -55,7 +55,7 @@ call :realpath !-I!
 set INSTALL_DIR=%RETVAL%
 
 :: Ask for confirmation:
-echo VCPKG_DIR        = %VCPKG_DIR%
+echo VCPKG_ROOT       = %VCPKG_ROOT%
 echo Source location  = %SOURCE_DIR%
 echo Build location   = %BUILD_DIR%
 echo Install location = %INSTALL_DIR%

--- a/vcpkg/vcpkg.json
+++ b/vcpkg/vcpkg.json
@@ -24,5 +24,6 @@
         "spdlog",
         "tracy",
         "meshoptimizer" 
-    ]
+    ],
+    "builtin-baseline": "9558037875497b9db8cf38fcd7db68ec661bffe7"
 }


### PR DESCRIPTION
Newer versions of vcpkg require a builtin-baseline setting that specifies the minimum versions of all packages, as described here: https://learn.microsoft.com/en-us/vcpkg/users/versioning#baselines and here: https://learn.microsoft.com/en-us/vcpkg/reference/vcpkg-json#builtin-baseline. Without this setting, bootstrap-vcpkg.bat errors out with this message:

```
[...]
-- Running vcpkg install
error: this vcpkg instance requires a manifest with a specified baseline in order to interact with ports. Please add 'builtin-baseline' to the manifest or add a 'vcpkg-configuration.json' that redefines the default registry.
-- Running vcpkg install - failed
[...]
```

The environment variable that contains the location of the vcpkg tool [is VCPKG_ROOT](https://learn.microsoft.com/en-us/vcpkg/users/config-environment#vcpkg_root), not VCPKC_DIR, and the path may contain spaces so it needs to be quoted.