### PR TITLE
CMake Install: Capitalization fixes data and CMake directories; fixed include settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,8 +50,8 @@ set(OSGEARTH_EMBEDDED_THIRD_PARTY_DIR ${PROJECT_SOURCE_DIR}/src/third_party)
 
 include(GNUInstallDirs)
 set(OSGEARTH_INSTALL_PLUGINSDIR "${CMAKE_INSTALL_LIBDIR}" CACHE STRING "Parent folder of OSG plugins folder")
-set(OSGEARTH_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/osgearth" CACHE STRING "osgEarth CMake package install directory")
-set(OSGEARTH_INSTALL_DATADIR "${CMAKE_INSTALL_DATADIR}/osgearth" CACHE STRING "osgEarth data directory")
+set(OSGEARTH_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/osgEarth" CACHE STRING "osgEarth CMake package install directory")
+set(OSGEARTH_INSTALL_DATADIR "${CMAKE_INSTALL_DATADIR}/osgEarth" CACHE STRING "osgEarth data directory")
 
 # Platform-specific settings ............................................
 

--- a/cmake/install-package-config-files.cmake
+++ b/cmake/install-package-config-files.cmake
@@ -6,7 +6,7 @@ function(osgearth_package_install_config_files)
     include(CMakePackageConfigHelpers)
 
     # main target include dir
-    set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}/osgearth")
+    set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}")
 
     configure_package_config_file(
         "${PROJECT_SOURCE_DIR}/cmake/osgearth-config.cmake.in"

--- a/cmake/osgearth-macros.cmake
+++ b/cmake/osgearth-macros.cmake
@@ -170,7 +170,7 @@ macro(add_osgearth_library)
     cmake_parse_arguments(MY "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     
     set(INSTALL_INCLUDE_FOLDER ${CMAKE_INSTALL_INCLUDEDIR}/${MY_TARGET})
-    
+
     set(ALL_HEADERS ${MY_HEADERS} ${MY_IMGUI_HEADERS} ${MY_PUBLIC_HEADERS})
     include_directories(${MY_INCLUDE_DIRECTORIES})        
 
@@ -179,11 +179,11 @@ macro(add_osgearth_library)
     source_group("Headers" FILES ${ALL_HEADERS})
     source_group("Shaders" FILES ${MY_SHADERS} )
     source_group("Templates" FILES ${MY_TEMPLATES} )
-    
+
     if(NOT MY_STATIC)
         set(MY_STATIC ${OSGEARTH_DYNAMIC_OR_STATIC})
     endif()
-    
+
     # create the library.
     add_library(
         ${MY_TARGET}
@@ -192,8 +192,6 @@ macro(add_osgearth_library)
         ${MY_SOURCES}
         ${MY_SHADERS}
         ${MY_TEMPLATES} )
-        
-    include_directories(${MY_INCLUDE_DIRECTORIES})
 
     # Link:
     if(NOT "${MY_TARGET}" STREQUAL "osgEarth")
@@ -218,7 +216,8 @@ macro(add_osgearth_library)
     # library install and target exports for the cmake config packaging.
     install(
         TARGETS ${MY_TARGET}
-        EXPORT ${MY_TARGET}Targets)
+        EXPORT ${MY_TARGET}Targets
+        INCLUDES DESTINATION include)
 
     # deploy the shaders for this library, if requested.
     if(OSGEARTH_INSTALL_SHADERS)


### PR DESCRIPTION
Minor fixes for CMake installation support on Linux
* Minimum version fixed from 3.10 to 3.11 to avoid constant warnings about GL on configure
* Added missing Threads dependency for UNIX systems
* Capitalization fix: osgEarth-config.cmake to osgearth-config.cmake, so that `find_package(osgEarth)` can work on Linux
* Filename rename from osgEarth-configVersion.cmake, to osgearth-config-version.cmake, to match style of other file
* Install config files to share/osgEarth instead of share/osgearth, matching install location for shaders

Tested with a small Linux app that uses find_package(osgEarth). It did still require explicit links to GDAL and GEOS in the final application (Linux only) but it found the package and I was able to link successfully. Before this change, CMake could not be coaxed to find the package because of the capitalization in both `share/osgEarth` and `osgEarth-config.cmake` being inconsistent with what CMake expected.