### PR TITLE
Fix vsi support in gdal-driver

### DIFF
--- a/src/osgEarth/GDAL.cpp
+++ b/src/osgEarth/GDAL.cpp
@@ -478,12 +478,7 @@ GDAL::Driver::open(
 
     if (useExternalDataset == false)
     {
-        std::string input;
-
-        if (gdalOptions().url().isSet() && source.empty())
-            input = gdalOptions().url()->full();
-        else
-            input = source;
+        std::string input = source;
 
         if (input.empty())
         {


### PR DESCRIPTION
The parsing for vsi-path is ignored, ie "source"-string is ignored.