### PR TITLE
Use GNUInstallDirs to handle correct platform install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,15 +47,13 @@ include_directories(${OSGEARTH_BUILDTIME_INCLUDE_DIR})
 
 # Third-party sources included in the reposotory
 set(OSGEARTH_EMBEDDED_THIRD_PARTY_DIR ${PROJECT_SOURCE_DIR}/src/third_party)
-    
-# Platform-specific settings ............................................
 
-# Default installation folders. The platform-specific includes will
-# override these values as necessary.
-set(INSTALL_RUNTIME_FOLDER "bin${OSGEARTH_INSTALL_FOLDER_SUFFIX}")  # executables
-set(INSTALL_LIBRARY_FOLDER "bin${OSGEARTH_INSTALL_FOLDER_SUFFIX}")  # .dll/.so
-set(INSTALL_ARCHIVE_FOLDER "lib${OSGEARTH_INSTALL_FOLDER_SUFFIX}")  # .lib/.a
-set(INSTALL_PLUGINS_FOLDER "bin${OSGEARTH_INSTALL_FOLDER_SUFFIX}")  # parent folder of OSG plugins folder
+include(GNUInstallDirs)
+set(OSGEARTH_INSTALL_PLUGINSDIR "${CMAKE_INSTALL_LIBDIR}" CACHE STRING "Parent folder of OSG plugins folder")
+set(OSGEARTH_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/osgEarth" CACHE STRING "osgEarth CMake package install directory")
+set(OSGEARTH_INSTALL_DATADIR "${CMAKE_INSTALL_DATADIR}/osgEarth" CACHE STRING "osgEarth data directory")
+
+# Platform-specific settings ............................................
 
 include(oe_ios)
 include(oe_osx)

--- a/cmake/install-package-config-files.cmake
+++ b/cmake/install-package-config-files.cmake
@@ -2,17 +2,17 @@
 #
 # Creates and installs the top-level LIBNAME-config.cmake file for a library
 #
-function(osgearth_package_install_config_files INCLUDE_INSTALL_DIR LIBRARY_INSTALL_DIR)
-
-    set(PACKAGE_INSTALL_DIR share/osgearth)
-
+function(osgearth_package_install_config_files)
     include(CMakePackageConfigHelpers)
+
+    # main target include dir
+    set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/osgEarth")
 
     configure_package_config_file(
         "${PROJECT_SOURCE_DIR}/cmake/osgEarth-config.cmake.in"
         "${CMAKE_CURRENT_BINARY_DIR}/osgEarth-config.cmake"
-        INSTALL_DESTINATION ${PACKAGE_INSTALL_DIR}
-        PATH_VARS INCLUDE_INSTALL_DIR LIBRARY_INSTALL_DIR) 
+        INSTALL_DESTINATION ${OSGEARTH_INSTALL_CMAKEDIR}
+        PATH_VARS INCLUDE_INSTALL_DIR OSGEARTH_INSTALL_DATADIR) 
 
     write_basic_package_version_file(
         "${CMAKE_CURRENT_BINARY_DIR}/osgEarth-configVersion.cmake"
@@ -24,7 +24,7 @@ function(osgearth_package_install_config_files INCLUDE_INSTALL_DIR LIBRARY_INSTA
             "${CMAKE_CURRENT_BINARY_DIR}/osgEarth-config.cmake"
             "${CMAKE_CURRENT_BINARY_DIR}/osgEarth-configVersion.cmake"
         DESTINATION
-             ${PACKAGE_INSTALL_DIR} )
+             ${OSGEARTH_INSTALL_CMAKEDIR} )
     
 endfunction()
 
@@ -36,13 +36,10 @@ endfunction()
 # and is included from the top-level osgEarth-config.cmake file.
 #
 function(osgearth_package_install_library_target MY_TARGET)
-
-    set(PACKAGE_INSTALL_DIR share/osgearth)
-
     install(
         EXPORT ${MY_TARGET}Targets
         FILE ${MY_TARGET}-targets.cmake
         NAMESPACE osgEarth::
-        DESTINATION ${PACKAGE_INSTALL_DIR} )
+        DESTINATION ${OSGEARTH_INSTALL_CMAKEDIR} )
     
 endfunction()

--- a/cmake/oe_unix.cmake
+++ b/cmake/oe_unix.cmake
@@ -12,8 +12,4 @@ if(UNIX AND NOT ANDROID)
     # for ptheads in linux
     find_package(Threads REQUIRED)
     
-    # add 64 to the lib prefix.
-    set(INSTALL_LIBRARY_FOLDER "lib64")
-    set(INSTALL_PLUGINS_FOLDER "lib64")
-    
 endif(UNIX AND NOT ANDROID)

