### PR TITLE
Linux fixes: GL_LINE_STIPPLE now defined, and fixed const reference.

### DIFF
--- a/src/osgEarth/Decals.cpp
+++ b/src/osgEarth/Decals.cpp
@@ -152,7 +152,7 @@ DecalRTTNode::traverse(osg::NodeVisitor& nv)
                 if (ObjectStorage::get(&nv, drawList))
                 {
                     auto& leaves = drawList->_perCamera.get(cv->getState()).leaves;
-                    auto& mm = *cv->getModelViewMatrix() * cv->getCurrentCamera()->getInverseViewMatrix();
+                    const auto& mm = *cv->getModelViewMatrix() * cv->getCurrentCamera()->getInverseViewMatrix();
                     Decal leaf = _decal;
                     leaf.matrix = mm * _decal.matrix;
                     leaves.emplace_back(std::move(leaf));

--- a/src/osgEarth/GLUtils.cpp
+++ b/src/osgEarth/GLUtils.cpp
@@ -17,11 +17,11 @@
 #include <osgViewer/GraphicsWindow>
 #include <osg/Texture2D>
 #include <osg/BindImageTexture>
+#include <osg/LineStipple>
 
 #ifdef OSG_GL_FIXED_FUNCTION_AVAILABLE
 #include <osg/LineWidth>
 #include <osg/Point>
-#include <osg/LineStipple>
 #endif
 
 using namespace osgEarth;


### PR DESCRIPTION
* `GL_LINE_STIPPLE` is pulled in from `osg/LineStipple` in `GLUtils.cpp`. Without it, there's a compile error in g++ 14.2
* Can't take a reference in Decal.cpp unless it's marked const, in g++ 14.2