### PR TITLE
CMake: osgPlugins on Windows now correctly goes to bin/osgPlugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,11 @@ include_directories(${OSGEARTH_BUILDTIME_INCLUDE_DIR})
 set(OSGEARTH_EMBEDDED_THIRD_PARTY_DIR ${PROJECT_SOURCE_DIR}/src/third_party)
 
 include(GNUInstallDirs)
-set(OSGEARTH_INSTALL_PLUGINSDIR "${CMAKE_INSTALL_LIBDIR}" CACHE STRING "Parent folder of OSG plugins folder")
+if(WIN32)
+    set(OSGEARTH_INSTALL_PLUGINSDIR "${CMAKE_INSTALL_BINDIR}" CACHE STRING "Parent folder of OSG plugins folder")
+else()
+    set(OSGEARTH_INSTALL_PLUGINSDIR "${CMAKE_INSTALL_LIBDIR}" CACHE STRING "Parent folder of OSG plugins folder")
+endif()
 set(OSGEARTH_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake/osgearth" CACHE STRING "osgEarth CMake package install directory")
 set(OSGEARTH_INSTALL_DATADIR "${CMAKE_INSTALL_DATADIR}/osgearth" CACHE STRING "osgEarth data directory")
 


### PR DESCRIPTION
On Windows, I was seeing plugins going to `lib/osgPlugins-3.6.5`. This changed with the recent `GNUInstallDirs` MR. Before this, on Windows it would install to `bin/osgPlugins-3.6.5`. This patch reverts to the older behavior.

I am not seeing in documentation any `GNUInstallDirs` variables that report a `lib` location on Linux, but a `bin` location on Windows (e.g. for DLL/SO files). So I used a simple if statement to swap.