### PR TITLE
Update the enums for SilverLining cloud types.

### DIFF
--- a/src/osgEarthSilverLining/SilverLiningAPIWrapper
+++ b/src/osgEarthSilverLining/SilverLiningAPIWrapper
@@ -18,13 +18,15 @@ namespace osgEarth { namespace SilverLining
     enum CloudTypes
     {
         CIRROCUMULUS,               /*!<  High planar cloud puffs */
+        CIRROSTRATUS,               /*!<  High, thin uniform planar cloud */
         CIRRUS_FIBRATUS,            /*!<  High, thicker and fibrous clouds that signal changing weather */
         STRATUS,                    /*!<  Low clouds represented as a slab */
         CUMULUS_MEDIOCRIS,          /*!<  Low, puffy clouds on fair days */
         CUMULUS_CONGESTUS,          /*!<  Large cumulus clouds, built for performance. */
         CUMULUS_CONGESTUS_HI_RES,   /*!<  Large cumulus clouds represented with high-resolution puff textures. */
         CUMULONIMBUS_CAPPILATUS,    /*!<  Big storm clouds. */
-        STRATOCUMULUS,              /*!<  Low, dense, puffy clouds with some sun breaks between them. */
+        STRATOCUMULUS,              /*!<  Low, dense, puffy clouds with some sun breaks between them. Implemented with GPU ray-casting. */
+        STRATOCUMULUS_PARTICLES,    /*!<  Low, dense, puffy clouds with some sun breaks between them. Implemented with billboard particles. */
         TOWERING_CUMULUS,           /*!<  Very large, tall cumulus clouds in the process of becoming a thunderstorm.*/
         SANDSTORM,                  /*!<  A "haboob" cloud of dust intended to be positioned at ground level. */
         NUM_CLOUD_TYPES             /*!<  Total number of cloud types. */


### PR DESCRIPTION
Sync up the enumeration for SilverLining cloud types with the current SilverLining API. Folks were getting the wrong clouds because of this.