### PR TITLE
Address race condition leading to use-after-free in `REX::TileNode::createChildren()` in the async path

### DIFF
--- a/src/osgEarthDrivers/engine_rex/TileNode.cpp
+++ b/src/osgEarthDrivers/engine_rex/TileNode.cpp
@@ -663,15 +663,16 @@ TileNode::createChildren()
         // create all 4 children in a single job.
         if (_createChildrenFutureResult.empty())
         {
-            EngineContext* context(_context.get());
-            osg::observer_ptr<TileNode> tile_weakptr(this);
+            osg::observer_ptr<TerrainEngineNode> engine_weakptr(_context->_terrainEngine);
+            osg::observer_ptr<TileNode>          tile_weakptr(this);
 
-            auto createChildrenOperation = [context, tile_weakptr](auto& state)
+            auto createChildrenOperation = [engine_weakptr, tile_weakptr](auto& state)
                 {
                     CreateChildrenResult result;
 
+                    osg::ref_ptr<TerrainEngineNode> engine;
                     osg::ref_ptr<TileNode> tile;
-                    if (tile_weakptr.lock(tile) && !state.canceled())
+                    if (engine_weakptr.lock(engine) && tile_weakptr.lock(tile) && !state.canceled())
                     {
                         for (unsigned q = 0; q < 4; ++q)
                         {
@@ -726,18 +727,20 @@ TileNode::createChildren()
         if (_createChildResults[0].empty())
         {
             TileKey parentkey(_key);
-            EngineContext* context(_context.get());
+            osg::observer_ptr<TerrainEngineNode> engine_weakptr(_context->_terrainEngine);
+
             for (unsigned quadrant = 0; quadrant < 4; ++quadrant)
             {
                 TileKey childkey = getKey().createChildKey(quadrant);
                 osg::observer_ptr<TileNode> tile_weakptr(this);
 
-                auto createChildOperation = [context, tile_weakptr, childkey](Cancelable& state)
+                auto createChildOperation = [engine_weakptr, tile_weakptr, childkey](Cancelable& state)
                     {
                         CreateChildResult result;
 
-                        osg::ref_ptr<TileNode> tile;
-                        if (tile_weakptr.lock(tile) && !state.canceled())
+                        osg::ref_ptr<TerrainEngineNode> engine;
+                        osg::ref_ptr<TileNode>          tile;
+                        if (engine_weakptr.lock(engine) && tile_weakptr.lock(tile) && !state.canceled())
                             result = tile->createChild(childkey, &state);
 
                         return result;


### PR DESCRIPTION
Consider the following, annotated snippet:
```cpp
EngineContext* context(_context.get());
osg::observer_ptr<TileNode> tile_weakptr(this);

auto createChildrenOperation = [context, tile_weakptr](auto& state)
    {
        CreateChildrenResult result;

        osg::ref_ptr<TileNode> tile;
        if (tile_weakptr.lock(tile) && !state.canceled())
        {
            // (1) tile acquired, referent object will not be destroyed in this scope
            //     However, context is a plain pointer and tile->_context is a weak pointer.
            //     It is therefore possible at this time for tile->_context to be destroyed.
            for (unsigned q = 0; q < 4; ++q)
            {
                auto childkey = tile->getKey().createChildKey(q); // (2) OK
                result[q] = tile->createChild(childkey, &state);  // (3) Potential use after free
            }
        }
        
        // (4)
        if (state.canceled())
        {
            for (int i = 0; i < 4; ++i)
                result[i] = {};
        }

        return result;
    };
```

A use-after-free can occur in `(3)` if the referent object at `tile->_context` is destroyed after `(1)` and before `(4)`.

However, it is insufficient to duplicate the pattern with `tile_weakptr` and `tile` for `context_weakptr` and `context`, because `REX::EngineContext` maintains non-referencing-counting pointers to objects that [may be destroyed with the `REX::TerrainEngineNode`](https://github.com/gwaldron/osgearth/blob/441c7c026da5e823a1019a199513a8033101f608/src/osgEarthDrivers/engine_rex/RexTerrainEngineNode.cpp#L314).

The solution proposed by this PR is capture a weak pointer to `REX::TerrainEngineNode` and convert it to a `ref_ptr` as is done with the `REX::TileNode`.