### PR TITLE
GDAL: Fix version comparison

### DIFF
--- a/src/osgEarth/GDAL.cpp
+++ b/src/osgEarth/GDAL.cpp
@@ -968,7 +968,7 @@ GDAL::Driver::getInterpolatedDEMValue(GDALRasterBand* band, double x, double y, 
     double r, c;
     geoToPixel(x, y, c, r);
 
-#if GDAL_VERSION_NUM >= 3010000 // 3.10+
+#if GDAL_VERSION_NUM >= 3100000 // 3.10+
     GDALRIOResampleAlg alg = GRIORA_NearestNeighbour;
 
     switch (gdalOptions().interpolation().value())


### PR DESCRIPTION
Version comparison appears correct (3.10), but testing demonstrated that the value was wrong for testing 3.10. I have a 3.8 GDAL that won't build without this change. Before this change, it was testing whether GDAL was greater than 3.1 instead of 3.10.