### PR TITLE
fix `HexTiling.glsl` compile error in MacOS

### DIFF
--- a/src/osgEarth/HexTiling.glsl
+++ b/src/osgEarth/HexTiling.glsl
@@ -295,7 +295,7 @@ void ht_hex2colTex_optimized(
     vec2 st3 = st + ht_hash(vertex3);
 
 
-#if OE_ENABLE_HEX_TILER_ANISOTROPIC_FILTERING
+#if defined(OE_ENABLE_HEX_TILER_ANISOTROPIC_FILTERING) && (OE_ENABLE_HEX_TILER_ANISOTROPIC_FILTERING)
 
     // apply a mip bias for sharpness:
     // https://bgolus.medium.com/sharper-mipmapping-using-shader-based-supersampling-ed7aadb47bec


### PR DESCRIPTION
Relative to Issue #2752 (can not run on MacOS). The main problem is `FRAGMENT glCompileShader "HexTiling.glsl_FRAGMENT" FAILED`, and complete out is here
```bash
> osgearth_imgui simple.earth
void StateSet::setGlobalDefaults() ShaderPipeline disabled.
void StateSet::setGlobalDefaults() ShaderPipeline disabled.
FRAGMENT glCompileShader "HexTiling.glsl_FRAGMENT" FAILED
FRAGMENT Shader "HexTiling.glsl_FRAGMENT" infolog:
ERROR: 0:233: '' : syntax error: incorrect preprocessor directive
ERROR: 0:233: '' : syntax error: unexpected tokens following #if preprocessor directive - expected a newline
```

I found the problem is that the Macro `OE_ENABLE_HEX_TILER_ANISOTROPIC_FILTERING` is not defined. Therefore, I change the if condition from
```
#if OE_ENABLE_HEX_TILER_ANISOTROPIC_FILTERING
```
to
```
#if defined(OE_ENABLE_HEX_TILER_ANISOTROPIC_FILTERING) && (OE_ENABLE_HEX_TILER_ANISOTROPIC_FILTERING)
```
and the problem is solved.