--- a/cmake/osgEarth-config.cmake.in
+++ b/cmake/osgEarth-config.cmake.in
@@ -25,9 +25,8 @@ if(NOT CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
-set(osgEarth_INCLUDE_DIR "${PACKAGE_PREFIX_DIR}/include")
-set(osgEarth_SHARE_DIR "${PACKAGE_PREFIX_DIR}/share/osgEarth")
-set_and_check(osgEarth_BUILD_DIR "${PACKAGE_PREFIX_DIR}")
+set_and_check(osgEarth_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+set(osgEarth_SHARE_DIR "@PACKAGE_OSGEARTH_INSTALL_DATADIR@")
 
 # always depend on the public-facing OSG libraries
 include(CMakeFindDependencyMacro)

--- a/cmake/osgearth-macros.cmake
+++ b/cmake/osgearth-macros.cmake
@@ -54,7 +54,7 @@ macro(add_osgearth_plugin)
    
     # install the shader source files, if requested:
     if(OSGEARTH_INSTALL_SHADERS)
-        install(FILES ${MY_SHADERS} DESTINATION share/osgEarth/shaders)
+        install(FILES ${MY_SHADERS} DESTINATION ${OSGEARTH_INSTALL_DATADIR}/shaders)
     endif()
 
     # macos-specific
@@ -64,9 +64,7 @@ macro(add_osgearth_plugin)
     
     # install the dynamic libraries.
     install(TARGETS ${MY_TARGET}
-        # RUNTIME DESTINATION ${INSTALL_RUNTIME_FOLDER}
-        # ARCHIVE DESTINATION ${INSTALL_ARCHIVE_FOLDER}/${OSG_PLUGINS}
-        LIBRARY DESTINATION ${INSTALL_PLUGINS_FOLDER}/${OSG_PLUGINS})
+        LIBRARY DESTINATION ${OSGEARTH_INSTALL_PLUGINSDIR}/${OSG_PLUGINS})
     
     # organize the files in the IDE
     source_group( "Header Files"   FILES ${ALL_HEADERS} )
@@ -127,9 +125,7 @@ macro(add_osgearth_app)
         set_target_properties(${TARGET_TARGETNAME} PROPERTIES XCODE_ATTRIBUTE_ENABLE_BITCODE ${IPHONE_ENABLE_BITCODE})
     endif()
 
-    install(
-        TARGETS ${MY_TARGET}
-        RUNTIME DESTINATION ${INSTALL_RUNTIME_FOLDER})
+    install(TARGETS ${MY_TARGET})
 
     if(NOT MY_FOLDER)
         set(MY_FOLDER "Ungrouped")
@@ -173,7 +169,7 @@ macro(add_osgearth_library)
     set(multiValueArgs SOURCES HEADERS PUBLIC_HEADERS SHADERS TEMPLATES LIBRARIES PUBLIC_LIBRARIES INCLUDE_DIRECTORIES)
     cmake_parse_arguments(MY "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     
-    set(INSTALL_INCLUDE_FOLDER include/${MY_TARGET})
+    set(INSTALL_INCLUDE_FOLDER ${CMAKE_INSTALL_INCLUDEDIR}/${MY_TARGET})
     
     set(ALL_HEADERS ${MY_HEADERS} ${MY_IMGUI_HEADERS} ${MY_PUBLIC_HEADERS})
     include_directories(${MY_INCLUDE_DIRECTORIES})        
@@ -222,18 +218,13 @@ macro(add_osgearth_library)
     # library install and target exports for the cmake config packaging.
     install(
         TARGETS ${MY_TARGET}
-        EXPORT ${MY_TARGET}Targets
-        RUNTIME DESTINATION ${INSTALL_RUNTIME_FOLDER}
-        LIBRARY DESTINATION ${INSTALL_LIBRARY_FOLDER}
-        ARCHIVE DESTINATION ${INSTALL_ARCHIVE_FOLDER}
-        INCLUDES DESTINATION include # ${CMAKE_INSTALL_INCLUDEDIR}
-    )
+        EXPORT ${MY_TARGET}Targets)
 
     # deploy the shaders for this library, if requested.
     if(OSGEARTH_INSTALL_SHADERS)
         install(
             FILES ${MY_SHADERS}
-            DESTINATION share/osgEarth/shaders )
+            DESTINATION ${OSGEARTH_INSTALL_DATADIR}/shaders )
     endif()
     
     # on Windows, install pdb files
@@ -241,7 +232,7 @@ macro(add_osgearth_library)
     if(OSGEARTH_INSTALL_PDBS)
         install(
             FILES $<TARGET_PDB_FILE:${MY_TARGET}>
-            DESTINATION ${INSTALL_LIBRARY_FOLDER} OPTIONAL)
+            DESTINATION ${CMAKE_INSTALL_LIBDIR} OPTIONAL)
     endif()
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,8 +62,4 @@ add_subdirectory(osgEarth)
 set_property(TARGET osgEarth PROPERTY FOLDER "Core")
 
 # Finally, generate and install the packaging config file (osgEarth-config.cmake)
-osgearth_package_install_config_files(
-    osgEarth
-    ${OSGEARTH_VERSION}
-    ${CMAKE_INSTALL_PREFIX}/include
-    ${CMAKE_INSTALL_PREFIX}/${INSTALL_LIBRARY_FOLDER})
+osgearth_package_install_config_files()


### PR DESCRIPTION
This is the standard way to set these on all platforms (despite the name) and does not assume a system where libraries are installed into a lib64 directory (e.g. macOS, NixOS, any 32-bit Linux).

Closes #2683.