### PR TITLE
osgEarth-config: Set OSG include on target instead of global

### DIFF
--- a/cmake/osgEarth-config.cmake.in
+++ b/cmake/osgEarth-config.cmake.in
@@ -32,7 +32,6 @@ set_and_check(osgEarth_BUILD_DIR "${PACKAGE_PREFIX_DIR}")
 # always depend on the public-facing OSG libraries
 include(CMakeFindDependencyMacro)
 find_dependency(OpenSceneGraph REQUIRED COMPONENTS osg osgDB osgGA osgUtil osgViewer OpenThreads)
-include_directories(${OPENSCENEGRAPH_INCLUDE_DIR})
 
 # additional public dependencies
 foreach(MY_DEPENDENCY @OSGEARTH_PUBLIC_DEPENDENCIES@)
@@ -45,6 +44,8 @@ foreach(MY_COMPONENT @OSGEARTH_COMPONENTS@)
         include("${CMAKE_CURRENT_LIST_DIR}/${MY_COMPONENT}-targets.cmake")
     endif()
 endforeach()
+
+target_include_directories(osgEarth::osgEarth INTERFACE "${OPENSCENEGRAPH_INCLUDE_DIR}")
 
 set(osgEarth_FOUND TRUE)
 set(OSGEARTH_FOUND TRUE)


### PR DESCRIPTION
The `find_package(osgEarth)` sets the global include directories field for OSG, polluting the global namespace. This change isolates the include directories for OSG to only be added to targets where `osgEarth::osgEarth` is linked against. Minor clean-up.

This syntax requires CMake 3.11, but the minimum CMake version for building osgEarth is 3.20, so this should be safe from a syntax perspective.