### PR TITLE
Fix pat in ModelLayer

### DIFF
--- a/src/osgEarth/ModelLayer.cpp
+++ b/src/osgEarth/ModelLayer.cpp
@@ -274,6 +274,7 @@ ModelLayer::openImplementation()
                 osg::DegreesToRadians(options().orientation()->z()), osg::Vec3(0, 1, 0));
             pat->setAttitude(rot_mat.getRotate());
             modelNodeParent = pat;
+            result = pat;
         }
 
         if (options().location().isSet())
@@ -282,11 +283,11 @@ ModelLayer::openImplementation()
             geo->setPosition(options().location().get());
             if (pat)
                 geo->addChild(pat);
+            else
+                modelNodeParent = geo;
 
-            modelNodeParent = geo;
+            result = geo;
         }
-
-        result = modelNodeParent.get();
 
         if (options().minVisibleRange().isSet() || options().maxVisibleRange().isSet())
         {


### PR DESCRIPTION
When both location and orientation is defined in the ModelLayer the orientation/pat is ignored because modelNodeParent now is set to the geo node, ie modelNodeParent should be pat if the model also should be rotated.