### PR TITLE
Update Triton user shaders to match current Triton release.

### DIFF
--- a/src/osgEarthTriton/Shaders/user-functions.glsl
+++ b/src/osgEarthTriton/Shaders/user-functions.glsl
@@ -50,6 +50,15 @@ void user_decal_color(in vec4 textureColor, in float alpha, in vec4 lightColor, 
 {
 
 }
+
+// Override the depth calculation for the decal fragment. May be needed if you are using a
+// logarithmic depth buffer, as the depth texture used for decals is always linear.
+// See also the overridePosition function in user-vert-functions.glsl if you are manipulating
+// depth values.
+void user_decal_depth(inout float depth)
+{
+
+}
 #endif
 
 //adjust the reflection color prior to it being used by triton.


### PR DESCRIPTION
Just updating the modified Triton user shaders to include the user_decal_depth function that was added back in October 2024. Triton will fail upon startup without it.