### PR TITLE
Layer: Remove deprecation on Layer::setCullCallback

### DIFF
--- a/src/osgEarth/Layer
+++ b/src/osgEarth/Layer
@@ -346,7 +346,6 @@ namespace osgEarth
         };
 
         //! Callback invoked by the terrain engine on this layer before applying
-        OE_DEPRECATED("Override cull() instead")
         void setCullCallback(TraversalCallback* tc);
         const TraversalCallback* getCullCallback() const;
 


### PR DESCRIPTION
`Layer::setCullCallback()` was recently marked with deprecation tags (`OE_DEPRECATED`), which appear to be part of a larger changeset that looked for any `@deprecated` text and converted it into `OE_DEPRECATED`.

I believe that this was incorrectly marked for deprecation. The deprecation seems to be made in 7a037316af and references a `cull()` method that does not exist. There doesn't appear to be any way to insert code into the cull traversal except through this method.  A related deprecation was recently removed in 0da8094c4 on `osgEarth::Layer::apply()`, which actually calls this cull callback, which implies that it shouldn't be deprecated.

We are currently using this cull callback in the SIMDIS SDK in two locations. One, to configure ocean layers for overhead mode; and two, for projectors to properly configure uniforms for images on the layer.