### PR TITLE
LayersGUI: Fix missing include

### DIFF
--- a/src/osgEarthImGui/LayersGUI
+++ b/src/osgEarthImGui/LayersGUI
@@ -24,6 +24,7 @@
 #include <osgEarth/ViewFitter>
 #include <osgEarth/ThreeDTilesLayer>
 #include <osgEarth/ImageLayer>
+#include <osgEarth/CoverageLayer>
 #include <osgEarth/MapboxGLImageLayer>
 #include <osgEarth/FeatureModelLayer>
 #include <osgEarth/ModelLayer>


### PR DESCRIPTION
CoverageLayer include was missing. Code was added recently to manipulate `CoverageLayer` in d08c83143 but it did not have an include. Build was failing on gcc-13 and MSVC 2022