### PR TITLE
osgEarthImGui/Common: Avoid double-define of NOMINMAX

### DIFF
--- a/src/osgEarthImGui/Common
+++ b/src/osgEarthImGui/Common
@@ -1,7 +1,9 @@
 #pragma once
 
 #if defined(_MSC_VER)
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #pragma warning( disable : 4244 )
 #pragma warning( disable : 4251 )
 #pragma warning( disable : 4267 )


### PR DESCRIPTION
I am seeing this show up as a repetitive warning when trying to build with Qt6. The ifdef stops the warning spam.