### PR TITLE
DuktapeEngine: Fixed minor memory leak.

### DIFF
--- a/src/osgEarthDrivers/script_engine_duktape/DuktapeEngine.cpp
+++ b/src/osgEarthDrivers/script_engine_duktape/DuktapeEngine.cpp
@@ -339,6 +339,11 @@ DuktapeEngine::Context::~Context()
         duk_destroy_heap(_ctx);
         _ctx = nullptr;
     }
+    if ( _bytecode )
+    {
+        delete[] _bytecode;
+        _bytecode = nullptr;
+    }
 }
 
 //............................................................................


### PR DESCRIPTION
Found with Valgrind on Linux.