### PR TITLE
Feature: Fixed Linux build issue with long vs int

### DIFF
--- a/src/osgEarth/Feature.cpp
+++ b/src/osgEarth/Feature.cpp
@@ -589,7 +589,7 @@ Feature::getGeoJSON(bool includeNulls) const
         else if (value.is<double>())
             props[attr.first] = value.get<double>();
         else if (value.is<long long>())
-            props[attr.first] = static_cast<long>(value.get<long long>());
+            props[attr.first] = static_cast<int>(value.get<long long>());
         else if (value.is<bool>())
             props[attr.first] = value.get<bool>();
         else if (includeNulls)


### PR DESCRIPTION
In `g++`, `sizeof(long)` is 8 bytes, same as `long long`. The `sizeof(int)` is 4 bytes, which is all Json::Value looks to support. This fixes a build error on current master.