### PR TITLE
Add cstdint include to fix build errors on linux

### DIFF
--- a/src/osgEarth/StringUtils
+++ b/src/osgEarth/StringUtils
@@ -10,6 +10,7 @@
 #include <osg/Vec4>
 #include <osg/Vec4ub>
 #include <string>
+#include <cstdint>
 #include <algorithm>
 #include <vector>
 #include <sstream>


### PR DESCRIPTION
Linux builds on our end are failing on osgEarth main, simple include fix addresses the issue on usage of `std::uint64_t`