### PR TITLE
WebP: sharpyuv only added if target exists, supporting older WebP

### DIFF
--- a/src/osgEarthDrivers/webp/CMakeLists.txt
+++ b/src/osgEarthDrivers/webp/CMakeLists.txt
@@ -5,5 +5,8 @@ if (WebP_FOUND)
     add_osgearth_plugin(
         TARGET osgdb_webp
         SOURCES ReaderWriterWebP.cpp)
-    target_link_libraries(osgdb_webp PRIVATE WebP::webp WebP::sharpyuv)
+    target_link_libraries(osgdb_webp PRIVATE WebP::webp)
+    if(TARGET WebP::sharpyuv)
+        target_link_libraries(osgdb_webp PRIVATE WebP::sharpyuv)
+    endif()
 endif()


### PR DESCRIPTION
The added code works great for WebP 1.4, but WebP 1.2 (which we support on an older Linux distro) doesn't have sharpyuv.