### PR TITLE
GLUtils: Line stipple now unconditionally included for GL_LINE_STIPPLE

### DIFF
--- a/src/osgEarth/GLUtils.cpp
+++ b/src/osgEarth/GLUtils.cpp
@@ -16,11 +16,11 @@
 #include <osgViewer/GraphicsWindow>
 #include <osg/Texture2D>
 #include <osg/BindImageTexture>
+#include <osg/LineStipple>
 
 #ifdef OSG_GL_FIXED_FUNCTION_AVAILABLE
 #include <osg/LineWidth>
 #include <osg/Point>
-#include <osg/LineStipple>
 #endif
 
 using namespace osgEarth;


### PR DESCRIPTION
About ~L335 `GL_LINE_STIPPLE` is used. In a GL3 build of OSG, with `OSG_GL_FIXED_FUNCTION_AVAILABLE` not defined, the `GL_LINE_STIPPLE` value is also not defined. Adding `osg/LineStipple` include adds the define if necessary.

This ifxes a build error on Linux gcc 14.2 with OSG in GL3 configuration.