### PR TITLE
Fix GDAL API compatibility for GetMetadata return type

### DIFF
--- a/src/osgEarth/GDAL.cpp
+++ b/src/osgEarth/GDAL.cpp
@@ -496,7 +496,8 @@ GDAL_detail::Driver::open(
         _srcDS = (GDALDataset*)GDALOpen(input.c_str(), GA_ReadOnly);
         if (_srcDS)
         {
-            char **subDatasets = _srcDS->GetMetadata("SUBDATASETS");
+            // Use auto for compatibility: older GDAL returns char**, newer GDAL returns CSLConstList (const char* const*)
+            auto subDatasets = _srcDS->GetMetadata("SUBDATASETS");
             int numSubDatasets = CSLCount(subDatasets);
 
             if (numSubDatasets > 0)


### PR DESCRIPTION
Use auto to handle both older GDAL (char**) and newer GDAL (CSLConstList) return types from GetMetadata().