### PR TITLE
Blend2d: ifdef to support 0.21.2 version

### DIFF
--- a/src/osgEarth/FeatureRasterizer.cpp
+++ b/src/osgEarth/FeatureRasterizer.cpp
@@ -17,7 +17,11 @@ using namespace osgEarth;
 #endif
 
 #ifdef USE_BLEND2D
+#if BL_VERSION >= 5378
+#include <blend2d/blend2d.h>
+#else
 #include <blend2d.h>
+#endif
 #endif
 
 #include <osgEarth/AGG.h>


### PR DESCRIPTION
Blend2D 0.21.2 moved blend2d.h to blend2d/blend2d.h.

Reference: https://github.com/blend2d/blend2d/commit/def0d1238c3e5d0983bb848e5676049d829e435b
Related PR: https://github.com/gwaldron/osgearth/pull/2856