### PR TITLE
Don't set prefix to lib64 on macOS

### DIFF
--- a/cmake/oe_unix.cmake
+++ b/cmake/oe_unix.cmake
@@ -13,7 +13,9 @@ if(UNIX AND NOT ANDROID)
     find_package(Threads REQUIRED)
     
     # add 64 to the lib prefix.
-    set(INSTALL_LIBRARY_FOLDER "lib64")
-    set(INSTALL_PLUGINS_FOLDER "lib64")
+    if(NOT APPLE)
+        set(INSTALL_LIBRARY_FOLDER "lib64")
+        set(INSTALL_PLUGINS_FOLDER "lib64")
+    endif()
     
 endif(UNIX AND NOT ANDROID)


### PR DESCRIPTION
The lib dir on macOS is always called lib. Homebrew e.g. won't even link lib64.

(This should probably better use [GNUInstallDirs](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html) anyway, but this is a quick fix the existing system)