### PR TITLE
Fixed multithreaded crash in VegetationLayer::getAssetPlacements

### DIFF
--- a/src/osgEarthProcedural/VegetationLayer.cpp
+++ b/src/osgEarthProcedural/VegetationLayer.cpp
@@ -1323,20 +1323,20 @@ VegetationLayer::getAssetPlacements(
     // after loading the biome map.
     if (loadBiomesOnDemand)
     {
+        std::lock_guard<std::mutex> lock(_assets.mutex());
+
         if (checkForNewAssets() == true)
         {
             _newAssets.join(progress);
             AssetsByGroup newAssets = _newAssets.release();
             if (!newAssets.empty())
             {
-                std::lock_guard<std::mutex> lock(_assets.mutex());
                 _assets = std::move(newAssets);
             }
         }
 
         // make a shallow copy of assets list safely
         {
-            std::lock_guard<std::mutex> lock(_assets.mutex());
             auto iter = _assets.find(group);
             if (iter == _assets.end())
             {


### PR DESCRIPTION
Fixed multithreaded crash in VegetationLayer::getAssetPlacements by ensuring that the _assets.mutex() is locked when _newAssets.release is being called.