### PR TITLE
Blend2D 0.21.2 include support fixed

### DIFF
--- a/src/osgEarth/CMakeLists.txt
+++ b/src/osgEarth/CMakeLists.txt
@@ -885,6 +885,15 @@ if(blend2d_FOUND)
     set(OSGEARTH_HAVE_BLEND2D ON)
     #include_directories(${BLEND2D_INCLUDES})
     target_link_libraries(${LIB_NAME} PRIVATE blend2d::blend2d)
+
+    # Blend2D 0.21.2 has a different include path; detect this
+    get_target_property(_BLEND2D_INCLUDE_PATHS blend2d::blend2d INTERFACE_INCLUDE_DIRECTORIES)
+    if(_BLEND2D_INCLUDE_PATHS)
+        list(GET _BLEND2D_INCLUDE_PATHS 0 _FIRST_INCLUDE_DIR)
+        if(EXISTS "${_FIRST_INCLUDE_DIR}/blend2d/blend2d.h")
+            target_compile_definitions(${LIB_NAME} PRIVATE BLEND2D_USE_SCOPED_INCLUDE)
+        endif()
+    endif()
 endif()
 
 # Tracy?

--- a/src/osgEarth/FeatureRasterizer.cpp
+++ b/src/osgEarth/FeatureRasterizer.cpp
@@ -17,7 +17,7 @@ using namespace osgEarth;
 #endif
 
 #ifdef USE_BLEND2D
-#if BL_VERSION >= 5378
+#ifdef BLEND2D_USE_SCOPED_INCLUDE
 #include <blend2d/blend2d.h>
 #else
 #include <blend2d.h>


### PR DESCRIPTION
Related PR https://github.com/gwaldron/osgearth/pull/2859

`BL_VERSION` is defined by including blend2d.h so you cannot use it to determine which include path to use.  My build of Blend2D adds two paths to `INTERFACE_INCLUDE_DIRECTORIES`, which are the same directory. My fix simply detects the first, looks to see if `include/blend2d/blend2d.h` exists, and sets a local compiler definition. BuildConfig.in does not need modifications for this.

Tested by doing a clean build against Blend2D 0.21.2.

Also, the target does not have versioning information unfortunately, so I cannot extract the version from the target (the easy solution). Another possible solution as mentioned in the linked PR is to use `__has_include` but that is CXX17 and I'm not sure how widespread support is or is not present in various compilers you support.