### PR TITLE
Linux: Fix reference compile errors

### DIFF
--- a/src/osgEarth/JoinPointsLinesFilter.cpp
+++ b/src/osgEarth/JoinPointsLinesFilter.cpp
@@ -324,7 +324,7 @@ FilterContext JoinPointsLinesFilter::push(FeatureList& input, FilterContext& con
                                 if (!output->empty())
                                 {
                                     entry.previous = output->back();
-                                    auto& prev_point = pointMap.find(entry.previous);
+                                    auto prev_point = pointMap.find(entry.previous);
                                     prev_point->second.next = point;
                                 }
 

--- a/src/osgEarth/PowerlineLayer.cpp
+++ b/src/osgEarth/PowerlineLayer.cpp
@@ -531,7 +531,7 @@ namespace
                                     if (!output->empty())
                                     {
                                         entry.previous = output->back();
-                                        auto& prev_point = pointMap.find(entry.previous);
+                                        auto prev_point = pointMap.find(entry.previous);
                                         prev_point->second.next = point;
                                     }
 


### PR DESCRIPTION
This returns an iterator in both cases, and is not able to be a reference. This fixes a compile error on gcc-13.